### PR TITLE
Add strict mode to emulator

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,11 @@
 import matplotlib as mpl
 
+from nengo_loihi.loihi_cx import CxSimulator
+
 
 def pytest_configure(config):
     mpl.use("Agg")
+    CxSimulator.strict = True
 
 
 def pytest_addoption(parser):

--- a/nengo_loihi/loihi_cx.py
+++ b/nengo_loihi/loihi_cx.py
@@ -695,6 +695,7 @@ class CxSimulator(object):
             self.error("Overflow in U (max was %d)" % u2.max())
         if np.any(u2 < U_MIN):
             self.error("Underflow in U (min was %d)" % u2.min())
+        u2 = np.clip(u2, a_min=U_MIN, a_max=U_MAX, out=u2)
 
         # self.V[:] = self.decayV_fn(v, self.decayV, a=12) + u2
         self.v[:] = self.decayV_fn(self.v, u2)
@@ -702,6 +703,7 @@ class CxSimulator(object):
             self.error("Overflow in V (max was %d)" % self.v.max())
         if np.any(self.v < V_MIN):
             self.error("Underflow in V (min was %d)" % self.v.min())
+        self.v = np.clip(self.v, a_min=V_MIN, a_max=V_MAX, out=self.v)
 
         np.clip(self.v, self.vmin, self.vmax, out=self.v)
         self.v[self.w > 0] = 0

--- a/nengo_loihi/tests/test_loihi_cx.py
+++ b/nengo_loihi/tests/test_loihi_cx.py
@@ -1,6 +1,8 @@
+from nengo.exceptions import SimulationError
 import numpy as np
+import pytest
 
-from nengo_loihi.loihi_cx import CxGroup, CxProbe, CxModel
+from nengo_loihi.loihi_cx import CxGroup, CxModel, CxProbe, CxSimulator
 
 
 def test_simulator_noise(request, plt, seed):
@@ -35,3 +37,18 @@ def test_simulator_noise(request, plt, seed):
 
     plt.plot(y)
     plt.yticks(())
+
+
+def test_strict_mode():
+    # Tests should be run in strict mode
+    assert CxSimulator.strict
+
+    with pytest.raises(SimulationError):
+        CxSimulator.error("Error in emulator")
+    CxSimulator.strict = False
+    with pytest.warns(UserWarning):
+        CxSimulator.error("Error in emulator")
+
+    # Strict mode is a global setting so we set it back to True
+    # for subsequent test runs.
+    CxSimulator.strict = True


### PR DESCRIPTION
In strict mode, issues (like U/V overflows) will raise a SimulatorException. When not in strict mode, these issues will be raised as a warning. The default is not to be in strict mode, as issues do happen on occasion, but we run the test suite in strict mode to find issues early.

Addresses #88.