### PR TITLE
Modifying tau_s gives a warning, not an Exception

### DIFF
--- a/nengo_loihi/builder.py
+++ b/nengo_loihi/builder.py
@@ -324,7 +324,7 @@ def build_ensemble(model, ens):
         model.build(ens.neuron_type, ens.neurons, group)
 
     # set default filter just in case no other filter gets set
-    group.configure_filter(model.inter_tau, dt=model.dt, default=True)
+    group.configure_default_filter(model.inter_tau, dt=model.dt)
 
     if ens.noise is not None:
         raise NotImplementedError("Ensemble noise not implemented")


### PR DESCRIPTION
Just a quick change, but as discussed in the meeting it might be worth addressing the fact that this makes the final model dependent on the build order (as it uses the final tau_s value).  Eventually we will support different tau_s values, but for now perhaps we should take the one with the longest time constant?