### PR TITLE
Compatibility with other python versions

### DIFF
--- a/nengo_loihi/simulator.py
+++ b/nengo_loihi/simulator.py
@@ -481,8 +481,8 @@ class Simulator(object):
                         for j, s in enumerate(spike_input.spikes[sent_count]):
                             if s:
                                 for output_axon in spike_input.axon_ids:
-                                    items.append((
-                                        sent_count, *output_axon[j]))
+                                    items.append(
+                                        (sent_count,) + output_axon[j])
                         sent_count += 1
                     spike_input.sent_count = sent_count
                 if len(items) > 0:

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     description="Run Nengo models on the Loihi chip",
     long_description=read("README.rst"),
     zip_safe=False,
+    python_requires=">=3.4",
     setup_requires=[
         "nengo",
     ],


### PR DESCRIPTION
Addressing #31.

Removing the star expression allows the emulator to work with Python 3.4. The tests also all appear to pass on Python 2.7, though I did not add any `__future__` import statements, so it's not guaranteed e.g. division will work identically in Python 2.

I mostly use Python 3 now, so I'm happy to just merge this and only officially support Python 3 (but ideally all common versions of it) going forward. However, if you think Python 2 support is also good to have, speak up!

Also, I'm tempted to say we should either officially support Python 2, or check on import that we're using Python 3.