### PR TITLE
Fix number of compartments

### DIFF
--- a/nengo_loihi/loihi_interface.py
+++ b/nengo_loihi/loihi_interface.py
@@ -213,7 +213,7 @@ def build_core(n2core, core):  # noqa: C901
 
         for group, cx_idxs, ax_range in core.iterate_groups():
             build_group(n2core, core, group, cx_idxs, ax_range)
-            n_cx = max(max(cx_idxs), n_cx)
+            n_cx = max(max(cx_idxs) + 1, n_cx)
 
     for inp, cx_idxs in core.iterate_inputs():
         build_input(n2core, core, inp, cx_idxs)


### PR DESCRIPTION
Two little bugs that I found when finding the 300 neuron hanging bug.

The first is just that we're counting the number of compartments wrong in loihi_interface. We need to add 1 to the last index to get the number.

The second I'm less sure about, but it looked wrong. It's that when we're sending spikes for precompute=True, we gather up all the spikes, and then send them all to the spike generator for the last input. As it happens, this isn't a problem right now, since all inputs share the same spike generator. But if we did change things so that they had their own generators, I think we'd want it as I have it here. I'd like @tcstewar to confirm this, though, since he wrote that code I think.