### PR TITLE
Add more accurate LIF rate function for decoders

### DIFF
--- a/nengo_loihi/builder.py
+++ b/nengo_loihi/builder.py
@@ -17,6 +17,7 @@ import nengo.utils.numpy as npext
 
 from nengo_loihi.loihi_cx import (
     CxModel, CxGroup, CxSynapses, CxAxons, CxProbe, CxSpikeInput)
+from nengo_loihi.neurons import loihi_rates
 from . import splitter
 
 logger = logging.getLogger(__name__)
@@ -406,7 +407,7 @@ def build_decoders(model, conn, rng, transform):
 
 
 def solve_for_decoders(conn, gain, bias, x, targets, rng, E=None):
-    activities = conn.pre_obj.neuron_type.rates(x, gain, bias)
+    activities = loihi_rates(conn.pre_obj.neuron_type, x, gain, bias)
     if np.count_nonzero(activities) == 0:
         raise BuildError(
             "Building %s: 'activities' matrix is all zero for %s. "

--- a/nengo_loihi/builder.py
+++ b/nengo_loihi/builder.py
@@ -86,6 +86,9 @@ class Model(CxModel):
     def __init__(self, dt=0.001, label=None, builder=None):
         super(Model, self).__init__()
 
+        if dt != 0.001:
+            raise NotImplementedError("`dt != 0.001` not yet supported")
+
         self.dt = dt
         self.label = label
 

--- a/nengo_loihi/builder.py
+++ b/nengo_loihi/builder.py
@@ -399,15 +399,15 @@ def build_decoders(model, conn, rng, transform):
     #                   if model.seeded[conn] else solve_for_decoders)
     # decoders, solver_info = wrapped_solver(
     decoders, solver_info = solve_for_decoders(
-        conn, gain, bias, x, targets, rng=rng, E=E)
+        conn, gain, bias, x, targets, rng=rng, dt=model.dt, E=E)
 
     weights = (decoders.T if conn.solver.weights else
                multiply(transform, decoders.T))
     return eval_points, weights, solver_info
 
 
-def solve_for_decoders(conn, gain, bias, x, targets, rng, E=None):
-    activities = loihi_rates(conn.pre_obj.neuron_type, x, gain, bias)
+def solve_for_decoders(conn, gain, bias, x, targets, rng, dt, E=None):
+    activities = loihi_rates(conn.pre_obj.neuron_type, x, gain, bias, dt)
     if np.count_nonzero(activities) == 0:
         raise BuildError(
             "Building %s: 'activities' matrix is all zero for %s. "

--- a/nengo_loihi/neurons.py
+++ b/nengo_loihi/neurons.py
@@ -8,18 +8,18 @@ from nengo.neurons import NeuronType
 from nengo.params import NumberParam
 
 
-def loihi_lif_rates(neuron_type, x, gain, bias):
-    dt = 0.001
+def loihi_lif_rates(neuron_type, x, gain, bias, dt):
+    # discretize tau_ref as per CxGroup.configure_lif
+    tau_ref = dt * np.round(neuron_type.tau_ref / dt)
     j = neuron_type.current(x, gain, bias) - 1
 
     out = np.zeros_like(j)
-    period = neuron_type.tau_ref + neuron_type.tau_rc * np.log1p(1. / j[j > 0])
+    period = tau_ref + neuron_type.tau_rc * np.log1p(1. / j[j > 0])
     out[j > 0] = (neuron_type.amplitude / dt) / np.ceil(period / dt)
     return out
 
 
-def loihi_spikingrectifiedlinear_rates(neuron_type, x, gain, bias):
-    dt = 0.001
+def loihi_spikingrectifiedlinear_rates(neuron_type, x, gain, bias, dt):
     j = neuron_type.current(x, gain, bias)
 
     out = np.zeros_like(j)
@@ -28,10 +28,10 @@ def loihi_spikingrectifiedlinear_rates(neuron_type, x, gain, bias):
     return out
 
 
-def loihi_rates(neuron_type, x, gain, bias):
+def loihi_rates(neuron_type, x, gain, bias, dt):
     for cls in type(neuron_type).__mro__:
         if cls in loihi_rate_functions:
-            return loihi_rate_functions[cls](neuron_type, x, gain, bias)
+            return loihi_rate_functions[cls](neuron_type, x, gain, bias, dt)
     return neuron_type.rates(x, gain, bias)
 
 

--- a/nengo_loihi/tests/test_neurons.py
+++ b/nengo_loihi/tests/test_neurons.py
@@ -34,7 +34,7 @@ def test_loihi_rates(neuron_type, Simulator, plt, allclose):
         sim.run(1.0)
 
     est_rates = sim.data[ap].mean(axis=0)
-    ref_rates = loihi_rates(neuron_type, x, gain, bias)
+    ref_rates = loihi_rates(neuron_type, x, gain, bias, dt=dt)
 
     plt.plot(x, ref_rates, "k", label="predicted")
     plt.plot(x, est_rates, "g", label="measured")

--- a/nengo_loihi/tests/test_neurons.py
+++ b/nengo_loihi/tests/test_neurons.py
@@ -1,0 +1,43 @@
+import numpy as np
+import nengo
+import pytest
+
+from nengo_loihi.neurons import loihi_rates
+
+
+@pytest.mark.parametrize("neuron_type", [
+    nengo.LIF(),
+    nengo.LIF(tau_ref=0.001, tau_rc=0.07, amplitude=0.34),
+    nengo.SpikingRectifiedLinear(),
+    nengo.SpikingRectifiedLinear(amplitude=0.23),
+])
+def test_loihi_rates(neuron_type, Simulator, plt, allclose):
+    n = 256
+    x = np.linspace(0, 1, n)
+
+    encoders = np.ones((n, 1))
+    max_rates = 400 * np.ones(n)
+    intercepts = 0 * np.ones(n)
+    gain, bias = neuron_type.gain_bias(max_rates, intercepts)
+    j = x * gain + bias
+
+    with nengo.Network() as model:
+        a = nengo.Ensemble(n, 1,
+                           neuron_type=neuron_type,
+                           encoders=encoders,
+                           gain=gain,
+                           bias=j)
+        ap = nengo.Probe(a.neurons)
+
+    dt = 0.001
+    with Simulator(model, dt=dt) as sim:
+        sim.run(1.0)
+
+    est_rates = sim.data[ap].mean(axis=0)
+    ref_rates = loihi_rates(neuron_type, x, gain, bias)
+
+    plt.plot(x, ref_rates, "k", label="predicted")
+    plt.plot(x, est_rates, "g", label="measured")
+    plt.legend(loc='best')
+
+    assert allclose(est_rates, ref_rates, atol=1, rtol=0)


### PR DESCRIPTION
This rate function accounts for Loihi discretization.

TODO: I'd like to look qualitatively/quantitatively at how much effect this actually has on some more integrated test cases.

Just looking at `test_connection.py`, I found that `mean rmse: 0.99851 +/- 1.8416` before the change and `mean rmse: 0.90317 +/- 1.7610` after. So there's some improvement.

TODO: Once the ReLU fix is merged, I'll rebase and do the same for that.