### PR TITLE
Support Distributions on Connection transforms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,7 @@ Release history
 
 - Models can now use the ``nengo.SpikingRectifiedLinear`` neuron model
   on both the emulator and hardware backends.
+- Added support for Distributions on Connection transforms.
 
 **Fixed**
 


### PR DESCRIPTION
Previously passing a `Distribution` for a transform gave errors on chip->host and host->chip connections, this fixes that and adds a test.

Note that the way the seeding is done isn't strictly correct, because we don't have access to the connection seeds (since this is all occurring before the seeding happens in the builder).  But it has the same functional behaviour (deterministic output if a seed is set on the Network or Connection).

This fixes #65 