### PR TITLE
Seeds match Nengo

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,13 @@ Release history
   this transition. The MNIST convnet example demonstrates the new syntax.
   (`#142 <https://github.com/nengo/nengo-loihi/pull/142>`__)
 
+**Fixed**
+
+- Objects in nengo-loihi will have the same random seeds as in
+  nengo core (and therefore any randomly generated parameters, such as
+  ensemble encoders, will be generated in the same way).
+  (`#70 <https://github.com/nengo/nengo-loihi/pull/70>`_)
+
 0.5.0 (February 12, 2019)
 =========================
 

--- a/nengo_loihi/compat.py
+++ b/nengo_loihi/compat.py
@@ -4,6 +4,7 @@ import nengo
 import numpy as np
 
 if LooseVersion(nengo.__version__) > LooseVersion('2.8.0'):
+    from nengo.builder.network import seed_network
     import nengo.transforms as nengo_transforms
 
     def conn_solver(solver, activities, targets, rng):
@@ -36,3 +37,8 @@ else:
     def sample_transform(conn, rng=np.random):
         return _get_samples(conn.transform, conn.size_out,
                             d=conn.size_mid, rng=rng)
+
+    def seed_network(*args, **kwargs):
+        # nengo <= 2.8.0 will overwrite any seeds set on the model, so no
+        # point doing anything in this function
+        pass


### PR DESCRIPTION
This ensures that all object seeds are the same as for the corresponding reference Nengo model. It also ensures that seeds for all objects are set and the same whether precompute is True or False.

Depends on nengo/nengo#1476.

Computing the seeds before building, as I'm doing here, is something we've talked about adding to Nengo for a while. I would be open/happy to take the functionality here and move it to Nengo instead, since I think that is ultimately where we want it.