### PR TITLE
Always set filter on post ensemble in connection

### DIFF
--- a/docs/examples/node_ens_ens.py
+++ b/docs/examples/node_ens_ens.py
@@ -23,7 +23,7 @@ with nengo.Network(seed=seed) as model:
     up = nengo.Probe(u, synapse=None)
 
     a = nengo.Ensemble(100, d, label='a')
-    nengo.Connection(u, a, synapse=None)
+    nengo.Connection(u, a)
     ap = nengo.Probe(a)
     anp = nengo.Probe(a.neurons)
     avp = nengo.Probe(a.neurons[:5], 'voltage')

--- a/docs/examples/node_ens_ens.py
+++ b/docs/examples/node_ens_ens.py
@@ -18,7 +18,7 @@ bnp = None
 nengo_loihi.set_defaults()
 with nengo.Network(seed=seed) as model:
     u = nengo.Node(
-        output=nengo.processes.WhiteSignal(tend, high=5, seed=seed + 1),
+        output=nengo.processes.WhiteSignal(tend, high=2, seed=seed + 1),
         size_out=d)
     up = nengo.Probe(u, synapse=None)
 

--- a/nengo_loihi/builder.py
+++ b/nengo_loihi/builder.py
@@ -521,6 +521,13 @@ def build_connection(model, conn):
             # (max_rate = INTER_RATE * INTER_N) is the spike rate we
             # use to represent a value of +/- 1
             weights = weights / (INTER_RATE * INTER_N * model.dt)
+
+            if conn.synapse is None:
+                warnings.warn(
+                    "No synapse set on Node connection. Since Node values are "
+                    "converted to spikes to transmit to Loihi, not having a "
+                    "synapse can cause increased spike noise. Consider using "
+                    "a synapse.")
     elif (isinstance(conn.pre_obj, Ensemble) and
           isinstance(conn.pre_obj.neuron_type, nengo.Direct)):
         raise NotImplementedError()

--- a/nengo_loihi/tests/test_connection.py
+++ b/nengo_loihi/tests/test_connection.py
@@ -65,7 +65,7 @@ def test_node_to_neurons(precompute, allclose, Simulator, plt):
         a = nengo.Ensemble(len(y), 1, label='a',
                            neuron_type=neuron_type, gain=gain, bias=bias)
         ap = nengo.Probe(a.neurons)
-        nengo.Connection(u, a.neurons, synapse=None, transform=A)
+        nengo.Connection(u, a.neurons, transform=A)
 
     with Simulator(model, precompute=precompute) as sim:
         sim.run(tfinal)
@@ -93,7 +93,7 @@ def test_neuron_to_neuron(Simulator, factor, seed, allclose):
         n = 10
         stim = nengo.Node(lambda t: [np.sin(t * 2 * np.pi)])
         a = nengo.Ensemble(n, 1)
-        nengo.Connection(stim, a, synapse=None)
+        nengo.Connection(stim, a)
 
         b = nengo.Ensemble(n, 1, neuron_type=nengo.SpikingRectifiedLinear(),
                            gain=np.ones(n), bias=np.zeros(n))
@@ -115,7 +115,7 @@ def test_ensemble_to_neurons(Simulator, seed, allclose, plt):
     with nengo.Network(seed=seed) as net:
         stim = nengo.Node(lambda t: [np.sin(t * 2 * np.pi)])
         pre = nengo.Ensemble(20, 1)
-        nengo.Connection(stim, pre, synapse=None)
+        nengo.Connection(stim, pre)
 
         post = nengo.Ensemble(2, 1,
                               gain=[1., 1.], bias=[0., 0.])
@@ -159,3 +159,14 @@ def test_ensemble_to_neurons(Simulator, seed, allclose, plt):
     assert allclose(np.sum(sim.data[p_post], axis=0) * sim.dt,
                     np.sum(nengosim.data[p_post], axis=0) * nengosim.dt,
                     atol=5)
+
+
+def test_node_no_synapse_warning(Simulator):
+    with nengo.Network() as model:
+        n = nengo.Node([0, 0])
+        a = nengo.Ensemble(100, 2)
+        nengo.Connection(n, a, synapse=None)
+
+    with pytest.warns(UserWarning):
+        with Simulator(model):
+            pass

--- a/nengo_loihi/tests/test_examples.py
+++ b/nengo_loihi/tests/test_examples.py
@@ -100,15 +100,15 @@ def test_node_ens_ens(allclose, plt):
     plt.subplot(413)
     plt.plot(t, a[:, 0] ** 2, c="b", label="a[0]**2")
     plt.plot(t, b[:, 0], c="g", label="b[0]")
-    plt.ylim([-1, 1])
+    plt.ylim([-0.05, 1])
     plt.legend(loc=0)
 
     plt.subplot(414)
-    plt.plot(t, a[:, 0] ** 2, c="b", label="a[1]**2")
-    plt.plot(t, b[:, 0], c="g", label="b[1]")
-    plt.ylim([-1, 1])
+    plt.plot(t, a[:, 1] ** 2, c="b", label="a[1]**2")
+    plt.plot(t, b[:, 1], c="g", label="b[1]")
+    plt.ylim([-0.05, 1])
     plt.legend(loc=0)
 
     tmask = t > 0.1  # ignore transients at the beginning
-    assert allclose(a[tmask], np.clip(u[tmask], -1, 1), atol=0.4, rtol=0.25)
-    assert allclose(b[tmask], a[tmask]**2, atol=0.35, rtol=0.0)
+    assert allclose(a[tmask], np.clip(u[tmask], -1, 1), atol=0.1, rtol=0.1)
+    assert allclose(b[tmask], a[tmask]**2, atol=0.15, rtol=0.2)

--- a/nengo_loihi/tests/test_learning.py
+++ b/nengo_loihi/tests/test_learning.py
@@ -15,7 +15,7 @@ def test_pes_comm_channel(allclose, Simulator, seed, plt, N):
 
         b = nengo.Node(None, size_in=1, size_out=1)
 
-        nengo.Connection(stim, a, synapse=None)
+        nengo.Connection(stim, a)
         conn = nengo.Connection(
             a, b, function=lambda x: 0, synapse=0.01,
             learning_rule_type=nengo.PES(learning_rate=1e-3))

--- a/nengo_loihi/tests/test_probe.py
+++ b/nengo_loihi/tests/test_probe.py
@@ -26,7 +26,7 @@ def test_voltage_decode(allclose, Simulator, seed, plt, dim):
 
         a = nengo.Ensemble(100 * 3, dim,
                            intercepts=nengo.dists.Uniform(-.95, .95))
-        nengo.Connection(stim, a, synapse=None)
+        nengo.Connection(stim, a)
 
         p_a = nengo.Probe(a, synapse=0.01)
 

--- a/nengo_loihi/tests/test_radius.py
+++ b/nengo_loihi/tests/test_radius.py
@@ -10,7 +10,7 @@ def test_radius_probe(Simulator, seed, radius):
         ens = nengo.Ensemble(n_neurons=100, dimensions=1,
                              radius=radius,
                              intercepts=nengo.dists.Uniform(-0.95, 0.95))
-        nengo.Connection(stim, ens, synapse=None)
+        nengo.Connection(stim, ens)
         p = nengo.Probe(ens, synapse=0.1)
     with Simulator(model, precompute=True) as sim:
         sim.run(0.5)
@@ -30,7 +30,7 @@ def test_radius_ens_ens(Simulator, seed, radius1, radius2, weights):
         b = nengo.Ensemble(n_neurons=100, dimensions=1,
                            radius=radius2,
                            intercepts=nengo.dists.Uniform(-0.95, 0.95))
-        nengo.Connection(stim, a, synapse=None)
+        nengo.Connection(stim, a)
         nengo.Connection(a, b, synapse=0.01, transform=radius2 / radius1,
                          solver=nengo.solvers.LstsqL2(weights=weights))
         p = nengo.Probe(b, synapse=0.1)


### PR DESCRIPTION
This would fix (for example) neuron->ensemble connections
(of which we currently have no test cases).

Unfortunately, this changes the behaviour of node->ensemble connections,
causing node_ens_ens to fail. The synapse set on the connection (None)
overrides the default INTER_TAU synapse, removing the filtering on
the ReLU neurons used to turn the node values into spikes.

Based on #43.