### PR TITLE
Limit intercept values

### DIFF
--- a/nengo_loihi/tests/test_builder.py
+++ b/nengo_loihi/tests/test_builder.py
@@ -1,0 +1,20 @@
+import nengo
+import numpy as np
+import pytest
+
+from nengo_loihi.builder import get_gain_bias, Model
+
+
+@pytest.mark.parametrize("passed_intercepts", [
+    nengo.dists.Uniform(-1, 1), np.linspace(-1, 1, 10000),
+])
+def test_intercept_limit(passed_intercepts, rng):
+    model = Model()
+    assert model.intercept_limit == 0.95
+
+    ens = nengo.Ensemble(10000, 1,
+                         intercepts=passed_intercepts,
+                         add_to_container=False)
+    with pytest.warns(UserWarning):
+        _, _, _, intercepts = get_gain_bias(ens, rng, model.intercept_limit)
+    assert np.all(intercepts <= model.intercept_limit)


### PR DESCRIPTION
As part of debugging #59 , @hunse noted that neurons with intercepts near 1 give very high gains, which makes those neurons vastly dominate the dynamic range of the fixed-point representation for the connection weights.  To address this, this PR puts an upper bound on the intercepts.  Any intercept above this limit is reduced to that limit.  In addition, to avoid unnatural clustering of intercepts at that bound, if the intercept distribution is given as a `nengo.dists.Uniform`, and the high value is above the limit, then it is reduced to the limit before sampling.

To illustrate the effects of this fix, here's a simple test model:
```python
model = nengo.Network()
with model:
    stim = nengo.Node(lambda t: np.sin(t*2*np.pi))
    ens = nengo.Ensemble(n_neurons=2000, dimensions=1)
    output = nengo.Node(None, size_in=1)
    nengo.Connection(stim, ens, synapse=None)
    def function(x):
        return x**2
    nengo.Connection(ens, output, function=function, synapse=None)
    p_stim = nengo.Probe(stim)
    p_output = nengo.Probe(output)

sim = nengo_loihi.Simulator(model, intercept_limit=1.0)
sim.run(1.0)

actual = sim.data[p_output]
ideal = function(sim.data[p_stim])
syn = nengo.synapses.Lowpass(0.1)
import pylab
pylab.plot(sim.trange(), syn.filt(actual))
pylab.plot(sim.trange(), syn.filt(ideal))
```

With `intercept_limit=1.0` (which is the same as without this PR), we get this:
![image](https://user-images.githubusercontent.com/2380772/45665524-4ac99b80-badf-11e8-9c06-9f5edae4ae73.png)

With `intercept_limit=0.95`, we get this:
![image](https://user-images.githubusercontent.com/2380772/45665549-616ff280-badf-11e8-8334-de5b6078e8fe.png)

That's a pretty startling improvement.  :)

To find a good default `intercept_limit`, I ran this a bunch of times and varied the number of neurons:
![image](https://user-images.githubusercontent.com/2380772/45665581-8a908300-badf-11e8-8fd0-fab03aaab415.png)

And I varied the order of the polynomial ($x^1$, $x^2$, $x^3$)
![image](https://user-images.githubusercontent.com/2380772/45665596-98de9f00-badf-11e8-81e0-c0e3b42c8dc8.png)

So, given this, I've set the default to 0.95.
