### PR TITLE
Add INRC-specific docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -25,6 +25,127 @@ Follow `our NumPy install instructions
 <https://www.nengo.ai/nengo/getting_started.html#installing-numpy>`_,
 then try again.
 
+INRC
+====
+
+.. note:: These instructions will only work on the INRC superhost.
+          If you have set up your own superhost
+          as per the :doc:`setup/superhost` page,
+          then see the next section.
+
+These steps will take you through
+setting up a Python environment
+for running Nengo Loihi,
+as well as for running models
+using the NxSDK directly.
+
+1. Create a new virtual environment.
+   Note, you *must* use the ``python_nx`` executable
+   provided by Intel when working with NxSDK.
+
+   .. code-block:: bash
+
+      mkvirtualenv loihi --python=python_nx
+
+2. Activate your new environment.
+
+   .. code-block:: bash
+
+      workon loihi
+
+   Sometimes the environment can have issues when first created.
+   Before continuing, run ``which pip`` and ensure that the path
+   to ``pip`` is in your virtual environment.
+
+   .. note:: You will need to run ``workon loihi`` every time
+             you log onto the INRC superhost.
+
+3. Clone the NxSDK git repository.
+
+   The location of ``NxSDK.git`` may have changed.
+   Refer to Intel's documentation to be sure.
+
+   .. code-block:: bash
+
+      git clone /nfs/ncl/git/NxSDK.git
+
+4. Check out a release tag.
+
+   As of August 2018, the most recent release is 0.5.5,
+   which is compatible with Nengo Loihi.
+
+   .. code-block:: bash
+
+      cd NxSDK
+      git checkout 0.5.5
+
+5. Add a ``setup.py`` file to NxSDK.
+
+   As of August 2018, NxSDK does not have a ``setup.py`` file,
+   which is necessary for installing NxSDK in a virtual environment.
+
+   To add it, execute the following command.
+
+   .. code-block:: bash
+
+      cat > setup.py << 'EOL'
+      import sys
+      from setuptools import setup
+
+      if not ((3, 5, 2) <= sys.version_info[:3] < (3, 6, 0)):
+          pyversion = ".".join("%d" % v for v in sys.version_info[:3])
+          raise EnvironmentError(
+              "NxSDK has .pyc files that only work on Python 3.5.2 through 3.5.5. "
+              "You are running version %s." % pyversion)
+
+      setup(
+          name='nxsdk',
+          version='0.5.5',
+          install_requires=[
+              "numpy",
+              "pandas",
+              "matplotlib",
+              "teamcity-messages",
+              "rpyc<4",
+          ]
+      )
+      EOL
+
+   Or you may paste the text above (excluding the first and last lines)
+   into a text editor and save as ``setup.py`` in the NxSDK folder.
+
+6. Install NxSDK.
+
+   .. code-block:: bash
+
+      pip install -e .
+
+7. Install Nengo Loihi.
+
+   .. code-block:: bash
+
+      cd ..
+      git clone https://github.com/nengo/nengo-loihi.git
+      cd nengo-loihi
+      pip install -e .
+
+   ``pip`` will install other requirements like Nengo automatically.
+
+8. Test that both packages installed correctly.
+
+   Start Python by running the ``python`` command.
+   If everything is installed correctly, you should
+   be able to import ``nxsdk`` and ``nengo_loihi``.
+
+   .. code-block:: pycon
+
+      Python 3.5.5 (default, Mar 15 2018, 11:03:27)
+      [GCC 5.4.0 20160609] on linux
+      Type "help", "copyright", "credits" or "license" for more information.
+      >>> import nxsdk
+      >>> import nengo_loihi
+
+
 Superhost
 =========
 
@@ -81,7 +202,7 @@ for running Loihi models.
       Follow the prompts to set up Miniconda as desired.
 
 2. Create a new ``conda`` environment.
-   Note, you _must_ use Python 3.5.5 when working with NxSDK.
+   Note, you *must* use Python 3.5.5 when working with NxSDK.
 
    .. code-block:: bash
 
@@ -109,28 +230,19 @@ for running Loihi models.
    The NumPy provided by conda is usually faster
    than those installed by other means.
 
-5. Install Nengo Loihi.
-
-   .. code-block:: bash
-
-      git clone https://github.com/nengo/nengo-loihi.git
-      cd nengo-loihi
-      pip install -e .
-
-   ``pip`` will install other requirements like Nengo automatically.
-
-6. Clone the NxSDK git repository.
+5. Clone the NxSDK git repository.
 
    As of August 2018, NxSDK is not publicly available,
-   but is available through Intel's NRC cloud.
-   See their documentation for the NxSDK location,
-   then
+   but is available through the INRC.
+   Refer to Intel's documentation for the details
+   on how to clone the repository,
+   but the command will look something like
 
    .. code-block:: bash
 
-      git clone path/to/NxSDK.git
+      git clone ssh://inrc/nfs/ncl/git/NxSDK.git
 
-7. Check out a release tag.
+6. Check out a release tag.
 
    As of August 2018, the most recent release is 0.5.5,
    which is compatible with Nengo Loihi.
@@ -140,7 +252,7 @@ for running Loihi models.
       cd NxSDK
       git checkout 0.5.5
 
-8. Add a ``setup.py`` file to NxSDK.
+7. Add a ``setup.py`` file to NxSDK.
 
    As of August 2018, NxSDK does not have a ``setup.py`` file,
    which is necessary for installing NxSDK in a conda environment.
@@ -172,12 +284,36 @@ for running Loihi models.
       )
       EOL
 
-
    Or you may paste the text above (excluding the first and last lines)
    into a text editor and save as ``setup.py`` in the NxSDK folder.
 
-9. Install NxSDK.
+8. Install NxSDK.
 
    .. code-block:: bash
 
       pip install -e .
+
+9. Install Nengo Loihi.
+
+   .. code-block:: bash
+
+      cd ..
+      git clone https://github.com/nengo/nengo-loihi.git
+      cd nengo-loihi
+      pip install -e .
+
+   ``pip`` will install other requirements like Nengo automatically.
+
+10. Test that both packages installed correctly.
+
+    Start Python by running the ``python`` command.
+    If everything is installed correctly, you should
+    be able to import ``nxsdk`` and ``nengo_loihi``.
+
+    .. code-block:: pycon
+
+       Python 3.5.5 |Anaconda, Inc.| (default, May 13 2018, 21:12:35)
+       [GCC 7.2.0] on linux
+       Type "help", "copyright", "credits" or "license" for more information.
+       >>> import nxsdk
+       >>> import nengo_loihi

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -22,6 +22,9 @@ a Loihi model using the following terms.
 - *Superhost*: The PC physically connected to the FPGA board.
   Typically the superhost and host communicate over ethernet,
   but it is also possible to communicate over serial USB.
+- *INRC*: A superhost provided to members of the
+  Intel Neuromorphic Research Community.
+  Whenever we refer to the superhost, you can use the INRC.
 - *Local machine*: The computer you are currently using.
   We usually assume that your local machine is not the superhost,
   though you can work directly on the superhost.

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -10,22 +10,29 @@ is made accessible through an FPGA board.
 We will refer to the devices involved in
 a Loihi model using the following terms.
 
-- *Board*: The Loihi board, which contains one or more Loihi chips.
-- *Chip*: A Loihi chip, which contains several cores.
-- *Core*: A computational unit on a chip.
+**Board**
+  The Loihi board, which contains one or more Loihi chips.
+**Chip**
+  A Loihi chip, which contains several cores.
+**Core**
+  A computational unit on a chip.
   Each chip has several neuron cores, which simulate compartments,
   synapses, etc. and several Lakemont cores, which are general purpose
   CPUs for handling input/output and other general tasks.
-- *Host*: The FPGA board that the Loihi board is connected to.
+**Host**
+  The FPGA board that the Loihi board is connected to.
   The host runs a Linux-based operating system to allow programs
   to interact with the board using drivers provided by Intel.
-- *Superhost*: The PC physically connected to the FPGA board.
+**Superhost**
+  The PC physically connected to the FPGA board.
   Typically the superhost and host communicate over ethernet,
   but it is also possible to communicate over serial USB.
-- *INRC*: A superhost provided to members of the
+**INRC**
+  A superhost provided to members of the
   Intel Neuromorphic Research Community.
   Whenever we refer to the superhost, you can use the INRC.
-- *Local machine*: The computer you are currently using.
+**Local machine**
+  The computer you are currently using.
   We usually assume that your local machine is not the superhost,
   though you can work directly on the superhost.
 

--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -329,6 +329,56 @@ to the local machine's ``~/remote/host-2`` directory.
 Superhost
 =========
 
+Plotting
+--------
+
+If you are generating plots with Matplotlib
+on the superhost or host,
+you may run into issues due to there being
+no monitor attached to those machines
+(i.e., they are "headless").
+Rather than plotting to a screen,
+you can instead save plots as files
+with ``plt.savefig``.
+You will also need to configure
+Matplotlib to use a headless backend by default.
+
+The easiest way to do this is with a ``matplotlibrc`` file.
+
+.. code-block:: bash
+
+   mkdir -p ~/.config/matplotlib
+   echo "backend: Agg" >> ~/.config/matplotlib/matplotlibrc
+
+IPython / Jupyter
+-----------------
+
+If you want to use the IPython interpreter
+or the Jupyter notebook on a superhost
+(e.g., the INRC superhost),
+you may run into issues due to the
+network file system (NFS),
+which does not work well
+with how IPython and Jupyter track command history.
+You can configure IPython and Jupyter
+to instead store command history to memory only.
+
+To do this, start by generating the configuration files.
+
+.. code-block:: bash
+
+   jupyter notebook --generate-config
+   ipython profile create
+
+Then add a line to three files to
+configure the command history for NFS.
+
+.. code-block:: bash
+
+   echo "c.NotebookNotary.db_file = ':memory:'" >> ~/.jupyter/jupyter_notebook_config.py
+   echo "c.HistoryAccessor.hist_file = ':memory:'" >> ~/.ipython/profile_default/ipython_config.py
+   echo "c.HistoryAccessor.hist_file = ':memory:'" >> ~/.ipython/profile_default/ipython_kernel_config.py
+
 Slurm cheatsheet
 ----------------
 
@@ -407,24 +457,3 @@ In the other terminal, run your job without Slurm.
 .. code-block:: bash
 
    SLURM=0 python models/my_model.py
-
-Plotting
---------
-
-If you are generating plots with Matplotlib
-on the superhost or host,
-you may run into issues due to there being
-no monitor attached to those machines
-(i.e., they are "headless").
-Rather than plotting to a screen,
-you can instead save plots as files
-with ``plt.savefig``.
-You will also need to configure
-Matplotlib to use a headless backend by default.
-
-The easiest way to do this is with a ``matplotlibrc`` file.
-
-.. code-block:: bash
-
-   mkdir -p ~/.config/matplotlib
-   echo "backend: Agg" >> ~/.config/matplotlib/matplotlibrc


### PR DESCRIPTION
It seems as though most people will be interacting with Loihi through the INRC superhost. Most of the docs are fine if you substitute INRC when we say "superhost" (it's likely a good thing for people to learn the term superhost well), but the installation instructions need to be different for a few reasons. Making a separate INRC section made more sense to me than making the generic superhost instructions have two possible paths. Also added INRC to the overview terminology and made some slight modifications in a few places. Also also added the IPython / Jupyter config thing that we had to do on the INRC to get it working.