### PR TITLE
Neuron to neuron examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,6 @@ docs/examples/integrator.py
 docs/examples/integrator_multi_d.py
 docs/examples/keyword_spotting.py
 docs/examples/learn_communication_channel.py
+docs/examples/neuron_to_neuron.py
 docs/examples/oscillator.py
 docs/examples/oscillator_nonlinear.py

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -15,5 +15,6 @@ We compare performance with Nengo core where appropriate.
    examples/integrator_multi_d
    examples/oscillator
    examples/oscillator_nonlinear
+   examples/neuron_to_neuron
    examples/learn_communication_channel
    examples/keyword_spotting

--- a/docs/examples/neuron_to_neuron.ipynb
+++ b/docs/examples/neuron_to_neuron.ipynb
@@ -1,0 +1,333 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Neuron to neuron connections\n",
+    "\n",
+    "While Nengo is often used with deep learning\n",
+    "and NEF style networks,\n",
+    "it can also be used for lower level models\n",
+    "in which each neuron to neuron connection\n",
+    "is explicitly specified.\n",
+    "\n",
+    "In these examples, we connect a `pre` population\n",
+    "to a `post` population with different sets of\n",
+    "specified connection weights."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "import numpy as np\n",
+    "\n",
+    "import nengo\n",
+    "from nengo.utils.matplotlib import rasterplot\n",
+    "import nengo_loihi"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Simple fan-out\n",
+    "\n",
+    "In this example,\n",
+    "a neuron is connected to several downstream neurons\n",
+    "with increasing synaptic strength.\n",
+    "\n",
+    "Synaptic strengths are defined through the `transform`\n",
+    "of a `nengo.Connection`.\n",
+    "While a `Connection` between two ensembles\n",
+    "operates on their vector representations,\n",
+    "a connection between two ensemble's neuron values\n",
+    "operates directly on neural activities (i.e., spikes)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with nengo.Network() as model:\n",
+    "    pre = nengo.Ensemble(1, dimensions=1, gain=[1], bias=[1.05])\n",
+    "    post = nengo.Ensemble(6, dimensions=1, gain=np.ones(6), bias=np.zeros(6))\n",
+    "\n",
+    "    transform = np.linspace(0.01, 0.15, post.n_neurons)\n",
+    "    transform = transform.reshape((post.n_neurons, pre.n_neurons))\n",
+    "    nengo.Connection(pre.neurons, post.neurons, transform=transform)\n",
+    "\n",
+    "    pre_probe = nengo.Probe(pre.neurons)\n",
+    "    post_probe = nengo.Probe(post.neurons)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Running the network in Nengo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with nengo.Simulator(model) as sim:\n",
+    "    sim.run(1)\n",
+    "t = sim.trange()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_rasters(t, data):\n",
+    "    plt.figure(figsize=(10, 8))\n",
+    "    plt.subplot(2, 1, 1)\n",
+    "    rasterplot(t, data[pre_probe])\n",
+    "    plt.xticks(())\n",
+    "    plt.ylabel(\"pre neuron number\")\n",
+    "    plt.subplot(2, 1, 2)\n",
+    "    rasterplot(t, data[post_probe])\n",
+    "    plt.ylabel(\"post neuron number\")\n",
+    "    plt.xlabel(\"Time (s)\")\n",
+    "    plt.tight_layout()\n",
+    "\n",
+    "\n",
+    "plot_rasters(t, sim.data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Running the network with Nengo Loihi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: figure out why we need to scale transform\n",
+    "model.connections[0].transform *= 1000\n",
+    "\n",
+    "with nengo_loihi.Simulator(model) as sim:\n",
+    "    sim.run(1)\n",
+    "t = sim.trange()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_rasters(t, sim.data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. One-to-one connections\n",
+    "\n",
+    "In this example, two populations of equal size\n",
+    "are connected one-to-one with random\n",
+    "biases in the `pre` population and\n",
+    "random excitatory connection weights."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rng = np.random.RandomState(seed=10)\n",
+    "n_neurons = 5\n",
+    "\n",
+    "with nengo.Network() as model:\n",
+    "    pre = nengo.Ensemble(n_neurons, 1,\n",
+    "                         gain=np.ones(n_neurons),\n",
+    "                         bias=rng.uniform(low=1.0, high=1.5, size=n_neurons))\n",
+    "    post = nengo.Ensemble(n_neurons, 1,\n",
+    "                          gain=np.ones(n_neurons),\n",
+    "                          bias=np.zeros(n_neurons))\n",
+    "\n",
+    "    transform = np.zeros((n_neurons, n_neurons))\n",
+    "    di = np.diag_indices(n_neurons)\n",
+    "    transform[di] = rng.uniform(low=0.0, high=0.2, size=n_neurons)\n",
+    "    nengo.Connection(pre.neurons, post.neurons, transform=transform)\n",
+    "\n",
+    "    pre_probe = nengo.Probe(pre.neurons)\n",
+    "    post_probe = nengo.Probe(post.neurons)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Running the network in Nengo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with nengo.Simulator(model) as sim:\n",
+    "    sim.run(1)\n",
+    "t = sim.trange()\n",
+    "plot_rasters(t, sim.data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Running the network with Nengo Loihi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: figure out why we need to scale transform\n",
+    "model.connections[0].transform *= 1000\n",
+    "\n",
+    "with nengo_loihi.Simulator(model) as sim:\n",
+    "    sim.run(1)\n",
+    "t = sim.trange()\n",
+    "plot_rasters(t, sim.data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Fixed probability connections\n",
+    "\n",
+    "In this example, two populations are recurrently connected\n",
+    "(i.e., `post` is also connected back to `pre`).\n",
+    "There is a fixed probability of two neurons\n",
+    "being connected in either direction,\n",
+    "a fixed probability of an inhibitory connection,\n",
+    "and all connections have the same weight."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rng = np.random.RandomState(seed=100)\n",
+    "inhibitory = 0.5  # 50% inhibitory connections\n",
+    "connection_prob = 0.6  # 60% probability of being connected\n",
+    "n_neurons = 25\n",
+    "\n",
+    "with nengo.Network() as model:\n",
+    "    pre = nengo.Ensemble(n_neurons, 1,\n",
+    "                         gain=np.ones(n_neurons),\n",
+    "                         bias=rng.uniform(low=-2, high=2, size=n_neurons))\n",
+    "    post = nengo.Ensemble(n_neurons, 1,\n",
+    "                          gain=np.ones(n_neurons),\n",
+    "                          bias=rng.uniform(low=-2, high=2, size=n_neurons))\n",
+    "\n",
+    "    pre_post = np.ones((n_neurons, n_neurons)) * 0.05\n",
+    "    # Make some inhibitory\n",
+    "    pre_post[rng.rand(n_neurons, n_neurons) <= inhibitory] *= -1\n",
+    "    # Remove 1 - connection_prob connections\n",
+    "    pre_post[rng.rand(n_neurons, n_neurons) > connection_prob] = 0\n",
+    "    nengo.Connection(pre.neurons, post.neurons, transform=pre_post)\n",
+    "\n",
+    "    post_pre = np.ones((n_neurons, n_neurons)) * 0.05\n",
+    "    post_pre[rng.rand(n_neurons, n_neurons) <= inhibitory] *= -1\n",
+    "    post_pre[rng.rand(n_neurons, n_neurons) > connection_prob] = 0\n",
+    "    nengo.Connection(post.neurons, pre.neurons, transform=post_pre)\n",
+    "\n",
+    "    pre_probe = nengo.Probe(pre.neurons)\n",
+    "    post_probe = nengo.Probe(post.neurons)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Running the network in Nengo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with nengo.Simulator(model) as sim:\n",
+    "    sim.run(1)\n",
+    "t = sim.trange()\n",
+    "plot_rasters(t, sim.data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Running the network with Nengo Loihi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: figure out why we need to scale transform\n",
+    "model.connections[0].transform *= 1000\n",
+    "model.connections[1].transform *= 1000\n",
+    "\n",
+    "with nengo_loihi.Simulator(model) as sim:\n",
+    "    sim.run(1)\n",
+    "t = sim.trange()\n",
+    "plot_rasters(t, sim.data)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/examples/neuron_to_neuron.ipynb
+++ b/docs/examples/neuron_to_neuron.ipynb
@@ -121,9 +121,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# TODO: figure out why we need to scale transform\n",
-    "model.connections[0].transform *= 1000\n",
-    "\n",
     "with nengo_loihi.Simulator(model) as sim:\n",
     "    sim.run(1)\n",
     "t = sim.trange()"
@@ -208,9 +205,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# TODO: figure out why we need to scale transform\n",
-    "model.connections[0].transform *= 1000\n",
-    "\n",
     "with nengo_loihi.Simulator(model) as sim:\n",
     "    sim.run(1)\n",
     "t = sim.trange()\n",
@@ -298,10 +292,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# TODO: figure out why we need to scale transform\n",
-    "model.connections[0].transform *= 1000\n",
-    "model.connections[1].transform *= 1000\n",
-    "\n",
     "with nengo_loihi.Simulator(model) as sim:\n",
     "    sim.run(1)\n",
     "t = sim.trange()\n",

--- a/nengo_loihi/loihi_cx.py
+++ b/nengo_loihi/loihi_cx.py
@@ -507,6 +507,9 @@ class CxSimulator(object):
         noiseTarget = np.hstack([
             group.noiseAtDendOrVm*ones(group.n) for group in self.groups])
         if group_dtype == np.int32:
+            if np.any(noiseExp0 < 7):
+                warnings.warn("Noise amplitude falls below lower limit")
+            noiseExp0[noiseExp0 < 7] = 7
             noiseMult = np.where(enableNoise, 2**(noiseExp0 - 7), 0)
 
             def noiseGen(n=self.n_cx, rng=self.rng):

--- a/nengo_loihi/tests/test_connection.py
+++ b/nengo_loihi/tests/test_connection.py
@@ -81,6 +81,7 @@ def test_node_to_neurons(precompute, allclose, Simulator, plt):
     assert allclose(rates, z, atol=3, rtol=0.1)
 
 
+@pytest.mark.xfail(reason="RectifiedLinear disabled for now")
 @pytest.mark.parametrize("factor", [0.11, 0.26, 0.51, 1.01])
 def test_neuron_to_neuron(Simulator, factor, seed, allclose):
     # note: we use these weird factor values so that voltages don't line up

--- a/nengo_loihi/tests/test_ens_on_host.py
+++ b/nengo_loihi/tests/test_ens_on_host.py
@@ -38,49 +38,58 @@ def test_ens_decoded_on_host(precompute, allclose, Simulator, seed, plt):
     assert allclose(sim.data[p_b], -sim.data[p_a], atol=0.15, rtol=0.1)
 
 
+@pytest.mark.parametrize('seed_ens', [True, False])
 @pytest.mark.parametrize('precompute', [True, False])
-def test_ens_neurons_on_host(precompute, allclose, Simulator, seed, plt):
-    out_synapse = nengo.synapses.Alpha(0.03)
+def test_n2n_on_host(precompute, allclose, Simulator, seed_ens, seed, plt):
+    """Ensure that neuron to neuron connections work on and off chip."""
 
-    n = 50
+    n_neurons = 50
+    # When the ensemble is seeded, the output plots will make more sense,
+    # but the test should work whether they're seeded or not.
+    ens_seed = (seed + 1) if seed_ens else None
+    if not seed_ens:
+        pytest.xfail("Seeds change when moving ensembles off/on chip")
 
     with nengo.Network(seed=seed) as model:
         nengo_loihi.add_params(model)
 
         stim = nengo.Node(lambda t: [np.sin(t * 2 * np.pi)])
 
-        a = nengo.Ensemble(n, 1)
-        model.config[a].on_chip = False
-        nengo.Connection(stim, a)
+        # pre receives stimulation and represents the sine wave
+        pre = nengo.Ensemble(n_neurons, dimensions=1, seed=ens_seed)
+        model.config[pre].on_chip = False
+        nengo.Connection(stim, pre)
 
-        b = nengo.Ensemble(n, 1)
-        nengo.Connection(a.neurons, b.neurons, transform=np.eye(n))
+        # post has pre's neural activity forwarded to it.
+        # Since the neuron parameters are the same, it should also represent
+        # the same sine wave.
+        # The 0.015 scaling is chosen so the values match visually,
+        # though a more principled reason would be better.
+        post = nengo.Ensemble(n_neurons, dimensions=1, seed=ens_seed)
+        nengo.Connection(pre.neurons, post.neurons,
+                         transform=np.eye(n_neurons) * 0.015)
 
-        c = nengo.Node(size_in=1)
-        nengo.Connection(b, c)
-
-        p_stim = nengo.Probe(stim, synapse=out_synapse)
-        p_a = nengo.Probe(a, synapse=out_synapse)
-        p_b = nengo.Probe(b, synapse=out_synapse)
-        p_c = nengo.Probe(c, synapse=out_synapse)
+        p_synapse = nengo.synapses.Alpha(0.03)
+        p_stim = nengo.Probe(stim, synapse=p_synapse)
+        p_pre = nengo.Probe(pre, synapse=p_synapse)
+        p_post = nengo.Probe(post, synapse=p_synapse)
 
     with Simulator(model, precompute=precompute) as sim:
         sim.run(1.0)
+    t = sim.trange()
 
-    with model:
-        model.config[a].on_chip = True
+    model.config[pre].on_chip = True
 
     with Simulator(model, precompute=precompute) as sim2:
         sim2.run(1.0)
+    t2 = sim2.trange()
 
-    plt.plot(sim.trange(), sim.data[p_stim])
-    plt.plot(sim.trange(), sim.data[p_a])
-    plt.plot(sim.trange(), sim.data[p_b])
-    plt.plot(sim.trange(), sim.data[p_c])
-    plt.plot(sim2.trange(), sim2.data[p_a])
-    plt.plot(sim2.trange(), sim2.data[p_b])
-    plt.plot(sim2.trange(), sim.data[p_c])
+    plt.plot(t, sim.data[p_stim], c="k", label="input")
+    plt.plot(t, sim.data[p_pre], label="pre off-chip")
+    plt.plot(t, sim.data[p_post], label="post (pre off-chip)")
+    plt.plot(t2, sim2.data[p_pre], label="pre on-chip")
+    plt.plot(t2, sim2.data[p_post], label="post (pre on-chip)")
+    plt.legend()
 
-    assert allclose(sim.data[p_a], sim2.data[p_a], atol=0.15)
-    assert allclose(sim.data[p_b], sim2.data[p_b], atol=0.15)
-    assert allclose(sim.data[p_c], sim2.data[p_c], atol=0.15)
+    assert allclose(sim.data[p_pre], sim2.data[p_pre], atol=0.1)
+    assert allclose(sim.data[p_post], sim2.data[p_post], atol=0.1)

--- a/nengo_loihi/tests/test_ensemble.py
+++ b/nengo_loihi/tests/test_ensemble.py
@@ -40,6 +40,7 @@ def test_lif_response_curves(tau_ref, Simulator, plt):
     assert np.all(scount >= lower_bound - 1)
 
 
+@pytest.mark.xfail(reason="RectifiedLinear disabled for now")
 def test_relu_response_curves(Simulator, plt):
     n = 256
     encoders = np.ones((n, 1))
@@ -70,6 +71,7 @@ def test_relu_response_curves(Simulator, plt):
     assert np.all(actual >= scount)
 
 
+@pytest.mark.xfail(reason="RectifiedLinear disabled for now")
 @pytest.mark.parametrize("amplitude", (0.1, 0.5, 1))
 def test_amplitude(Simulator, amplitude, seed, allclose):
     # TODO: test rectifiedlinear as well (not working at the moment due to


### PR DESCRIPTION
A notebook with three example networks using direct neuron-to-neuron connections. Here are the plots from the notebook if you don't want to run it yourself:

* Simple fan-out with Nengo

![1-nengo](https://user-images.githubusercontent.com/203709/44424755-0981b280-a558-11e8-96c4-d99799590f48.png)

* Simple fan-out with Nengo Loihi

![1-loihi](https://user-images.githubusercontent.com/203709/44424765-0dadd000-a558-11e8-942b-1f86164e8651.png)

* One-to-one connections with Nengo

![2-nengo](https://user-images.githubusercontent.com/203709/44424830-3c2bab00-a558-11e8-90db-c3967cefb838.png)

* One-to-one connections with Nengo Loihi

![2-loihi](https://user-images.githubusercontent.com/203709/44424829-3c2bab00-a558-11e8-8695-1b60246211cf.png)

* Fixed probability connections with Nengo

![3-nengo](https://user-images.githubusercontent.com/203709/44424832-3c2bab00-a558-11e8-831d-50e5baeac01b.png)

* Fixed probability connections with Nengo Loihi

![3-loihi](https://user-images.githubusercontent.com/203709/44424831-3c2bab00-a558-11e8-80b3-1d7ade9fece1.png)

This was originally going to be part of #23 (and therefore is based on it), but I ran into an issue so I figured I would split this off into a separate PR so that it doesn't block the release (if we manage to figure it out in time though, we can include it).

The issue is that when making neuron-to-neuron connection in Nengo Loihi, the transform matrix has to be scaled up by `1 / dt` (at least, scaling up by 1000 worked, so I assume it's a `1 / dt` scaling problem). This means that you can't run the same model in Nengo and expect it to work in Nengo Loihi if you're using direct neuron-to-neuron connections, which is a pretty big issue.

I'll start looking into this tomorrow, but if anyone knows why this might be the case (or how it can be fixed), help would be appreciated.