### PR TITLE
Reset spike probes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,10 @@ Release history
 - Models can now use the ``nengo.SpikingRectifiedLinear`` neuron model
   on both the emulator and hardware backends.
 
+**Fixed**
+
+- Manually reset spike probes when Simulator is initialized.
+
 0.2.0 (August 27, 2018)
 =======================
 

--- a/nengo_loihi/conftest.py
+++ b/nengo_loihi/conftest.py
@@ -36,6 +36,18 @@ def pytest_terminal_summary(terminalreporter):
             np.mean(all_rmses), np.std(all_rmses)))
 
 
+def pytest_addoption(parser):
+    parser.addoption("--no-hang", action="store_true", default=False,
+                     help="Skip tests that hang")
+
+
+def pytest_runtest_setup(item):
+    if (getattr(item.obj, "hang", False) and
+            item.config.getvalue("--target") == "loihi" and
+            item.config.getvalue("--no-hang")):
+        pytest.xfail("This test causes Loihi to hang indefinitely")
+
+
 @pytest.fixture(scope="session")
 def Simulator(request):
     """Simulator class to be used in tests"""

--- a/nengo_loihi/loihi_interface.py
+++ b/nengo_loihi/loihi_interface.py
@@ -16,12 +16,14 @@ try:
     from nxsdk.arch.n2a.compiler.tracecfggen.tracecfggen import TraceCfgGen
     from nxsdk.arch.n2a.graph.graph import N2Board
     from nxsdk.arch.n2a.graph.inputgen import BasicSpikeGenerator
+    from nxsdk.arch.n2a.graph.probes import N2SpikeProbe
 except ImportError:
     exc_info = sys.exc_info()
 
     def no_nxsdk(*args, **kwargs):
         raise exc_info[1]
-    nxsdk = N2Board = BasicSpikeGenerator = TraceCfgGen = no_nxsdk
+    nxsdk = N2Board = BasicSpikeGenerator = TraceCfgGen = N2SpikeProbe = (
+        no_nxsdk)
 
 from nengo_loihi.allocators import one_to_one_allocator
 from nengo_loihi.loihi_api import (
@@ -396,6 +398,10 @@ class LoihiSimulator(object):
 
         if seed is not None:
             warnings.warn("Seed will be ignored when running on Loihi")
+
+        # probeDict is a class attribute, so might contain things left over
+        # from previous simulators
+        N2SpikeProbe.probeDict.clear()
 
         self.build(cx_model, seed=seed)
 

--- a/nengo_loihi/tests/test_learning.py
+++ b/nengo_loihi/tests/test_learning.py
@@ -3,8 +3,7 @@ import numpy as np
 import pytest
 
 
-@pytest.mark.xfail(pytest.config.getoption("--target") == "loihi",
-                   reason="Hangs indefinitely on Loihi")
+@pytest.mark.hang
 @pytest.mark.parametrize('N', [100, 300])
 def test_pes_comm_channel(allclose, Simulator, seed, plt, N):
     input_fn = lambda t: np.sin(t*2*np.pi)

--- a/nengo_loihi/tests/test_probe.py
+++ b/nengo_loihi/tests/test_probe.py
@@ -16,8 +16,7 @@ def test_spike_units(Simulator, seed):
     assert len(values) == 2
 
 
-@pytest.mark.xfail(pytest.config.getoption("--target") == "loihi",
-                   reason="Hangs indefinitely on Loihi")
+@pytest.mark.hang
 @pytest.mark.parametrize('dim', [1, 3])
 def test_voltage_decode(allclose, Simulator, seed, plt, dim):
     with nengo.Network(seed=seed) as model:

--- a/nengo_loihi/tests/test_probe.py
+++ b/nengo_loihi/tests/test_probe.py
@@ -38,3 +38,13 @@ def test_voltage_decode(allclose, Simulator, seed, plt, dim):
     plt.plot(sim.trange(), sim.data[p_stim])
 
     assert allclose(sim.data[p_stim], sim.data[p_a], atol=0.3)
+
+
+def test_repeated_probes(Simulator):
+    with nengo.Network() as net:
+        ens = nengo.Ensemble(1024, 1)
+        nengo.Probe(ens.neurons)
+
+    for _ in range(5):
+        with Simulator(net, precompute=True) as sim:
+            sim.run(0.1)


### PR DESCRIPTION
This fixes the spike counter issue pointed out in #5.  Note that there are still some issues with random hanging in the test suite, but I think those are caused by being assigned to particular boards in the INRC cloud, rather than global state (rerunning the tests in the same way but landing on a different device fixes the problem, as opposed to earlier where the tests would deterministically fail at the same spot in the test suite).

I also added a `--no-hang` option to pytest, which will automatically skip tests that are known to hang on Loihi  (`pytest nengo_loihi --target loihi --no-hang`).  That way you can run the whole test suite at once, rather than having to stop and restart. 