### PR TITLE
Better stopping behaviour for snips

### DIFF
--- a/nengo_loihi/simulator.py
+++ b/nengo_loihi/simulator.py
@@ -375,7 +375,7 @@ class Simulator(object):
                     self.host_sim.run_steps(1)
                     self.handle_host2chip_communications()
                     self.handle_chip2host_communications()
-                self._n_steps += 1
+                    self._n_steps += 1
             finally:
                 # tell the snip to shut down
                 logger.info("Stopping snip, waiting for completion")

--- a/nengo_loihi/snips/nengo_io.c.template
+++ b/nengo_loihi/snips/nengo_io.c.template
@@ -1,12 +1,17 @@
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include "nengo_io.h"
 
 #define N_OUTPUTS {{ n_outputs }}
 #define N_ERRORS {{ n_errors }}
+#define STOP()\
+    s->userData[1023] = 1;\
+    printf("stopping\n");\
+    return
 
 int guard_io(runState *s) {
-    return 1;
+    return s->userData[1023] == 0;
 }
 
 void nengo_io(runState *s) {
@@ -32,9 +37,20 @@ void nengo_io(runState *s) {
 
     readChannel(inChannel, count, 1);
     // printf("count %d\n", count[0]);
+    if (count[0] < 0) {
+        STOP();
+    }
 
     for (int i=0; i < count[0]; i++) {
-        readChannel(inChannel, spike, 2);
+        readChannel(inChannel, spike, 1);
+        if (spike[0] < 0) {
+            STOP();
+        }
+        readChannel(inChannel, spike+1, 1);
+        if (spike[1] < 0) {
+            STOP();
+        }
+
         // printf("send spike %d.%d\n", spike[0], spike[1]);
         coreId = (CoreId) { .id=spike[0] };
         nx_send_discrete_spike(s->time, coreId, spike[1]);

--- a/nengo_loihi/tests/test_communication.py
+++ b/nengo_loihi/tests/test_communication.py
@@ -27,9 +27,9 @@ def test_input_node(allclose, Simulator, val, type):
     with Simulator(net, precompute=True) as sim:
         sim.run(1.0)
 
-        # TODO: seems like error margins should be smaller than this?
-        assert allclose(sim.data[p_b][-100:], val, atol=0.15)
-        assert allclose(sim.data[p_c][-100:], val, atol=0.15)
+    # TODO: seems like error margins should be smaller than this?
+    assert allclose(sim.data[p_b][-100:], val, atol=0.15)
+    assert allclose(sim.data[p_c][-100:], val, atol=0.15)
 
 
 @pytest.mark.parametrize('pre_d', [1, 3])

--- a/nengo_loihi/tests/test_stopping.py
+++ b/nengo_loihi/tests/test_stopping.py
@@ -1,0 +1,38 @@
+import nengo
+import pytest
+
+
+def test_stopping(Simulator):
+    with nengo.Network() as model:
+        stim = nengo.Node(0.5)
+        ens = nengo.Ensemble(n_neurons=100, dimensions=1)
+        nengo.Connection(stim, ens)
+
+        def output_func(t, x):
+            if t > 0.05:
+                raise RuntimeError('Stopping')
+        output = nengo.Node(output_func, size_in=1)
+        nengo.Connection(ens, output)
+
+    with Simulator(model, precompute=False) as sim:
+        with pytest.raises(RuntimeError):
+            sim.run(0.1)
+
+
+def test_closing(Simulator):
+    with nengo.Network() as model:
+        stim = nengo.Node(0.5)
+        ens = nengo.Ensemble(n_neurons=100, dimensions=1)
+        nengo.Connection(stim, ens)
+
+        def output_func(t, x):
+            if t > 0.05:
+                sim.close()
+
+        output = nengo.Node(output_func, size_in=1)
+        nengo.Connection(ens, output)
+
+    with Simulator(model, precompute=False) as sim:
+        sim.run(0.1)
+
+    assert sim.n_steps == 51


### PR DESCRIPTION
We now send an explicit stop signal, and once that is received the snip will just return immediately.

We needed better stopping behaviour for working with nengo_gui (since we don't know when the simulator might be closed).  It also handles pressing Ctrl-C while your model is running, which might be handy.

[EDIT:]  This PR may need to be re-thought in terms of making it fit with #26 , which made some big changes to the communication protocol between chip and host.