### PR TITLE
Remove passthrough nodes onchip

### DIFF
--- a/docs/examples/integrator.ipynb
+++ b/docs/examples/integrator.ipynb
@@ -132,7 +132,7 @@
    },
    "outputs": [],
    "source": [
-    "with nengo_loihi.Simulator(model, precompute=False) as sim:\n",
+    "with nengo_loihi.Simulator(model) as sim:\n",
     "    sim.run(6)\n",
     "t = sim.trange()"
    ]

--- a/docs/examples/integrator_multi_d.ipynb
+++ b/docs/examples/integrator_multi_d.ipynb
@@ -133,7 +133,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with nengo_loihi.Simulator(model, precompute=False) as sim:\n",
+    "with nengo_loihi.Simulator(model) as sim:\n",
     "    sim.run(6)\n",
     "t = sim.trange()"
    ]

--- a/nengo_loihi/passthrough.py
+++ b/nengo_loihi/passthrough.py
@@ -1,0 +1,273 @@
+import warnings
+
+import nengo
+from nengo.exceptions import BuildError, NengoException
+import numpy as np
+
+
+def is_passthrough(obj):
+    return isinstance(obj, nengo.Node) and obj.output is None
+
+
+def base_obj(obj):
+    """Returns the Ensemble or Node underlying an object"""
+    if isinstance(obj, nengo.ensemble.Neurons):
+        return obj.ensemble
+    return obj
+
+
+class ClusterException(NengoException):
+    pass
+
+
+class Cluster(object):
+    """A collection of passthrough Nodes directly connected to each other.
+
+    When removing passthrough Nodes, we often have large chains of Nodes that
+    should be removed together. That is, we tend to have a directed graph,
+    starting with inputs coming from Ensembles and non-passthrough Nodes, and
+    ending in Ensembles and non-passthrough Nodes. This Cluster object
+    represents this collection of passthrough Nodes and allows us to remove
+    them all at once.
+    """
+    def __init__(self, obj):
+        self.objs = set([obj])  # the Nodes in the cluster
+        self.conns_in = set()  # Connections into the cluster
+        self.conns_out = set()  # Connections out of the cluster
+        self.conns_mid = set()  # Connections within the cluster
+        self.probed_objs = set()  # Nodes that have Probes on them
+
+    def merge_with(self, other):
+        """Combine this Cluster with another Cluster"""
+        self.objs.update(other.objs)
+        self.conns_in.update(other.conns_in)
+        self.conns_out.update(other.conns_out)
+        self.conns_mid.update(other.conns_mid)
+        self.probed_objs.update(other.probed_objs)
+
+    def merge_transforms(self, size1, trans1, slice1,
+                         node, slice2, trans2, size2):
+        """Return an equivalent transform to the two provided transforms.
+
+        This is for finding a transform that converts this::
+
+            a = nengo.Node(size1)
+            b = nengo.Node(size2)
+            nengo.Connection(a, node[slice1], transform=trans1)
+            nengo.Connection(node[slice2], b, transform=trans2)
+
+        Into this::
+
+            a = nengo.Node(size1)
+            b = nengo.Node(size2)
+            nengo.Connection(a, b, transform=t)
+
+        """
+        if trans1.ndim == 0:  # scalar
+            trans1 = np.eye(size1) * trans1
+        elif trans1.ndim != 2:
+            raise BuildError("Unhandled transform shape: %s" % (trans1.shape,))
+
+        if trans2.ndim == 0:  # scalar
+            trans2 = np.eye(size2) * trans2
+        elif trans2.ndim != 2:
+            raise BuildError("Unhandled transform shape: %s" % (trans2.shape,))
+
+        mid_t = np.eye(node.size_in)[slice2, slice1]
+        return np.dot(trans2, np.dot(mid_t, trans1))
+
+    def merge_synapses(self, syn1, syn2):
+        """Return an equivalent synapse for the two provided synapses."""
+        if syn1 is None:
+            return syn2
+        elif syn2 is None:
+            return syn1
+        else:
+            assert isinstance(syn1, nengo.Lowpass) and isinstance(
+                syn2, nengo.Lowpass)
+            warnings.warn(
+                "Combining two Lowpass synapses, this may change the "
+                "behaviour of the network (set `remove_passthrough=False` "
+                "to avoid this).")
+            return nengo.Lowpass(syn1.tau + syn2.tau)
+
+    def generate_from(self, obj, outputs, previous=None):
+        """Generates all direct Connections from obj out of the Cluster.
+
+        This is a recursive process, starting at this obj (a Node within the
+        Cluster) and iterating to find all outputs and all probed Nodes
+        within the Cluster. The transform and synapse values needed are
+        computed while iterating through the graph.
+
+        Return values can be used to make equivalent Connection objects::
+
+            nengo.Connection(
+                obj[pre_slice], post, transform=trans, synapse=syn)
+
+        """
+        previous = [] if previous is None else previous
+        if obj not in outputs:
+            return
+
+        if obj in self.probed_objs:
+            # this Node has a Probe, so we need to keep it around and create
+            # a new Connection that goes to it, as the original Connections
+            # will get removed
+            yield slice(None), np.array(1.0), None, obj
+
+        for c in outputs[obj]:
+            if c.learning_rule_type is not None:
+                raise ClusterException("no learning allowed")
+            elif isinstance(c.post_obj, nengo.connection.LearningRule):
+                raise ClusterException("no error signals allowed")
+            elif c.post_obj in previous:
+                # cycles of passthrough Nodes are possible in Nengo, but
+                # cannot be compiled away
+                raise ClusterException("no loops allowed")
+
+            if c in self.conns_out:
+                # this is an output from the Cluster, so stop iterating
+                yield c.pre_slice, c.transform, c.synapse, c.post
+            else:
+                # this Connection goes to another passthrough Node in this
+                # Cluster, so iterate into that Node and continue
+                for pre_slice, transform, synapse, post in self.generate_from(
+                        c.post_obj, outputs, previous=previous+[obj]):
+
+                    syn = self.merge_synapses(c.synapse, synapse)
+                    trans = self.merge_transforms(c.pre.size_out,
+                                                  c.transform,
+                                                  c.post_slice,
+                                                  c.post_obj,
+                                                  pre_slice,
+                                                  transform,
+                                                  post.size_in)
+
+                    yield c.pre_slice, trans, syn, post
+
+    def generate_conns(self):
+        """Generate the set of direct Connections replacing this Cluster."""
+        outputs = {}
+        for c in self.conns_in | self.conns_mid | self.conns_out:
+            pre = c.pre_obj
+            if pre not in outputs:
+                outputs[pre] = set([c])
+            else:
+                outputs[pre].add(c)
+
+        for c in self.conns_in:
+            assert c.post_obj in self.objs
+            for pre_slice, transform, synapse, post in self.generate_from(
+                    c.post_obj, outputs):
+                syn = self.merge_synapses(c.synapse, synapse)
+                trans = self.merge_transforms(c.size_mid,
+                                              c.transform,
+                                              c.post_slice,
+                                              c.post_obj,
+                                              pre_slice,
+                                              transform,
+                                              post.size_in)
+
+                if not np.allclose(trans, np.zeros_like(trans)):
+                    yield nengo.Connection(
+                        pre=c.pre,
+                        post=post,
+                        function=c.function,
+                        eval_points=c.eval_points,
+                        scale_eval_points=c.scale_eval_points,
+                        synapse=syn,
+                        transform=trans,
+                        add_to_container=False)
+
+
+def find_clusters(net, offchip):
+    """Create the Clusters for a given nengo Network."""
+
+    # find which objects have Probes, as we need to make sure to keep them
+    probed_objs = set(base_obj(p.target) for p in net.all_probes)
+
+    clusters = {}   # mapping from object to its Cluster
+    for c in net.all_connections:
+        base_pre = base_obj(c.pre_obj)
+        base_post = base_obj(c.post_obj)
+
+        pass_pre = is_passthrough(c.pre_obj) and c.pre_obj not in offchip
+        if pass_pre and c.pre_obj not in clusters:
+            # add new objects to their own initial Cluster
+            clusters[c.pre_obj] = Cluster(c.pre_obj)
+            if c.pre_obj in probed_objs:
+                clusters[c.pre_obj].probed_objs.add(c.pre_obj)
+
+        pass_post = is_passthrough(c.post_obj) and c.post_obj not in offchip
+        if pass_post and c.post_obj not in clusters:
+            # add new objects to their own initial Cluster
+            clusters[c.post_obj] = Cluster(c.post_obj)
+            if c.post_obj in probed_objs:
+                clusters[c.post_obj].probed_objs.add(c.post_obj)
+
+        if pass_pre and pass_post:
+            # both pre and post are passthrough, so merge the two
+            # clusters into one cluster
+            cluster = clusters[base_pre]
+            cluster.merge_with(clusters[base_post])
+            for obj in cluster.objs:
+                clusters[obj] = cluster
+            cluster.conns_mid.add(c)
+        elif pass_pre:
+            # pre is passthrough but post is not, so this is an output
+            cluster = clusters[base_pre]
+            cluster.conns_out.add(c)
+        elif pass_post:
+            # pre is not a passthrough but post is, so this is an input
+            cluster = clusters[base_post]
+            cluster.conns_in.add(c)
+    return clusters
+
+
+def convert_passthroughs(network, offchip):
+    """Create a set of Connections that could replace the passthrough Nodes.
+
+    This does not actually modify the Network, but instead returns the
+    set of passthrough Nodes to be removed, the Connections to be removed,
+    and the Connections that should be added to replace the Nodes and
+    Connections.
+
+    The parameter offchip provides a list of objects that should be considered
+    to be offchip. The system will only remove passthrough Nodes that go
+    between two onchip objects.
+    """
+    clusters = find_clusters(network, offchip=offchip)
+
+    removed_passthroughs = set()
+    removed_connections = set()
+    added_connections = set()
+    handled_clusters = set()
+    for cluster in clusters.values():
+        if cluster not in handled_clusters:
+            handled_clusters.add(cluster)
+            onchip_input = False
+            onchip_output = False
+            for c in cluster.conns_in:
+                if base_obj(c.pre_obj) not in offchip:
+                    onchip_input = True
+                    break
+            for c in cluster.conns_out:
+                if base_obj(c.post_obj) not in offchip:
+                    onchip_output = True
+                    break
+            has_input = len(cluster.conns_in) > 0
+            no_output = len(cluster.conns_out) + len(cluster.probed_objs) == 0
+
+            if has_input and ((onchip_input and onchip_output) or no_output):
+                try:
+                    new_conns = list(cluster.generate_conns())
+                except ClusterException:
+                    # this Cluster has an issue, so don't remove it
+                    continue
+
+                removed_passthroughs.update(cluster.objs - cluster.probed_objs)
+                removed_connections.update(cluster.conns_in
+                                           | cluster.conns_mid
+                                           | cluster.conns_out)
+                added_connections.update(new_conns)
+    return removed_passthroughs, removed_connections, added_connections

--- a/nengo_loihi/tests/test_learning.py
+++ b/nengo_loihi/tests/test_learning.py
@@ -29,7 +29,7 @@ def test_pes_comm_channel(allclose, plt, seed, Simulator, n_per_dim, dims):
         p_pre = nengo.Probe(pre, synapse=0.02)
         p_post = nengo.Probe(post, synapse=0.02)
 
-    with Simulator(model, precompute=False) as sim:
+    with Simulator(model) as sim:
         sim.run(5.0)
 
     t = sim.trange()
@@ -81,7 +81,7 @@ def test_multiple_pes(allclose, plt, seed, Simulator):
             nengo.Connection(output[i], conn.learning_rule)
 
         probe = nengo.Probe(output, synapse=0.1)
-    with Simulator(model, precompute=False) as sim:
+    with Simulator(model) as sim:
         sim.run(1.0)
     t = sim.trange()
 

--- a/nengo_loihi/tests/test_learning.py
+++ b/nengo_loihi/tests/test_learning.py
@@ -61,21 +61,18 @@ def test_pes_comm_channel(allclose, plt, seed, Simulator, n_per_dim, dims):
 
 def test_multiple_pes(allclose, plt, seed, Simulator):
     n_errors = 5
-    targets = np.linspace(-1, 1, n_errors)
+    targets = np.linspace(-0.9, 0.9, n_errors)
     with nengo.Network(seed=seed) as model:
         pre_ea = nengo.networks.EnsembleArray(200, n_ensembles=n_errors)
-        errors = nengo.Node(size_in=n_errors)
         output = nengo.Node(size_in=n_errors)
 
         target = nengo.Node(targets)
-        nengo.Connection(target, errors, transform=-1)
-        nengo.Connection(output, errors)
 
         for i in range(n_errors):
             conn = nengo.Connection(
                 pre_ea.ea_ensembles[i],
                 output[i],
-                learning_rule_type=nengo.PES(learning_rate=1e-3),
+                learning_rule_type=nengo.PES(learning_rate=5e-4),
             )
             nengo.Connection(target[i], conn.learning_rule, transform=-1)
             nengo.Connection(output[i], conn.learning_rule)
@@ -90,5 +87,4 @@ def test_multiple_pes(allclose, plt, seed, Simulator):
         plt.axhline(target, **style)
 
     for i, target in enumerate(targets):
-        assert allclose(sim.data[probe][t > 0.8, i], target,
-                        atol=0.05, rtol=0.05)
+        assert allclose(sim.data[probe][t > 0.8, i], target, atol=0.1)

--- a/nengo_loihi/tests/test_passthrough.py
+++ b/nengo_loihi/tests/test_passthrough.py
@@ -1,0 +1,204 @@
+import pytest
+import nengo
+import numpy as np
+
+from nengo_loihi import splitter
+import nengo_loihi
+
+
+def test_passthrough_placement():
+    with nengo.Network() as model:
+        stim = nengo.Node(0)
+        a = nengo.Node(None, size_in=1)   # should be off-chip
+        b = nengo.Ensemble(10, 1)
+        c = nengo.Node(None, size_in=1)   # should be removed
+        d = nengo.Node(None, size_in=1)   # should be removed
+        e = nengo.Node(None, size_in=1)   # should be removed
+        f = nengo.Ensemble(10, 1)
+        g = nengo.Node(None, size_in=1)   # should be off-chip
+        nengo.Connection(stim, a)
+        nengo.Connection(a, b)
+        nengo.Connection(b, c)
+        nengo.Connection(c, d)
+        nengo.Connection(d, e)
+        nengo.Connection(e, f)
+        nengo.Connection(f, g)
+        nengo.Probe(g)
+
+    nengo_loihi.add_params(model)
+    networks = splitter.split(model,
+                              precompute=False,
+                              remove_passthrough=True,
+                              max_rate=1000,
+                              inter_tau=0.005)
+    chip = networks.chip
+    host = networks.host
+
+    assert a in host.nodes
+    assert a not in chip.nodes
+    assert c not in host.nodes
+    assert c not in chip.nodes
+    assert d not in host.nodes
+    assert d not in chip.nodes
+    assert e not in host.nodes
+    assert e not in chip.nodes
+    assert g in host.nodes
+    assert g not in chip.nodes
+
+
+@pytest.mark.parametrize("d1", [1, 3])
+@pytest.mark.parametrize("d2", [1, 3])
+@pytest.mark.parametrize("d3", [1, 3])
+def test_transform_merging(d1, d2, d3):
+    with nengo.Network() as model:
+        a = nengo.Ensemble(10, d1)
+        b = nengo.Node(None, size_in=d2)
+        c = nengo.Ensemble(10, d3)
+
+        t1 = np.random.uniform(-1, 1, (d2, d1))
+        t2 = np.random.uniform(-1, 1, (d3, d2))
+
+        nengo.Connection(a, b, transform=t1)
+        nengo.Connection(b, c, transform=t2)
+
+    nengo_loihi.add_params(model)
+    networks = splitter.split(model,
+                              precompute=False,
+                              remove_passthrough=True,
+                              max_rate=1000,
+                              inter_tau=0.005)
+    chip = networks.chip
+
+    assert len(chip.connections) == 1
+    conn = chip.connections[0]
+    assert np.allclose(conn.transform, np.dot(t2, t1))
+
+
+@pytest.mark.parametrize("n_ensembles", [1, 3])
+@pytest.mark.parametrize("ens_dimensions", [1, 3])
+def test_identity_array(n_ensembles, ens_dimensions):
+    with nengo.Network() as model:
+        a = nengo.networks.EnsembleArray(10, n_ensembles, ens_dimensions)
+        b = nengo.networks.EnsembleArray(10, n_ensembles, ens_dimensions)
+        nengo.Connection(a.output, b.input)
+
+    nengo_loihi.add_params(model)
+    networks = splitter.split(model,
+                              precompute=False,
+                              remove_passthrough=True,
+                              max_rate=1000,
+                              inter_tau=0.005)
+
+    # ignore the a.input -> a.ensemble connections
+    connections = [c for c in networks.chip.connections
+                   if not (isinstance(c.pre_obj, splitter.ChipReceiveNode)
+                           and c.post_obj in a.ensembles)]
+
+    assert len(connections) == n_ensembles
+    pre = set()
+    post = set()
+    for c in connections:
+        assert c.pre in a.all_ensembles or c.pre_obj is a.input
+        assert c.post in b.all_ensembles
+        assert np.allclose(c.transform, np.eye(ens_dimensions))
+        pre.add(c.pre)
+        post.add(c.post)
+    assert len(pre) == n_ensembles
+    assert len(post) == n_ensembles
+
+
+@pytest.mark.parametrize("n_ensembles", [1, 3])
+@pytest.mark.parametrize("ens_dimensions", [1, 3])
+def test_full_array(n_ensembles, ens_dimensions):
+    with nengo.Network() as model:
+        a = nengo.networks.EnsembleArray(10, n_ensembles, ens_dimensions)
+        b = nengo.networks.EnsembleArray(10, n_ensembles, ens_dimensions)
+        D = n_ensembles * ens_dimensions
+        nengo.Connection(a.output, b.input, transform=np.ones((D, D)))
+
+    nengo_loihi.add_params(model)
+    networks = splitter.split(model,
+                              precompute=False,
+                              remove_passthrough=True,
+                              max_rate=1000,
+                              inter_tau=0.005)
+
+    # ignore the a.input -> a.ensemble connections
+    connections = [c for c in networks.chip.connections
+                   if not (isinstance(c.pre_obj, splitter.ChipReceiveNode)
+                           and c.post_obj in a.ensembles)]
+
+    assert len(connections) == n_ensembles ** 2
+    pairs = set()
+    for c in connections:
+        assert c.pre in a.all_ensembles
+        assert c.post in b.all_ensembles
+        assert np.allclose(c.transform, np.ones((ens_dimensions,
+                                                 ens_dimensions)))
+        pairs.add((c.pre, c.post))
+    assert len(pairs) == n_ensembles ** 2
+
+
+def test_synapse_merging(Simulator, seed):
+    with nengo.Network(seed=seed) as model:
+        a = nengo.networks.EnsembleArray(10, n_ensembles=2)
+        b = nengo.Node(None, size_in=2)
+        c = nengo.networks.EnsembleArray(10, n_ensembles=2)
+        nengo.Connection(a.output[0], b[0], synapse=None)
+        nengo.Connection(a.output[1], b[1], synapse=0.1)
+        nengo.Connection(b[0], c.input[0], synapse=None)
+        nengo.Connection(b[0], c.input[1], synapse=0.2)
+        nengo.Connection(b[1], c.input[0], synapse=None)
+        nengo.Connection(b[1], c.input[1], synapse=0.2)
+
+    nengo_loihi.add_params(model)
+    networks = splitter.split(model,
+                              precompute=False,
+                              remove_passthrough=True,
+                              max_rate=1000,
+                              inter_tau=0.005)
+
+    # ignore the a.input -> a.ensemble connections
+    connections = [c for c in networks.chip.connections
+                   if not (isinstance(c.pre_obj, splitter.ChipReceiveNode)
+                           and c.post_obj in a.ensembles)]
+
+    assert len(connections) == 4
+    desired_filters = {
+        ('0', '0'): None,
+        ('0', '1'): 0.2,
+        ('1', '0'): 0.1,
+        ('1', '1'): 0.3,
+    }
+    for c in connections:
+        if desired_filters[(c.pre.label, c.post.label)] is None:
+            assert c.synapse is None
+        else:
+            assert isinstance(c.synapse, nengo.Lowpass)
+            assert np.allclose(
+                c.synapse.tau, desired_filters[(c.pre.label, c.post.label)])
+
+    # check that model builds/runs correctly
+    with Simulator(model, remove_passthrough=True) as sim:
+        sim.step()
+
+
+def test_no_input(Simulator, seed, allclose):
+    # check that remove_passthrough does not change the behaviour of the
+    # network
+
+    with nengo.Network(seed=seed) as net:
+        a = nengo.Node(size_in=1)
+        b = nengo.Ensemble(200, 1)
+        c = nengo.Node(size_in=1)
+        nengo.Connection(a, b, synapse=None)
+        nengo.Connection(b, c, synapse=None)
+        p = nengo.Probe(c)
+
+    with Simulator(net, remove_passthrough=False) as sim_base:
+        sim_base.run_steps(100)
+
+    with Simulator(net, remove_passthrough=True) as sim_remove:
+        sim_remove.run_steps(100)
+
+    assert allclose(sim_base.data[p], sim_remove.data[p])

--- a/nengo_loihi/tests/test_simulator.py
+++ b/nengo_loihi/tests/test_simulator.py
@@ -77,7 +77,7 @@ def test_dt(dt, pre_on_chip, Simulator, seed, plt, allclose):
         nengo.Connection(pre, post, function=function,
                          solver=nengo.solvers.LstsqL2(weights=True))
 
-    with Simulator(model, precompute=False) as sim:
+    with Simulator(model) as sim:
         sim.run(1.0)
 
     x = sim.data[stim_p]

--- a/nengo_loihi/tests/test_simulator.py
+++ b/nengo_loihi/tests/test_simulator.py
@@ -23,7 +23,7 @@ def test_cx_model_validate_notempty(Simulator):
 def test_probedict_fallbacks(precompute, Simulator):
     with nengo.Network() as net:
         nengo_loihi.add_params(net)
-        node_a = nengo.Node(size_in=1)
+        node_a = nengo.Node(0)
         with nengo.Network():
             ens_b = nengo.Ensemble(10, 1)
             conn_ab = nengo.Connection(node_a, ens_b)
@@ -187,6 +187,7 @@ def test_all_run_steps(Simulator):
     with net:
         out = nengo.Node(size_in=1)
         nengo.Connection(post, out)
+        nengo.Probe(out)  # probe to prevent `out` from being optimized away
 
     # 3a. precompute=False, host (same as 2a)
     with Simulator(net) as sim:

--- a/nengo_loihi/tests/test_snips.py
+++ b/nengo_loihi/tests/test_snips.py
@@ -10,6 +10,6 @@ def test_snip_input_count(Simulator, seed, plt):
         for i in range(30):
             stim = nengo.Node(0.5)
             nengo.Connection(stim, a, synapse=None)
-    with Simulator(model, precompute=False) as sim:
+    with Simulator(model) as sim:
         with pytest.warns(UserWarning, match="Too many spikes"):
             sim.run(0.01)

--- a/nengo_loihi/tests/test_splitter.py
+++ b/nengo_loihi/tests/test_splitter.py
@@ -123,7 +123,7 @@ def test_place_inter_network_connection():
     networks.move(onchip, "chip")
     networks.move(offchip, "host")
 
-    place_internetwork_connections(networks)
+    place_internetwork_connections(networks, networks.original.all_connections)
     assert onoff not in networks
     assert offon not in networks
     assert networks.location(onon) == "chip"
@@ -301,7 +301,7 @@ def test_split_host_to_learning_rule():
     networks.needs_sender[ens_conn.learning_rule] = "ens_pes_target"
     networks.needs_sender[neurons_conn.learning_rule] = "neurons_pes_target"
 
-    split_host_to_learning_rules(networks)
+    split_host_to_learning_rules(networks, networks.original.all_connections)
     assert on2on_ens not in networks
     assert on2on_neurons not in networks
     assert sorted([type(obj).__name__ for obj in networks.adds]) == [


### PR DESCRIPTION
This PR gets rid of the passthrough Nodes between on-chip Ensembles.  They are replaced by Connections that do the same thing as those Nodes.  Without this PR, all passthrough Nodes are implemented on the host, which means a lot more communication between the host and the chip.  Also, removing these passthrough Nodes allows us to use precompute=True for networks with these intermediate passthrough Nodes.

The basic functionality works, but the main thing I still need to do here is write a *lot* of tests.  In particular, this is a completely different method for removing passthrough nodes than I've ever implemented before.  This method is a lot cleaner, I think, and I think it's much less prone to the weird edge-case problems that I've run into with previous implementations, but given that I'm used to seeing lots of weird edge cases, I want to make sure there's lots of tests to make sure it handles different network configurations and all slicing possibilities and whatnot.

I would also like to do some exploration of what drawbacks moving these passthrough nodes on-chip has.  In particular, I think there are cases where this greatly increases the number of connection weights that must be stored.  I'm not quite sure what these cases are, but we'll see what things come up for the benchmarks.

 - [x] finish unit tests
 - [x] add option to turn this on or off