### PR TITLE
Enable running Nengo tests

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -18,6 +18,8 @@ if [[ "$COMMAND" == "install" ]]; then
     pip install -e .
 elif [[ "$COMMAND" == "run" ]]; then
     coverage run -m pytest nengo_loihi -v --duration 20 --plots && coverage report
+elif [[ "$COMMAND" == "run-nengo" ]]; then
+    pytest --pyargs nengo
 elif [[ "$COMMAND" == "upload" ]]; then
     eval "bash <(curl -s https://codecov.io/bash)"
 else

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ nengo_loihi/snips/nengo_io.c
 # For .ipynb examples
 *.pdf
 *.pkl
+*.pkl.gz
 docs/examples/adaptive_motor_control.py
 docs/examples/communication_channel.py
 docs/examples/integrator.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,16 @@ notifications:
 
 env:
   global:
+    - NENGO="false"
     - STATIC="false"
     - DOCS="false"
 
 matrix:
   include:
-    - env: PYTHON="3.5.5"
-    - env: PYTHON="3.5.5" STATIC="true"
-    - env: PYTHON="3.5.5" DOCS="true"
+    - env: PYTHON="3.5.2"
+    - env: PYTHON="3.5.2" NENGO="true"
+    - env: PYTHON="3.5.2" STATIC="true"
+    - env: PYTHON="3.5.2" DOCS="true"
 
 before_install:
   - source .ci/conda.sh install
@@ -34,6 +36,8 @@ script:
       .ci/docs.sh run;
     elif [[ "$DOCS" == "true" ]]; then
       .ci/docs.sh check;
+    elif [[ "$NENGO" == "true" ]]; then
+      .ci/test.sh run-nengo;
     else
       .ci/test.sh run;
     fi

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,7 @@ Release history
 
 - An error is now raised if
   a learning rule is applied to a non-decoded connection.
+  (`#103 <https://github.com/nengo/nengo-loihi/pull/103>`_)
 
 **Fixed**
 

--- a/conftest.py
+++ b/conftest.py
@@ -3,8 +3,8 @@ import logging
 import os
 from functools import partial
 
-import nengo.utils.numpy as npext
 import matplotlib as mpl
+import nengo.utils.numpy as npext
 import numpy as np
 import pytest
 
@@ -13,7 +13,6 @@ from nengo.conftest import plt, TestConfig  # noqa: F401
 from nengo.utils.compat import ensure_bytes
 
 import nengo_loihi
-
 from nengo_loihi.loihi_cx import CxSimulator
 
 
@@ -21,7 +20,6 @@ def pytest_configure(config):
     mpl.use("Agg")
     CxSimulator.strict = True
 
-    TestConfig.RefSimulator = TestConfig.Simulator = nengo_loihi.Simulator
     if config.getoption('seed_offset'):
         TestConfig.test_seed = config.getoption('seed_offset')[0]
     nengo_loihi.set_defaults()
@@ -38,8 +36,8 @@ def pytest_addoption(parser):
 
 def pytest_report_header(config, startdir):
     target = config.getoption("--target")
-    return "Nengo Loihi is using {}".format(
-        "Loihi hardware" if target == "loihi" else "the Numpy simulator")
+    return "Nengo Loihi is using Loihi {}".format(
+        "hardware" if target == "loihi" else "emulator")
 
 
 def pytest_terminal_summary(terminalreporter):
@@ -58,9 +56,9 @@ def pytest_terminal_summary(terminalreporter):
 
 
 def pytest_runtest_setup(item):
-    if (getattr(item.obj, "hang", False) and
-            item.config.getvalue("--target") == "loihi" and
-            item.config.getvalue("--no-hang")):
+    if (getattr(item.obj, "hang", False)
+            and item.config.getvalue("--target") == "loihi"
+            and item.config.getvalue("--no-hang")):
         pytest.xfail("This test causes Loihi to hang indefinitely")
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -196,12 +196,7 @@ def pytest_collection_modifyitems(session, config, items):
         return
 
     hanging_nengo_tests = [
-        "nengo/tests/test_connection.py::test_slicing[LIF]",
-        "nengo/tests/test_connection.py::test_slicing[SpikingRectifiedLinear]",
-        "nengo/tests/test_connection.py::test_slicing_function",
         "nengo/tests/test_learning_rules.py::test_slicing",
-        "nengo/tests/test_ensemble.py::test_vector[LIF]",
-        "nengo/tests/test_ensemble.py::test_vector[SpikingRectifiedLinear]",
         "nengo/tests/test_neurons.py::test_direct_mode_nonfinite_value",
         "nengo/tests/test_neurons.py::test_lif_min_voltage[-inf]",
         "nengo/tests/test_neurons.py::test_lif_min_voltage[-1]",

--- a/conftest.py
+++ b/conftest.py
@@ -190,3 +190,45 @@ def allclose(request):
         return result
 
     return _allclose
+
+
+def pytest_collection_modifyitems(session, config, items):
+    target = config.getoption("--target")
+    if target != "loihi":
+        return
+
+    hanging_nengo_tests = [
+        "nengo/tests/test_connection.py::test_slicing[LIF]",
+        "nengo/tests/test_connection.py::test_slicing[SpikingRectifiedLinear]",
+        "nengo/tests/test_connection.py::test_slicing_function",
+        "nengo/tests/test_learning_rules.py::test_slicing",
+        "nengo/tests/test_ensemble.py::test_vector[LIF]",
+        "nengo/tests/test_ensemble.py::test_vector[SpikingRectifiedLinear]",
+        "nengo/tests/test_neurons.py::test_direct_mode_nonfinite_value",
+        "nengo/tests/test_neurons.py::test_lif_min_voltage[-inf]",
+        "nengo/tests/test_neurons.py::test_lif_min_voltage[-1]",
+        "nengo/tests/test_neurons.py::test_lif_min_voltage[0]",
+        "nengo/tests/test_neurons.py::test_lif_zero_tau_ref",
+        "nengo/tests/test_node.py::test_none",
+        "nengo/tests/test_node.py::test_invalid_values[inf]",
+        "nengo/tests/test_node.py::test_invalid_values[nan]",
+        "nengo/tests/test_node.py::test_invalid_values[string]",
+        "nengo/utils/tests/test_network.py::"  # no comma
+        "test_activate_direct_mode_learning[learning_rule0-False]",
+        "nengo/utils/tests/test_network.py::"  # no comma
+        "test_activate_direct_mode_learning[learning_rule1-True]",
+        "nengo/utils/tests/test_network.py::"  # no comma
+        "test_activate_direct_mode_learning[learning_rule2-True]",
+        "nengo/utils/tests/test_network.py::"  # no comma
+        "test_activate_direct_mode_learning[learning_rule3-False]",
+    ]
+    deselected = [
+        item for item in items if item.nodeid in hanging_nengo_tests
+    ]
+    config.hook.pytest_deselected(items=deselected)
+    for item in deselected:
+        items.remove(item)
+
+
+nengo.conftest.RefSimulator = Simulator
+nengo.conftest.Simulator = Simulator

--- a/nengo_loihi/builder.py
+++ b/nengo_loihi/builder.py
@@ -6,6 +6,7 @@ import numpy as np
 
 import nengo
 from nengo import Network, Ensemble, Connection, Node, Probe
+from nengo.builder.connection import BuiltConnection
 from nengo.dists import Distribution, get_samples
 from nengo.connection import LearningRule
 from nengo.ensemble import Neurons
@@ -134,6 +135,12 @@ class Model(CxModel):
         averaged over time will be 1.
         """
         return 1. / (self.dt * self.inter_rate * self.inter_n)
+
+    def __getstate__(self):
+        raise NotImplementedError("Can't pickle nengo_loihi.builder.Model")
+
+    def __setstate__(self, state):
+        raise NotImplementedError("Can't pickle nengo_loihi.builder.Model")
 
     def __str__(self):
         return "Model: %s" % self.label
@@ -326,12 +333,9 @@ def build_ensemble(model, ens):
     gain, bias, max_rates, intercepts = get_gain_bias(
         ens, rng, model.intercept_limit)
 
-    if isinstance(ens.neuron_type, nengo.Direct):
-        raise NotImplementedError()
-    else:
-        group = CxGroup(ens.n_neurons, label='%s' % ens)
-        group.bias[:] = bias
-        model.build(ens.neuron_type, ens.neurons, group)
+    group = CxGroup(ens.n_neurons, label='%s' % ens)
+    group.bias[:] = bias
+    model.build(ens.neuron_type, ens.neurons, group)
 
     # set default filter just in case no other filter gets set
     group.configure_default_filter(model.inter_tau, dt=model.dt)
@@ -376,6 +380,18 @@ def build_interencoders(model, ens):
     group.add_synapses(synapses, name='inter_encoders')
 
 
+@Builder.register(nengo.neurons.NeuronType)
+def build_neurons(model, neurontype, neurons, group):
+    # If we haven't registered a builder for a specific type, then it cannot
+    # be simulated on Loihi.
+    raise BuildError(
+        "The neuron type %r cannot be simulated on Loihi. Please either "
+        "switch to a supported neuron type like LIF or "
+        "SpikingRectifiedLinear, or explicitly mark ensembles using this "
+        "neuron type as off-chip with\n"
+        "  net.config[ensembles].on_chip = False")
+
+
 @Builder.register(nengo.LIF)
 def build_lif(model, lif, neurons, group):
     group.configure_lif(
@@ -400,11 +416,6 @@ def build_node(model, node):
         return
     else:
         raise NotImplementedError()
-
-
-BuiltConnection = collections.namedtuple(
-    'BuiltConnection',
-    ('eval_points', 'solver_info', 'weights', 'transform'))
 
 
 def get_eval_points(model, conn, rng):
@@ -534,7 +545,7 @@ def build_connection(model, conn):
             # TODO: this identity transform may be avoidable
             transform = np.eye(conn.pre.size_out)
         else:
-            assert transform.ndim == 2
+            assert transform.ndim == 2, "transform shape not handled yet"
             assert transform.shape[1] == conn.pre.size_out
 
         assert transform.shape[1] == conn.pre.size_out
@@ -565,7 +576,7 @@ def build_connection(model, conn):
             needs_interneurons = True
     elif isinstance(conn.pre_obj, Neurons):
         assert conn.pre_slice == slice(None)
-        assert transform.ndim == 2
+        assert transform.ndim == 2, "transform shape not handled yet"
         weights = transform / model.dt
         neuron_type = conn.pre_obj.ensemble.neuron_type
     else:

--- a/nengo_loihi/loihi_cx.py
+++ b/nengo_loihi/loihi_cx.py
@@ -386,7 +386,8 @@ class CxSynapses(object):
         assert weights.shape[0] == self.n_axons
 
         idxBits = int(np.ceil(np.log2(self.max_ind() + 1)))
-        assert idxBits <= SynapseFmt.INDEX_BITS_MAP[-1]
+        assert idxBits <= SynapseFmt.INDEX_BITS_MAP[-1], (
+            "idxBits out of range, ensemble too large?")
         idxBits = next(i for i, v in enumerate(SynapseFmt.INDEX_BITS_MAP)
                        if v >= idxBits)
         self.format(compression=3, idxBits=idxBits, fanoutType=1,
@@ -904,7 +905,7 @@ class CxSimulator(object):
             for probe in group.probes:
                 x_slice = self.group_cxs[probe.target]
                 p_slice = probe.slice
-                assert hasattr(self, probe.key)
+                assert hasattr(self, probe.key), "probe key not found"
                 x = getattr(self, probe.key)[x_slice][p_slice].copy()
                 self.probe_outputs[probe].append(x)
 

--- a/nengo_loihi/loihi_interface.py
+++ b/nengo_loihi/loihi_interface.py
@@ -358,7 +358,7 @@ def build_axons(n2core, core, group, axons, cx_ids):
 
 
 def build_probe(n2core, core, group, probe, cx_idxs):
-    assert probe.key in ('u', 'v', 's')
+    assert probe.key in ('u', 'v', 's'), "probe key not found"
     key_map = {'s': 'spike'}
     key = key_map.get(probe.key, probe.key)
 
@@ -696,7 +696,7 @@ class LoihiSimulator(object):
 
     def create_io_snip(self):
         # snips must be created before connecting
-        assert not self.is_connected()
+        assert not self.is_connected(), "still connected"
 
         snips_dir = os.path.join(os.path.dirname(__file__), "snips")
         env = jinja2.Environment(

--- a/nengo_loihi/simulator.py
+++ b/nengo_loihi/simulator.py
@@ -44,7 +44,7 @@ class ProbeDict(NengoProbeDict):
                 if key in fallback:
                     target = fallback.raw
                     break
-        assert key in target
+        assert key in target, "probed object not found"
 
         if (key not in self._cache
                 or len(self._cache[key]) != len(target[key])):
@@ -141,16 +141,173 @@ class Simulator(object):
     # is not supported by the backend. For example:
     #     unsupported = [('test_pes*', 'PES rule not implemented')]
     # would skip all tests whose names start with 'test_pes'.
-    unsupported = []
+    unsupported = [
+        # no ensembles on chip
+        ('test_circularconv.py:*', "no ensembles onchip"),
+        ('test_product.py:test_direct_mode_with_single_neuron',
+         "no ensembles onchip"),
+        ('test_connection.py:test_neuron_slicing', "no ensembles onchip"),
+        ('test_connection.py:test_boolean_indexing', "no ensembles onchip"),
+        ('test_learning_rules.py:test_pes_synapse*', "no ensembles onchip"),
+        ('test_learning_rules.py:test_pes_recurrent_slice*',
+         "no ensembles onchip"),
+        ('test_neurons.py:test_amplitude[[]LIFRate[]]', "no ensembles onchip"),
+        ('test_neurons.py:test_amplitude[[]RectifiedLinear[]]',
+         "no ensembles onchip"),
+        ('test_neurons.py:test_alif_rate', "no ensembles onchip"),
+        ('test_neurons.py:test_izhikevich', "no ensembles onchip"),
+        ('test_neurons.py:test_sigmoid_response_curves*',
+         "no ensembles onchip"),
+        ('test_node.py:test_[!i]*', "no ensembles onchip"),
+        ('test_probe.py:test_multirun', "no ensembles onchip"),
+        ('test_probe.py:test_dts', "no ensembles onchip"),
+        ('test_probe.py:test_large', "no ensembles onchip"),
+        ('test_probe.py:test_conn_output', "no ensembles onchip"),
+        ('test_processes.py:test_time', "no ensembles onchip"),
+        ('test_processes.py:test_brownnoise', "no ensembles onchip"),
+        ('test_processes.py:test_gaussian_white*', "no ensembles onchip"),
+        ('test_processes.py:test_whitesignal*', "no ensembles onchip"),
+        ('test_processes.py:test_reset', "no ensembles onchip"),
+        ('test_processes.py:test_seed', "no ensembles onchip"),
+        ('test_processes.py:test_present_input', "no ensembles onchip"),
+        ('test_processes.py:TestPiecewise*', "no ensembles onchip"),
+        ('test_simulator.py:test_steps', "no ensembles onchip"),
+        ('test_simulator.py:test_time_absolute', "no ensembles onchip"),
+        ('test_simulator.py:test_trange*', "no ensembles onchip"),
+        ('test_simulator.py:test_probe_cache', "no ensembles onchip"),
+        ('test_simulator.py:test_invalid_run_time', "no ensembles onchip"),
+        ('test_simulator.py:test_sample_every*', "no ensembles onchip"),
+        ('test_synapses.py:test_lowpass', "no ensembles onchip"),
+        ('test_synapses.py:test_alpha', "no ensembles onchip"),
+        ('test_synapses.py:test_triangle', "no ensembles onchip"),
+        ('test_synapses.py:test_linearfilter', "no ensembles onchip"),
+        ('utils/*test_ensemble.py:test_*_curves_direct_mode*',
+         "no ensembles onchip"),
+        ('utils/*test_network.py:*direct_mode_learning[learning_rule[123]*',
+         "no ensembles onchip"),
+        ('utils/*test_neurons.py:test_rates_*', "no ensembles onchip"),
+
+        # accuracy
+        ('test_actionselection.py:test_basic', "inaccurate"),
+        ('test_am_[!s]*', "integrator instability"),
+        ('test_ensemblearray.py:test_matrix_mul', "inaccurate"),
+        ('test_product.py:test_sine_waves', "inaccurate"),
+        ('test_workingmemory.py:test_inputgatedmemory', "inaccurate"),
+        ('test_cortical.py:test_convolution', "inaccurate"),
+        ('test_thalamus.py:test_routing', "inaccurate"),
+        ('test_thalamus.py:test_nondefault_routing', "inaccurate"),
+        ('test_connection.py:test_node_to_ensemble*', "inaccurate"),
+        ('test_connection.py:test_neurons_to_node*', "inaccurate"),
+        ('test_connection.py:test_function_and_transform', "inaccurate"),
+        ('test_connection.py:test_weights*', "inaccurate"),
+        ('test_connection.py:test_vector*', "inaccurate"),
+        ('test_connection.py:test_slicing*', "inaccurate"),
+        ('test_connection.py:test_function_output_size', "inaccurate"),
+        ('test_connection.py:test_function_points', "inaccurate"),
+        ('test_ensemble.py:test_scalar*', "inaccurate"),
+        ('test_ensemble.py:test_vector*', "inaccurate"),
+        ('test_learning_rules.py:test_pes_transform', "inaccurate"),
+        ('test_learning_rules.py:test_slicing', "inaccurate"),
+        ('test_neurons.py:test_alif', "inaccurate"),
+        ('test_neurons.py:test_amplitude[[]LIF[]]', "inaccurate"),
+        ('test_neurons.py:test_amplitude[[]SpikingRectifiedLinear[]]',
+         "inaccurate"),
+        ('test_presets.py:test_thresholding_preset', "inaccurate"),
+        ('test_synapses.py:test_decoders', "inaccurate"),
+
+        # builder inconsistencies
+        ('test_connection.py:test_neurons_to_ensemble*',
+         "transform shape not implemented"),
+        ('test_connection.py:test_transform_probe',
+         "transform shape not implemented"),
+        ('test_connection.py:test_list_indexing*', "indexing bug?"),
+        ('test_connection.py:test_prepost_errors', "learning bug?"),
+        ('test_ensemble.py:test_gain_bias_warning', "warning not raised"),
+        ('test_ensemble.py:*invalid_intercepts*', "BuildError not raised"),
+        ('test_learning_rules.py:test_pes_ens_*', "learning bug?"),
+        ('test_learning_rules.py:test_pes_weight_solver', "learning bug?"),
+        ('test_learning_rules.py:test_pes_neuron_*', "learning bug?"),
+        ('test_learning_rules.py:test_pes_multidim_error',
+         "dict of learning rules not handled"),
+        ('test_learning_rules.py:test_reset*', "learning bug?"),
+        ('test_neurons.py:test_lif_min_voltage*', "lif.min_voltage ignored"),
+        ('test_neurons.py:test_lif_zero_tau_ref', "lif.tau_ref ignored"),
+        ('test_probe.py:test_input_probe', "shape mismatch"),
+        ('test_probe.py:test_slice', "ObjView not handled properly"),
+        ('test_probe.py:test_update_timing', "probe bug?"),
+        ('test_solvers.py:test_nosolver*', "NoSolver bug"),
+
+        # reset bugs
+        ('test_neurons.py:test_reset*', "sim.reset not working correctly"),
+
+        # non-PES learning rules
+        ('test_learning_rules.py:test_unsupervised*',
+         "non-PES learning rules not implemented"),
+        ('test_learning_rules.py:test_dt_dependence*',
+         "non-PES learning rules not implemented"),
+        ('*voja*', "voja not implemented"),
+        ('test_learning_rules.py:test_custom_type',
+         "non-PES learning rules not implemented"),
+
+        # Nengo bug
+        ('test_simulator.py:test_entry_point',
+         "logic should be more flexible"),
+
+        # ensemble noise
+        ('test_ensemble.py:test_noise*', "ensemble.noise not implemented"),
+
+        # probe types
+        ('test_connection.py:test_dist_transform',
+         "probe type not implemented"),
+        ('test_connection.py:test_decoder_probe',
+         "probe type not implemented"),
+        ('test_probe.py:test_defaults', "probe type not implemented"),
+        ('test_probe.py:test_ensemble_encoders', "probe type not implemented"),
+
+        # probe.sample_every
+        ('test_integrator.py:test_integrator',
+         "probe.sample_every not implemented"),
+        ('test_oscillator.py:test_oscillator',
+         "probe.sample_every not implemented"),
+        ('test_ensemble.py:test_product*',
+         "probe.sample_every not implemented"),
+        ('test_neurons.py:test_dt_dependence*',
+         "probe.sample_every not implemented"),
+        ('test_probe.py:test_multiple_probes',
+         "probe.sample_every not implemented"),
+
+        # needs better place and route
+        ('test_ensemble.py:test_eval_points_heuristic*',
+         "max number of compartments exceeded"),
+        ('test_neurons.py:test_lif*', "idxBits out of range"),
+
+        # serialization / deserialization
+        ('test_cache.py:*', "model pickling not implemented"),
+        ('test_copy.py:test_pickle_model', "model pickling not implemented"),
+        ('test_simulator.py:test_signal_init_values',
+         "nengo.builder.Model instances not handled"),
+
+        # progress bars
+        ('test_simulator.py:test_simulator_progress_bars',
+         "progress bars not implemented"),
+
+        # utils.connection.target_function (deprecated)
+        ('utils/tests/test_connection.py*',
+         "target_function (deprecated) not working"),
+    ]
 
     def __init__(self, network, dt=0.001, seed=None, model=None,  # noqa: C901
-                 precompute=False, target=None):
+                 precompute=False, target=None, progress_bar=None):
         self.closed = True  # Start closed in case constructor raises exception
+        if progress_bar is not None:
+            raise NotImplementedError("progress bars not implemented")
 
         if model is None:
             # Call the builder to make a model
             self.model = Model(dt=float(dt), label="%s, dt=%f" % (network, dt))
         else:
+            assert isinstance(model, Model), (
+                "model is not type 'nengo_loihi.builder.Model'")
             self.model = model
             assert self.model.dt == dt
 
@@ -295,7 +452,8 @@ class Simulator(object):
         for probe in self.model.probes:
             if probe in self.model.chip2host_params:
                 continue
-            assert probe.sample_every is None
+            assert probe.sample_every is None, (
+                "probe.sample_every not implemented")
             assert ("loihi" not in self.sims
                     or "emulator" not in self.sims)
             if "loihi" in self.sims:
@@ -329,6 +487,7 @@ class Simulator(object):
             self.seed = seed
 
         self._n_steps = 0
+        self._time = 0
 
         # clear probe data
         for probe in self.model.probes:
@@ -510,7 +669,7 @@ class Simulator(object):
         logger.info("Finished running for %d steps", steps)
         self._probe()
 
-    def trange(self, sample_every=None):
+    def trange(self, sample_every=None, dt=None):
         """Create a vector of times matching probed data.
 
         Note that the range does not start at 0 as one might expect, but at

--- a/nengo_loihi/splitter.py
+++ b/nengo_loihi/splitter.py
@@ -154,7 +154,7 @@ def place_ensembles(networks):
         # User-specified config takes precedence
         if config[ens].on_chip is not None:
             networks.move(ens, "chip" if config[ens].on_chip else "host")
-        # Direct mode ensembles must be off chip
+        # Direct mode ensembles must be off-chip
         elif isinstance(ens.neuron_type, nengo.Direct):
             networks.move(ens, "host")
 

--- a/nengo_loihi/tests/test_precompute.py
+++ b/nengo_loihi/tests/test_precompute.py
@@ -45,10 +45,10 @@ def test_precompute(allclose, Simulator, seed, plt):
     assert allclose(sim1.data[p_out], sim2.data[p_out], atol=0.2)
 
 
-@pytest.mark.xfail(pytest.config.getoption("--target") == "loihi",
-                   reason="Fails allclose check")
 @pytest.mark.skipif(pytest.config.getoption("--target") != "loihi",
                     reason="Loihi only test")
+@pytest.mark.xfail(pytest.config.getoption("--target") == "loihi",
+                   reason="Fails allclose check")
 def test_input_node_precompute(allclose, Simulator, plt):
     input_fn = lambda t: np.sin(2 * np.pi * t)
     targets = ["sim", "loihi"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
-addopts = -p nengo.tests.options
+addopts = -p nengo.tests.options --simulator nengo_loihi.Simulator --neurons nengo.LIF,nengo.SpikingRectifiedLinear
 filterwarnings =
     ignore:Seed will be ignored when running on Loihi
-log_format=%(levelname).1s %(module)-18s %(message)s
-log_level=DEBUG
+log_format = %(levelname).1s %(module)-18s %(message)s
+log_level = DEBUG
 norecursedirs = .* *.egg build dist docs *.analytics *.logs *.plots


### PR DESCRIPTION
This adds some additional options to `pytest.ini` which makes it possible to run the Nengo tests with

```bash
pytest --pyargs nengo
```

Most of the test failures I'm seeing right now (just running on the emulator) are due to issues already fixed in existing pull requests, so the number of passing tests isn't very meaningful.

Still todo:

- [x] Figure out how to deal with tests with no ensembles
- [x] Expand `allclose` fixture to deal with different tolerances on different backends (@drasmuss)
- [x] Reenable SpikingReLu tests
- [x] Make sure all sims are properly closed (in tests, and in `nengo_loihi/simulator.py`)

[Additional discussion](https://gitter.im/nengo/loihi-48)