### PR TITLE
Nengo GUI integration

### DIFF
--- a/nengo_loihi/snips/nengo_io.c.template
+++ b/nengo_loihi/snips/nengo_io.c.template
@@ -5,9 +5,20 @@
 #define N_OUTPUTS %d
 
 void nengo_io(runState *s) {
+    // use the last element in userData as a quit flag
+    if (s->userData[1023] != 0) {
+        return;
+    }
+
     int count[1];
     readChannel("nengo_io_h2c", count, 1);
     //printf("count %%d\n", count[0]);
+    if (count[0] < 0) {
+        // a negative value indicates we should stop
+        s->userData[1023] = 1;
+        printf("stopping\n");
+        return;
+    }
 
     int spike[2];
     for (int i=0; i<count[0]; i++) {

--- a/nengo_loihi/tests/test_stopping.py
+++ b/nengo_loihi/tests/test_stopping.py
@@ -1,0 +1,39 @@
+import nengo
+import pytest
+
+
+def test_stopping(Simulator, seed):
+    model = nengo.Network(seed=seed)
+    with model:
+        stim = nengo.Node(0.5)
+        ens = nengo.Ensemble(n_neurons=100, dimensions=1)
+        nengo.Connection(stim, ens)
+
+        def output_func(t, x):
+            if t > 0.05:
+                raise Exception('Stopping')
+        output = nengo.Node(output_func, size_in=1)
+        nengo.Connection(ens, output)
+
+    with Simulator(model, precompute=False) as sim:
+        with pytest.raises(Exception):
+            sim.run(0.1)
+
+
+def test_closing(Simulator, seed):
+    model = nengo.Network(seed=seed)
+    with model:
+        stim = nengo.Node(0.5)
+        ens = nengo.Ensemble(n_neurons=100, dimensions=1)
+        nengo.Connection(stim, ens)
+
+        def output_func(t, x):
+            if t > 0.05:
+                sim.close()
+        output = nengo.Node(output_func, size_in=1)
+        nengo.Connection(ens, output)
+
+    sim = Simulator(model, precompute=False)
+
+    sim.run(0.1)
+    assert sim.n_steps == 51


### PR DESCRIPTION
This adds a few more tweaks on top of #27  (which this PR is based on) that were needed to get it to stop and restart fine in nengo_gui.  So now you can do `nengo --backend nengo_loihi` and it behaves almost like you'd expect (i.e. you can stop and continue, and change the code and it'll rebuild), with one slightly odd caveat: you can't have it run forever, and it's not a good idea to set that upper limit of how long it runs very high.  Here's why:

The Simulator will now attempt to stop any snips that are running if it is closed.  Unfortunately, I can't figure out a way to actually stop the execution, so the model will still run for however many timesteps were requested, but at least the snips won't cause the execution to halt (to wait for new input).

This means that we can't have nengo_gui do something like sim.run(1000) and expect it to work well.  That'll work fine once, but the moment you interrupt it, the chip will be unresponsive until it has run 1000000 time steps.  

So, to get around this problem, we need to let nengo_gui users specify this maximum run time.  The easiest thing I could think of was to add a magic variable max_loihi_time.  It defaults to 1.0 and if you set it in your gui code, it'll use whatever you say.

To run this, you need nengo_gui branch loihi.  

If anyone has stumbled across a way to tell loihi to stop its execution in the middle of a run, let me know!  :)  Barring that, I think this is the best we can do.

[EDIT: ]  This PR probably needs to be re-thought in light of the changes to the communication protocol between chip and host introduced in #26 