### PR TITLE
Fix keyword spotting example

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,10 @@ Release history
 0.4.0 (unreleased)
 ==================
 
+**Changed**
 
+- An error is now raised if
+  a learning rule is applied to a non-decoded connection.
 
 0.3.0 (September 28, 2018)
 ==========================

--- a/nengo_loihi/builder.py
+++ b/nengo_loihi/builder.py
@@ -759,8 +759,7 @@ def conn_probe(model, probe):
         else:
             raise NotImplementedError()
 
-        target = nengo.Node(None, size_in=output_dim,
-                            add_to_container=False)
+        target = nengo.Node(size_in=output_dim, add_to_container=False)
 
         conn = Connection(probe.target, target, synapse=synapse,
                           solver=probe.solver, add_to_container=False,

--- a/nengo_loihi/splitter.py
+++ b/nengo_loihi/splitter.py
@@ -320,40 +320,27 @@ def split_chip_to_host(networks, conn):
         d=conn.size_mid,
         rng=np.random.RandomState(seed=seed))
 
-    if (isinstance(conn.pre, nengo.ensemble.Neurons)
-            and transform.ndim == 2):
-        # decoders manually specified in the transform
-        # should be handled like a normal decoder
-        probe = nengo.Probe(
-            conn.pre.ensemble,
-            synapse=None,
-            solver=nengo.solvers.NoSolver(transform.T),
-            add_to_container=False,
-        )
-        dims = transform.shape[0]
-        networks.chip2host_params[probe] = dict(
-            learning_rule_type=conn.learning_rule_type,
-            function=lambda x, dims=dims: np.zeros(dims),
-            transform=np.array(1),
-        )
-    else:
-        probe = nengo.Probe(
-            conn.pre,
-            synapse=None,
-            solver=conn.solver,
-            add_to_container=False,
-        )
-        networks.chip2host_params[probe] = dict(
-            learning_rule_type=conn.learning_rule_type,
-            function=conn.function,
-            eval_points=conn.eval_points,
-            scale_eval_points=conn.scale_eval_points,
-            transform=transform
-        )
+    probe = nengo.Probe(
+        conn.pre,
+        synapse=None,
+        solver=conn.solver,
+        add_to_container=False,
+    )
+    networks.chip2host_params[probe] = dict(
+        learning_rule_type=conn.learning_rule_type,
+        function=conn.function,
+        eval_points=conn.eval_points,
+        scale_eval_points=conn.scale_eval_points,
+        transform=transform
+    )
     networks.add(probe, "chip")
     networks.chip2host_receivers[probe] = receive
 
     if conn.learning_rule_type is not None:
+        if not isinstance(conn.pre_obj, nengo.Ensemble):
+            raise NotImplementedError(
+                "Learning rule presynaptic object must be an Ensemble "
+                "(got %r)" % type(conn.pre_obj).__name__)
         networks.needs_sender[conn.learning_rule] = PESModulatoryTarget(probe)
     networks.remove(conn)
 

--- a/nengo_loihi/tests/test_learning.py
+++ b/nengo_loihi/tests/test_learning.py
@@ -13,7 +13,7 @@ def test_pes_comm_channel(allclose, plt, seed, Simulator, n_per_dim, dims):
         stim = nengo.Node(input_fn)
 
         pre = nengo.Ensemble(n_per_dim * dims, dims)
-        post = nengo.Node(None, size_in=dims)
+        post = nengo.Node(size_in=dims)
 
         nengo.Connection(stim, pre, synapse=None)
         conn = nengo.Connection(
@@ -64,8 +64,8 @@ def test_multiple_pes(allclose, plt, seed, Simulator):
     targets = np.linspace(-1, 1, n_errors)
     with nengo.Network(seed=seed) as model:
         pre_ea = nengo.networks.EnsembleArray(200, n_ensembles=n_errors)
-        errors = nengo.Node(None, size_in=n_errors)
-        output = nengo.Node(None, size_in=n_errors)
+        errors = nengo.Node(size_in=n_errors)
+        output = nengo.Node(size_in=n_errors)
 
         target = nengo.Node(targets)
         nengo.Connection(target, errors, transform=-1)

--- a/nengo_loihi/tests/test_precompute.py
+++ b/nengo_loihi/tests/test_precompute.py
@@ -16,7 +16,7 @@ def test_precompute(allclose, Simulator, seed, plt):
 
         nengo.Connection(stim, a)
 
-        output = nengo.Node(None, size_in=D)
+        output = nengo.Node(size_in=D)
 
         nengo.Connection(a, output)
 

--- a/nengo_loihi/tests/test_splitter.py
+++ b/nengo_loihi/tests/test_splitter.py
@@ -56,13 +56,18 @@ def test_manual_decoders(
         pre_probe = nengo.Probe(pre.neurons, synapse=None)
         post_probe = nengo.Probe(post, synapse=None)
 
-    with Simulator(model, precompute=False) as sim:
-        sim.run(0.1)
+    if not use_solver and learn:
+        with pytest.raises(NotImplementedError):
+            with Simulator(model) as sim:
+                pass
+    else:
+        with Simulator(model) as sim:
+            sim.run(0.1)
 
-    # Ensure pre population has a lot of activity
-    assert np.mean(sim.data[pre_probe]) > 100
-    # But that post has no activity due to the zero weights
-    assert np.all(sim.data[post_probe] == 0)
+        # Ensure pre population has a lot of activity
+        assert np.mean(sim.data[pre_probe]) > 100
+        # But that post has no activity due to the zero weights
+        assert np.all(sim.data[post_probe] == 0)
 
 
 def test_place_nodes():
@@ -231,13 +236,7 @@ def test_split_chip_to_host():
                 ens_onchip.neurons, ens_offchip, transform=np.ones((1, 10))),
             nengo.Connection(
                 ens_onchip.neurons, node_offchip, transform=np.ones((1, 10))),
-            nengo.Connection(ens_onchip.neurons, node_offchip,
-                             transform=np.ones((1, 10)),
-                             learning_rule_type=nengo.PES()),
         ]
-        connections.append(
-            nengo.Connection(ens_onchip, connections[-1].learning_rule)
-        )
         connections.append(
             nengo.Connection(ens_onchip, connections[1].learning_rule)
         )

--- a/nengo_loihi/tests/test_splitter.py
+++ b/nengo_loihi/tests/test_splitter.py
@@ -35,7 +35,7 @@ def test_manual_decoders(
         pre = nengo.Ensemble(50, dimensions=pre_dims,
                              gain=np.ones(50),
                              bias=np.ones(50) * 5)
-        post = nengo.Node(None, size_in=post_dims)
+        post = nengo.Node(size_in=post_dims)
 
         learning_rule_type = nengo.PES() if learn else None
         weights = np.zeros((post_dims, 50))
@@ -221,7 +221,7 @@ def test_split_chip_to_host():
     with nengo.Network() as net:
         ens_onchip = nengo.Ensemble(10, 1)
         ens_offchip = nengo.Ensemble(10, 1)
-        node_offchip = nengo.Node(None, size_in=1)
+        node_offchip = nengo.Node(size_in=1)
         connections = [
             nengo.Connection(ens_onchip, ens_offchip),
             nengo.Connection(
@@ -349,12 +349,12 @@ def test_split_pre_from_host():
     with nengo.Network() as net:
         pre_1 = nengo.Node(0, label="pre_1")
         pre_2 = nengo.Ensemble(10, 1, label="pre_2")
-        pre_3 = nengo.Node(None, size_in=1, label="pre_3")
+        pre_3 = nengo.Node(size_in=1, label="pre_3")
         pre_4 = nengo.Ensemble(1, 1, label="pre_4")
         send = HostSendNode(dimensions=1)
         onchip = nengo.Ensemble(1, 1, label="onchip")
         post1 = nengo.Ensemble(10, 1, label="post1")
-        post2 = nengo.Node(None, size_in=1, label="post2")
+        post2 = nengo.Node(size_in=1, label="post2")
         pre_connections = [
             nengo.Connection(pre_1, pre_2),
             nengo.Connection(pre_2, pre_3),


### PR DESCRIPTION
@pblouw reported that his keyword spotting demo is broken in v0.3.0, and indeed [our keyword spotting example is broken also](https://www.nengo.ai/nengo-loihi/examples/keyword_spotting.html). He tracked it down to [this commit](https://github.com/nengo/nengo-loihi/commit/0811e2a840cf0c9bb24d77a10f43e6e3fc8a8486), which seems like it shouldn't even affect the keyword spotting network, but in fact it does.

The reason why that commit affects the keyword spotting network is that it translates **all** neuron->* connections in which `pre` is onchip and `post` is offchip with `transform=weights` to a `solver=NoSolver(weight.T)` connection. This would be fine if those two connections made no difference to how the network behaves, but that is unfortunately not the case, as evidenced by the keyword spotting example failing.

Investigating this issue is made more complicated by the fact that it is impossible to compare the two connection types because `transform=weights` connections are translated to `NoSolver` connections by the splitter. Commenting out this behavior in the splitter results in obvious differences between the two.

One way we can still investigate this is in looking at neuron->* connections in which `pre` is offchip and `post` is onchip, as this case was not handled in the same way as the reverse of that, so `transform=weights` connections still act differently from `solver=NoSolver` connections. This is definitely an oversight, but in this case a convenient one as it allowed me to write the `test_n2n_transform_solver` test in this PR.

Running that test with the commit it's introduced in (9042d86b6eeff64ac9079243087ddb0bd2233004) reveals some hard to debug issues. Thanks to the new `allclose` changes, here's the first bunch of failures when comparing a connections with a transform and a NoSolver:

```
allclose first 5 failures:
  (22, 0): 0.005813399449355831 -0.027141482844726717
  (23, 0): -0.027332068748132363 -0.026265229725634918
  (24, 0): -0.026442792216304224 -0.025404153073492673
  (25, 0): 0.051607908894409936 -0.024571305871791547
  (26, 0): 0.04992955092214089 0.05341804061865481
  (27, 0): 0.04829266554173085 0.051680339469823776
  (28, 0): 0.04670944364715465 0.0170311741195067
```

I attempted to fix this in splitter in f2ae792627a9f8250b98bbd2bd83dda4f5e85eac. I was not able to fix it (I find the `ChipReceiveNeurons` and `HostSendNode` stuff quite confusing), but looking at how it fails now gives me some hope:

```
allclose first 5 failures:
  (11, 0): -0.037291051016988146 0.0
  (12, 0): -0.03607528021115636 0.0
  (13, 0): 0.0058673941456823045 0.0
  (14, 0): 0.005681813349207329 0.0
  (15, 0): 0.0054955413512869184 0.0
  (16, 0): 0.005315376075829346 0.0
  (17, 0): -0.014805258804706747 -0.037291051016988146
```

It looks like the `NoSolver` case might be operating the same as the `transform` case, only 6 timesteps delayed. We should make them the same, but seeing as I tried to do that here, I think I will need help to do that.

Also, even if we fix this case, it doesn't fix the keyword spotting example. However, it might give us a bit of insight into why the switch from the `transform` connection to the `NoSolver` connection made a difference. Does the way we did the connection splitting in 0811e2a840cf0c9bb24d77a10f43e6e3fc8a8486 have the same weird issue as in 9042d86b6eeff64ac9079243087ddb0bd2233004, or is it simply delayed by some timesteps? My guess is that having several timesteps delay would not cause the keyword spotting example to change in the way that it changed, so I think we need to revisit the change in 0811e2a840cf0c9bb24d77a10f43e6e3fc8a8486 and ensure that switching the type of connection doesn't change behavior.