### PR TITLE
Compatibility with NxSDK 0.7 release

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,10 +12,7 @@ that has ``pip``.
 .. code-block:: bash
 
    git clone https://github.com/nengo/nengo-loihi.git
-   cd nengo-loihi
-   pip install -e .
-
-Note that the ``.`` at the end of ``pip`` command is required.
+   pip install -e nengo-loihi
 
 ``pip`` will do its best to install
 Nengo Loihi's requirements.
@@ -25,13 +22,8 @@ Follow `our NumPy install instructions
 <https://www.nengo.ai/nengo/getting_started.html#installing-numpy>`_,
 then try again.
 
-INRC
-====
-
-.. note:: These instructions will only work on the INRC superhost.
-          If you have set up your own superhost
-          as per the :doc:`setup/superhost` page,
-          then see the next section.
+INRC/Superhost
+==============
 
 These steps will take you through
 setting up a Python environment
@@ -39,129 +31,9 @@ for running Nengo Loihi,
 as well as for running models
 using the NxSDK directly.
 
-1. Create a new virtual environment.
-   Note, you *must* use the ``python_nx`` executable
-   provided by Intel when working with NxSDK.
-
-   .. code-block:: bash
-
-      mkvirtualenv loihi --python=python_nx
-
-2. Activate your new environment.
-
-   .. code-block:: bash
-
-      workon loihi
-
-   Sometimes the environment can have issues when first created.
-   Before continuing, run ``which pip`` and ensure that the path
-   to ``pip`` is in your virtual environment.
-
-   .. note:: You will need to run ``workon loihi`` every time
-             you log onto the INRC superhost.
-
-3. Clone the NxSDK git repository.
-
-   The location of ``NxSDK.git`` may have changed.
-   Refer to Intel's documentation to be sure.
-
-   .. code-block:: bash
-
-      git clone /nfs/ncl/git/NxSDK.git
-
-4. Check out a release tag.
-
-   As of August 2018, the most recent release is 0.5.5,
-   which is compatible with Nengo Loihi.
-
-   .. code-block:: bash
-
-      cd NxSDK
-      git checkout 0.5.5
-
-5. Add a ``setup.py`` file to NxSDK.
-
-   As of August 2018, NxSDK does not have a ``setup.py`` file,
-   which is necessary for installing NxSDK in a virtual environment.
-
-   To add it, execute the following command.
-
-   .. code-block:: bash
-
-      cat > setup.py << 'EOL'
-      import sys
-      from setuptools import setup
-
-      if not ((3, 5, 2) <= sys.version_info[:3] < (3, 6, 0)):
-          pyversion = ".".join("%d" % v for v in sys.version_info[:3])
-          raise EnvironmentError(
-              "NxSDK has .pyc files that only work on Python 3.5.2 through 3.5.5. "
-              "You are running version %s." % pyversion)
-
-      setup(
-          name='nxsdk',
-          version='0.5.5',
-          install_requires=[
-              "numpy",
-              "pandas",
-              "matplotlib",
-              "teamcity-messages",
-              "rpyc<4",
-          ]
-      )
-      EOL
-
-   Or you may paste the text above (excluding the first and last lines)
-   into a text editor and save as ``setup.py`` in the NxSDK folder.
-
-6. Install NxSDK.
-
-   .. code-block:: bash
-
-      pip install -e .
-
-7. Install Nengo Loihi.
-
-   .. code-block:: bash
-
-      cd ..
-      git clone https://github.com/nengo/nengo-loihi.git
-      cd nengo-loihi
-      pip install -e .
-
-   ``pip`` will install other requirements like Nengo automatically.
-
-8. Test that both packages installed correctly.
-
-   Start Python by running the ``python`` command.
-   If everything is installed correctly, you should
-   be able to import ``nxsdk`` and ``nengo_loihi``.
-
-   .. code-block:: pycon
-
-      Python 3.5.5 (default, Mar 15 2018, 11:03:27)
-      [GCC 5.4.0 20160609] on linux
-      Type "help", "copyright", "credits" or "license" for more information.
-      >>> import nxsdk
-      >>> import nengo_loihi
-
-
-Superhost
-=========
-
-.. note:: These instructions assume that you are working
-          on a superhost that has already been configured
-          as per the :doc:`setup/superhost` page.
-          Those instructions only need to be run once
-          for each superhost,
-          while these instructions need to be run
-          by every user that is using the superhost.
-
-If you are installing Nengo Loihi on a superhost,
-there are several additional constraints
-due to needing to install NxSDK.
-The easiest way to satisfy
-all of those constraints is to use
+Note, you *must* use Python 3.5.2 and NumPy 1.14.3
+when working with NxSDK.
+The easiest way to satisfy those constraints is to use
 `Miniconda <https://conda.io/docs/user-guide/install/index.html>`_
 to set up an isolated environment
 for running Loihi models.
@@ -202,11 +74,11 @@ for running Loihi models.
       Follow the prompts to set up Miniconda as desired.
 
 2. Create a new ``conda`` environment.
-   Note, you *must* use Python 3.5.5 when working with NxSDK.
+   Note, you *must* use Python 3.5.2 when working with NxSDK.
 
    .. code-block:: bash
 
-      conda create --name loihi python=3.5.5
+      conda create --name loihi python=3.5.2
 
 3. Activate your new environment.
 
@@ -221,99 +93,60 @@ for running Loihi models.
    .. note:: You will need to run ``source activate loihi`` every time
              you log onto the superhost.
 
-4. Install NumPy with conda.
+4. Install NumPy and Cython with conda.
+   Note, you *must* use NumPy 1.14.3 when working with NxSDK.
 
    .. code-block:: bash
 
-      conda install numpy
+      conda install numpy=1.14.3 cython
 
    The NumPy provided by conda is usually faster
    than those installed by other means.
 
-5. Clone the NxSDK git repository.
+5. Copy the latest NxSDK release to your current directory.
 
-   As of August 2018, NxSDK is not publicly available,
-   but is available through the INRC.
-   Refer to Intel's documentation for the details
-   on how to clone the repository,
-   but the command will look something like
+   .. note:: The location of NxSDK may have changed.
+             Refer to Intel's documentation to be sure.
+             The most recent release and NxSDK location
+             are current as of September 2018.
 
-   .. code-block:: bash
-
-      git clone ssh://inrc/nfs/ncl/git/NxSDK.git
-
-6. Check out a release tag.
-
-   As of August 2018, the most recent release is 0.5.5,
-   which is compatible with Nengo Loihi.
+   If you are logged into INRC:
 
    .. code-block:: bash
 
-      cd NxSDK
-      git checkout 0.5.5
+      cp /nfs/ncl/releases/0.7/nxsdk-0.7.tar.gz .
 
-7. Add a ``setup.py`` file to NxSDK.
-
-   As of August 2018, NxSDK does not have a ``setup.py`` file,
-   which is necessary for installing NxSDK in a conda environment.
-
-   To add it, execute the following command.
+   If you are setting up a non-INRC superhost:
 
    .. code-block:: bash
 
-      cat > setup.py << 'EOL'
-      import sys
-      from setuptools import setup
+      scp <inrc-host>:/nfs/ncl/releases/0.7/nxsdk-0.7.tar.gz .
 
-      if not ((3, 5, 2) <= sys.version_info[:3] < (3, 6, 0)):
-          pyversion = ".".join("%d" % v for v in sys.version_info[:3])
-          raise EnvironmentError(
-              "NxSDK has .pyc files that only work on Python 3.5.2 through 3.5.5. "
-              "You are running version %s." % pyversion)
-
-      setup(
-          name='nxsdk',
-          version='0.5.5',
-          install_requires=[
-              "numpy",
-              "pandas",
-              "matplotlib",
-              "teamcity-messages",
-              "rpyc<4",
-          ]
-      )
-      EOL
-
-   Or you may paste the text above (excluding the first and last lines)
-   into a text editor and save as ``setup.py`` in the NxSDK folder.
-
-8. Install NxSDK.
+6. Install NxSDK.
 
    .. code-block:: bash
 
-      pip install -e .
+      pip install nxsdk-0.7.tar.gz
 
-9. Install Nengo Loihi.
+7. Install Nengo Loihi.
 
    .. code-block:: bash
 
-      cd ..
       git clone https://github.com/nengo/nengo-loihi.git
-      cd nengo-loihi
-      pip install -e .
+      pip install -e nengo-loihi
 
    ``pip`` will install other requirements like Nengo automatically.
 
-10. Test that both packages installed correctly.
+8. Test that both packages installed correctly.
 
-    Start Python by running the ``python`` command.
-    If everything is installed correctly, you should
-    be able to import ``nxsdk`` and ``nengo_loihi``.
+   Start Python by running the ``python`` command.
+   If everything is installed correctly, you should
+   be able to import ``nxsdk`` and ``nengo_loihi``.
 
-    .. code-block:: pycon
+   .. code-block:: pycon
 
-       Python 3.5.5 |Anaconda, Inc.| (default, May 13 2018, 21:12:35)
-       [GCC 7.2.0] on linux
-       Type "help", "copyright", "credits" or "license" for more information.
-       >>> import nxsdk
-       >>> import nengo_loihi
+      Python 3.5.2 |Anaconda, Inc.| (default, May 13 2018, 21:12:35)
+      [GCC 7.2.0] on linux
+      Type "help", "copyright", "credits" or "license" for more information.
+      >>> import nxsdk
+      >>> import nengo_loihi

--- a/nengo_loihi/loihi_interface.py
+++ b/nengo_loihi/loihi_interface.py
@@ -451,10 +451,10 @@ class LoihiSimulator(object):
             for k, n2core in enumerate(n2chip.n2Cores):
                 print("  Core %d, id=%d" % (k, n2core.id))
 
-    def run_steps(self, steps, async=False):
+    def run_steps(self, steps, blocking=True):
         # NOTE: we need to call connect() after snips are created
         self.connect()
-        self.n2board.run(steps, aSync=async)
+        self.n2board.run(steps, aSync=not blocking)
 
     def wait_for_completion(self):
         self.n2board.finishRun()

--- a/nengo_loihi/loihi_interface.py
+++ b/nengo_loihi/loihi_interface.py
@@ -1,5 +1,6 @@
 from __future__ import division
 
+from distutils.version import LooseVersion
 import logging
 import os
 import sys
@@ -17,6 +18,7 @@ try:
     from nxsdk.arch.n2a.graph.graph import N2Board
     from nxsdk.arch.n2a.graph.inputgen import BasicSpikeGenerator
     from nxsdk.arch.n2a.graph.probes import N2SpikeProbe
+
 except ImportError:
     exc_info = sys.exc_info()
 
@@ -384,6 +386,8 @@ class LoihiSimulator(object):
     """
 
     def __init__(self, cx_model, seed=None, snip_max_spikes_per_step=50):
+        self.check_nxsdk_version()
+
         self.n2board = None
         self._probe_filters = {}
         self._probe_filter_pos = {}
@@ -410,6 +414,24 @@ class LoihiSimulator(object):
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.close()
+
+    @staticmethod
+    def check_nxsdk_version():
+        # raise exception if nxsdk not installed
+        if callable(nxsdk):
+            nxsdk()
+
+        # if installed, check version
+        version = LooseVersion(getattr(nxsdk, "__version__", "0.0.0"))
+        minimum = LooseVersion("0.7.0")
+        max_tested = LooseVersion("0.7.0")
+        if version < minimum:
+            raise ImportError("nengo-loihi requires nxsdk>=%s, found %s"
+                              % (minimum, version))
+        elif version > max_tested:
+            warnings.warn("nengo-loihi has not been tested with your nxsdk "
+                          "version (%s); latest fully supported version is "
+                          "%s" % (version, max_tested))
 
     def build(self, cx_model, seed=None):
         cx_model.validate()

--- a/nengo_loihi/loihi_interface.py
+++ b/nengo_loihi/loihi_interface.py
@@ -432,7 +432,7 @@ class LoihiSimulator(object):
     def run_steps(self, steps, async=False):
         # NOTE: we need to call connect() after snips are created
         self.connect()
-        self.n2board.run(steps, async=async)
+        self.n2board.run(steps, aSync=async)
 
     def wait_for_completion(self):
         self.n2board.finishRun()

--- a/nengo_loihi/simulator.py
+++ b/nengo_loihi/simulator.py
@@ -414,12 +414,12 @@ class Simulator(object):
             if self.precompute:
                 self.host_pre_sim.run_steps(steps)
                 self.handle_host2chip_communications()
-                self.loihi.run_steps(steps)
+                self.loihi.run_steps(steps, blocking=True)
                 self.handle_chip2host_communications()
                 self.host_post_sim.run_steps(steps)
             elif self.host_sim is not None:
                 self.loihi.create_io_snip()
-                self.loihi.run_steps(steps, async=True)
+                self.loihi.run_steps(steps, blocking=False)
                 for i in range(steps):
                     self.host_sim.run_steps(1)
                     self.handle_host2chip_communications()
@@ -432,7 +432,7 @@ class Simulator(object):
                 self.loihi.wait_for_completion()
                 logger.info("done")
             else:
-                self.loihi.run_steps(steps)
+                self.loihi.run_steps(steps, blocking=True)
 
         self._n_steps += steps
         logger.info("Finished running for %d steps", steps)

--- a/nengo_loihi/tests/test_loihi_interface.py
+++ b/nengo_loihi/tests/test_loihi_interface.py
@@ -1,0 +1,36 @@
+import pytest
+
+from nengo_loihi import loihi_interface
+
+
+class MockNxsdk:
+    def __init__(self):
+        self.__version__ = None
+
+
+def test_error_on_old_version(monkeypatch):
+    mock = MockNxsdk()
+    mock.__version__ = "0.5.5"
+
+    monkeypatch.setattr(loihi_interface, 'nxsdk', mock)
+    with pytest.raises(ImportError):
+        loihi_interface.LoihiSimulator.check_nxsdk_version()
+
+
+def test_no_warn_on_current_version(monkeypatch):
+    mock = MockNxsdk()
+    mock.__version__ = "0.7.0"
+
+    monkeypatch.setattr(loihi_interface, 'nxsdk', mock)
+    with pytest.warns(None) as record:
+        loihi_interface.LoihiSimulator.check_nxsdk_version()
+    assert len(record) == 0
+
+
+def test_warn_on_future_version(monkeypatch):
+    mock = MockNxsdk()
+    mock.__version__ = "0.7.1"
+
+    monkeypatch.setattr(loihi_interface, 'nxsdk', mock)
+    with pytest.warns(UserWarning):
+        loihi_interface.LoihiSimulator.check_nxsdk_version()


### PR DESCRIPTION
Update `async` parameter to `aSync`. I left our parameter name as `async`.  We could update it, but since we're sticking to the Python convention of snake_case names I figured `async` was preferred.

Updated the installation instructions for the new workflow (and using conda for everything).  This removed the distinction between the INRC/Superhost installation steps, so I combined them.