### PR TITLE
Emulator input delay

### DIFF
--- a/nengo_loihi/loihi_cx.py
+++ b/nengo_loihi/loihi_cx.py
@@ -665,11 +665,12 @@ class CxSimulator(object):
         for a_in in self.a_in.values():
             a_in[:] = 0
 
-        for input in self.inputs:
-            for axons in input.axons:
-                synapses = axons.target
-                assert axons.target_inds == slice(None)
-                self.a_in[synapses] += input.spikes[self.t]
+        if self.t >= 1:  # input spikes take one time-step to arrive
+            for input in self.inputs:
+                for axons in input.axons:
+                    synapses = axons.target
+                    assert axons.target_inds == slice(None)
+                    self.a_in[synapses] += input.spikes[self.t - 1]
 
         for group in self.groups:
             for axons in group.axons:

--- a/nengo_loihi/tests/test_loihi_cx.py
+++ b/nengo_loihi/tests/test_loihi_cx.py
@@ -163,5 +163,5 @@ def test_uv_overflow(n_axons, Simulator, plt, allclose):
     plt.plot(emu_s)
     plt.plot(sim_s)
 
-    assert allclose(emu_u[:-1], sim_u[1:])
-    assert allclose(emu_v[:-1], sim_v[1:])
+    assert allclose(emu_u, sim_u)
+    assert allclose(emu_v, sim_v)


### PR DESCRIPTION
On Loihi, spikes always take one timestep to get where they're going. With input spikes in the emulator, we were not accounting for that delay and having them arrive instantaneously. This PR fixes that.

Based off #111, so that I could update the test there to get rid of the delay.