### PR TITLE
Speeding up snips by communicating less often

### DIFF
--- a/nengo_loihi/loihi_interface.py
+++ b/nengo_loihi/loihi_interface.py
@@ -509,6 +509,14 @@ class LoihiSimulator(object):
             if core.learning_coreid:
                 n_errors += 1
 
+        n_inputs = 0
+        for chip in self.board.chips:
+            for core in chip.cores:
+                for inp, cx_ids in core.iterate_inputs():
+                    axon_ids = inp.axon_ids[0]
+                    assert len(axon_ids) % 2 == 0
+                    n_inputs += len(axon_ids) //2
+
         n_outputs = 1
         probes = []
         cores = set()
@@ -533,6 +541,7 @@ class LoihiSimulator(object):
         code = template.render(
             n_outputs=n_outputs,
             n_errors=n_errors,
+            n_inputs=n_inputs,
             cores=cores,
             probes=probes,
         )
@@ -559,7 +568,7 @@ class LoihiSimulator(object):
             phase="preLearnMgmt",
         )
 
-        size = self.snip_max_spikes_per_step * 2 + 1 + n_errors*2
+        size = n_inputs + n_errors*2
         logger.debug("Creating nengo_io_h2c channel")
         self.nengo_io_h2c = self.n2board.createChannel(b'nengo_io_h2c',
                                                        "int", size)

--- a/nengo_loihi/loihi_interface.py
+++ b/nengo_loihi/loihi_interface.py
@@ -490,7 +490,7 @@ class LoihiSimulator(object):
         x = x if cx_probe.weights is None else np.dot(x, cx_probe.weights)
         return self._filter_probe(cx_probe, x)
 
-    def create_io_snip(self):
+    def create_io_snip(self, io_steps):
         # snips must be created before connecting
         assert not self.is_connected()
 
@@ -542,6 +542,7 @@ class LoihiSimulator(object):
             n_outputs=n_outputs,
             n_errors=n_errors,
             n_inputs=n_inputs,
+            io_steps=io_steps,
             cores=cores,
             probes=probes,
         )
@@ -570,11 +571,13 @@ class LoihiSimulator(object):
 
         size = n_inputs + n_errors*2
         logger.debug("Creating nengo_io_h2c channel")
+        # double the size of the buffers so we don't have to be in lock-step
         self.nengo_io_h2c = self.n2board.createChannel(b'nengo_io_h2c',
-                                                       "int", size)
+                                                       "int", size*2)
         logger.debug("Creating nengo_io_c2h channel")
+        # double the size of the buffers so we don't have to be in lock-step
         self.nengo_io_c2h = self.n2board.createChannel(b'nengo_io_c2h',
-                                                       "int", n_outputs)
+                                                       "int", n_outputs*2)
         self.nengo_io_h2c.connect(None, nengo_io)
         self.nengo_io_c2h.connect(nengo_io, None)
         self.nengo_io_c2h_count = n_outputs

--- a/nengo_loihi/loihi_interface.py
+++ b/nengo_loihi/loihi_interface.py
@@ -515,7 +515,7 @@ class LoihiSimulator(object):
                 for inp, cx_ids in core.iterate_inputs():
                     axon_ids = inp.axon_ids[0]
                     assert len(axon_ids) % 2 == 0
-                    n_inputs += len(axon_ids) //2
+                    n_inputs += len(axon_ids) // 2
 
         n_outputs = 1
         probes = []

--- a/nengo_loihi/simulator.py
+++ b/nengo_loihi/simulator.py
@@ -394,7 +394,7 @@ class Simulator(object):
 
         self.run_steps(1)
 
-    def run_steps(self, steps):
+    def run_steps(self, steps):  # noqa: C901
         """Simulate for the given number of ``dt`` steps.
 
         Parameters

--- a/nengo_loihi/simulator.py
+++ b/nengo_loihi/simulator.py
@@ -468,7 +468,6 @@ class Simulator(object):
                                           axon_ids[half+i][2]))
         return spike_targets
 
-
     def handle_host2chip_communications(self):  # noqa: C901
         if self.simulator is not None:
             if self.precompute or self.host_sim is not None:
@@ -543,7 +542,7 @@ class Simulator(object):
                             latest = x
                         del sender.queue[:]
                         if latest is not None:
-                            msg = (x * (1<<15)).astype(int)
+                            msg = (x * (1 << 15)).astype(int)
                             to_send.extend(msg.tolist())
 
                 msg = []

--- a/nengo_loihi/snips/nengo_io.c.template
+++ b/nengo_loihi/snips/nengo_io.c.template
@@ -11,6 +11,7 @@
 #define IDX_POS_ACCUMULATORS (IDX_VALUES + (N_INPUTS*3)*4)
 #define IDX_NEG_ACCUMULATORS (IDX_POS_ACCUMULATORS + (N_INPUTS*3)*4)
 
+#define IO_STEPS {{ io_steps }}
 
 int guard_io(runState *s) {
     return 1;
@@ -49,17 +50,27 @@ void nengo_io(runState *s) {
         }
     }
 
-    if (s->time % 100 == 0) {
+    if (s->time % 1000 == 0) {
         printf("time %d\n", s->time);
     }
 
     //readChannel(inChannel, count, 1);
     // printf("count %d\n", count[0]);
 
-    for (int i=0; i < N_INPUTS; i++) {
-        readChannel(inChannel, spike, 1);
-        //printf("stim value %d.%d\n", i, spike[0]);
-        value[i] = spike[0];
+    if (s->time % IO_STEPS == 0) {
+        for (int i=0; i < N_INPUTS; i++) {
+            readChannel(inChannel, spike, 1);
+            //printf("  %d: stim value %d.%d\n", s->time, i, spike[0]);
+            value[i] = spike[0];
+        }
+
+        // Communicate with learning snip
+        for (int i=0; i < N_ERRORS; i++) {
+            readChannel(inChannel, error, 2);
+            // printf("send error %d.%d\n", error[0], error[1]);
+            s->userData[0] = error[0];
+            s->userData[1] = error[1];
+        }
     }
 
     for (int i=0; i < N_INPUTS; i++) {
@@ -93,18 +104,12 @@ void nengo_io(runState *s) {
         }
     }
 
-    // Communicate with learning snip
-    for (int i=0; i < N_ERRORS; i++) {
-        readChannel(inChannel, error, 2);
-        // printf("send error %d.%d\n", error[0], error[1]);
-        s->userData[0] = error[0];
-        s->userData[1] = error[1];
-    }
-
-    output[0] = s->time;
+    if ((IO_STEPS==1) || (s->time % IO_STEPS == 1)) {
+        output[0] = s->time;
 {% for n_out, core, cx in probes %}
-    output[{{ n_out }}] = core{{ core }}->cx_state[{{ cx }}].V;
+        output[{{ n_out }}] = core{{ core }}->cx_state[{{ cx }}].V;
 {% endfor %}
 
-    writeChannel(outChannel, output, N_OUTPUTS);
+        writeChannel(outChannel, output, N_OUTPUTS);
+    }
 }

--- a/nengo_loihi/snips/nengo_io.c.template
+++ b/nengo_loihi/snips/nengo_io.c.template
@@ -2,8 +2,15 @@
 #include <string.h>
 #include "nengo_io.h"
 
+#define N_INPUTS {{ n_inputs }}
 #define N_OUTPUTS {{ n_outputs }}
 #define N_ERRORS {{ n_errors }}
+
+#define IDX_SPIKE_TARGETS (N_ERRORS * 2)
+#define IDX_VALUES (IDX_SPIKE_TARGETS + (N_INPUTS*3))
+#define IDX_POS_ACCUMULATORS (IDX_VALUES + (N_INPUTS*3)*4)
+#define IDX_NEG_ACCUMULATORS (IDX_POS_ACCUMULATORS + (N_INPUTS*3)*4)
+
 
 int guard_io(runState *s) {
     return 1;
@@ -17,27 +24,73 @@ void nengo_io(runState *s) {
     int inChannel = getChannelID("nengo_io_h2c");
     int outChannel = getChannelID("nengo_io_c2h");
     int32_t count[1];
-    int32_t spike[2];
+    int32_t spike[3];
     int32_t error[2];
     int32_t output[N_OUTPUTS];
+
+    int32_t *value = (int32_t*)(s->userData+IDX_VALUES);
+    int32_t *pos_accum = (int32_t*)(s->userData+IDX_POS_ACCUMULATORS);
+    int32_t *neg_accum = (int32_t*)(s->userData+IDX_NEG_ACCUMULATORS);
 
     if (inChannel == -1 || outChannel == -1) {
         printf("Got an invalid channel ID\n");
         return;
     }
 
+    if (s->time == 1) {
+        printf("initializing\n");
+        for (int i=0; i<N_INPUTS; i++) {
+            readChannel(inChannel, spike, 3);
+            s->userData[IDX_SPIKE_TARGETS+(i*3)+0] = spike[0];
+            s->userData[IDX_SPIKE_TARGETS+(i*3)+1] = spike[1];
+            s->userData[IDX_SPIKE_TARGETS+(i*3)+2] = spike[2];
+            printf("  spike target %d: (%d %d %d)\n",
+                   i, spike[0], spike[1], spike[2]);
+        }
+    }
+
     if (s->time % 100 == 0) {
         printf("time %d\n", s->time);
     }
 
-    readChannel(inChannel, count, 1);
+    //readChannel(inChannel, count, 1);
     // printf("count %d\n", count[0]);
 
-    for (int i=0; i < count[0]; i++) {
-        readChannel(inChannel, spike, 2);
-        // printf("send spike %d.%d\n", spike[0], spike[1]);
-        coreId = (CoreId) { .id=spike[0] };
-        nx_send_discrete_spike(s->time, coreId, spike[1]);
+    for (int i=0; i < N_INPUTS; i++) {
+        readChannel(inChannel, spike, 1);
+        //printf("stim value %d.%d\n", i, spike[0]);
+        value[i] = spike[0];
+    }
+
+    for (int i=0; i < N_INPUTS; i++) {
+        //printf("%d   value:%d  accum:%d\n");
+        pos_accum[i] += (value[i] + (1<<15));
+        if (pos_accum[i] >= (1<<16)) {
+            uint8_t core = s->userData[IDX_SPIKE_TARGETS+(i*3)];
+            uint8_t cx = s->userData[IDX_SPIKE_TARGETS+(i*3)+1];
+            //printf("  spike %d.%d\n", core, cx);
+
+            coreId = (CoreId) { .id=core };
+            nx_send_discrete_spike(s->time, coreId, cx);
+
+            pos_accum[i] -= (1<<16);
+        } else if (pos_accum[i] < 0) {
+            pos_accum[i] = 0;
+        }
+
+        neg_accum[i] += (-value[i] + (1<<15));
+        if (neg_accum[i] >= (1<<16)) {
+            uint8_t core = s->userData[IDX_SPIKE_TARGETS+(i*3)];
+            uint8_t cx = s->userData[IDX_SPIKE_TARGETS+(i*3)+2];
+            //printf("  spike %d.%d\n", core, cx);
+
+            coreId = (CoreId) { .id=core };
+            nx_send_discrete_spike(s->time, coreId, cx);
+
+            neg_accum[i] -= (1<<16);
+        } else if (neg_accum[i] < 0) {
+            neg_accum[i] = 0;
+        }
     }
 
     // Communicate with learning snip

--- a/nengo_loihi/splitter.py
+++ b/nengo_loihi/splitter.py
@@ -91,8 +91,8 @@ class ChipReceiveNeurons(ChipReceiveNode):
         super(ChipReceiveNeurons, self).__init__(dimensions, dimensions)
 
 
-def split(model, inter_rate, inter_n,
-          spiking_interneurons_on_host=True):  # noqa: C901
+def split(model, inter_rate, inter_n,          # noqa: C901
+          spiking_interneurons_on_host=True):
     """Split a model into code running on the host and on-chip"""
 
     logger.info("Splitting model into host and chip parts")

--- a/nengo_loihi/splitter.py
+++ b/nengo_loihi/splitter.py
@@ -180,13 +180,7 @@ def split(model, inter_rate, inter_n):  # noqa: C901
                 with host:
                     max_rate = inter_rate * inter_n
                     assert max_rate <= 1000
-
-                    logger.debug("Creating NIF ensemble for %s", c)
-                    ens = nengo.Ensemble(
-                        2 * dim, dim, neuron_type=NIF(tau_ref=0.0),
-                        encoders=np.vstack([np.eye(dim), -np.eye(dim)]),
-                        max_rates=[max_rate] * dim + [max_rate] * dim,
-                        intercepts=[-1] * dim + [-1] * dim)
+                    # TODO: move the above check elsewhere
 
                     # scale the input spikes based on the radius of the
                     #  target ensemble
@@ -196,15 +190,14 @@ def split(model, inter_rate, inter_n):  # noqa: C901
                         scaling = 1.0
 
                     logger.debug("Creating HostSendNode for %s", c)
-                    send = HostSendNode(dim * 2)
-                    nengo.Connection(c.pre, ens,
+                    send = HostSendNode(dim)
+                    nengo.Connection(c.pre, send,
                                      function=c.function,
                                      solver=c.solver,
                                      eval_points=c.eval_points,
                                      scale_eval_points=c.scale_eval_points,
-                                     synapse=None,
+                                     synapse=c.synapse,
                                      transform=c.transform * scaling)
-                    nengo.Connection(ens.neurons, send, synapse=None)
                 host2chip_senders[send] = receive
         elif pre_onchip and not post_onchip:
             dim = c.size_out

--- a/sandbox/snips/learn-multi.py
+++ b/sandbox/snips/learn-multi.py
@@ -1,0 +1,40 @@
+import nengo
+import nengo_loihi
+import numpy as np
+
+D = 3
+
+with nengo.Network(seed=1) as model:
+    stim = nengo.Node(lambda t: [0.5]*D)
+
+    a = nengo.Ensemble(500, D, label='a',
+                       max_rates=nengo.dists.Uniform(100, 120),
+                       intercepts=nengo.dists.Uniform(-0.9, 0.9)
+			)
+    nengo.Connection(stim, a, synapse=None)
+
+    def output(t, x):
+        return x
+
+    out = nengo.Node(output, size_in=1, size_out=1)
+    c = nengo.Connection(a, out,
+                         learning_rule_type=nengo.PES(learning_rate=1e-3),
+                         function=lambda x: 0,
+                         synapse=0.01)
+
+    error = nengo.Node(None, size_in=1)
+
+    nengo.Connection(out, error, transform=1)
+    nengo.Connection(stim[0], error, transform=-1)
+
+    nengo.Connection(error, c.learning_rule, transform=1.0)
+
+    p = nengo.Probe(out, synapse=0.05)
+
+T = 0.01
+with nengo_loihi.Simulator(model, precompute=False) as sim:
+    sim.run(T)
+
+print(sim.time_per_step)
+
+print(sim.data[p][-10:])


### PR DESCRIPTION
This changes the snip I/O system so that we don't communicate every timestep.  This adds a `snip_io_steps parameter` to Simulator to let you control how often (in units of steps) we should communicate.  The reason for this is to drastically speed up the simulation!  If this is set to 1 (which is the same as what it used to be), then we're at around 8ms per time step.  If it's set to 10 (which is the new default I just created), then we get ~1.5ms per time step!   Yay faster loihi!
One big change that was used to implement this is that we are no longer sending spikes from host to chip.  Instead, we send decoded values, and those values are then turned into spikes on-chip.   Right now, this is done in the snip itself on the x86 processor, just by implementing a bunch of little accumulators.  However, in a future PR we could also reorganize this so that we actually use a Loihi core to do this, since simulating spiking neurons is what it's for.  In that case, whenever we receive a value from the host, we'd set the bias of a Loihi Cx.  This would mean that we wouldn't be doing anything in the snip itself on time steps where we're not communicating.