### PR TITLE
Integrator accuracy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,15 @@ Release history
 0.5.0 (unreleased)
 ==================
 
+**Fixed**
 
+- We integrate current (U) and voltage (V) more accurately now by accounting
+  for rounding during the decay process. This integral is used when
+  discretizing weights and firing thresholds. This change significantly
+  improves accuracy for many networks, but in particular dynamical systems
+  like integrators.
+  (`#124 <https://github.com/nengo/nengo-loihi/pull/124>`_,
+  `#114 <https://github.com/nengo/nengo-loihi/issues/114>`_)
 
 0.4.0 (December 6, 2018)
 ========================

--- a/conftest.py
+++ b/conftest.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 import nengo.conftest
-from nengo.conftest import plt, TestConfig  # noqa: F401
+from nengo.conftest import logger, plt, TestConfig  # noqa: F401
 from nengo.utils.compat import ensure_bytes
 
 import nengo_loihi

--- a/nengo_loihi/loihi_api.py
+++ b/nengo_loihi/loihi_api.py
@@ -600,11 +600,15 @@ class SynapseFmt(Profile):
 
         w = np.round(w / 2.**s).clip(-m, m).astype(dtype)
         s2 = s + self.wgtExp
-        shift(w, s2, out=w)
-        np.left_shift(w, 6, out=w)
-
         if s2 < 0:
             warnings.warn("Lost %d extra bits in weight rounding" % (-s2,))
+
+            # round before `s2` right shift, since just shifting would floor
+            # everything resulting in weights biased towards being smaller
+            w = (np.round(w * 2.**s2) / 2**s2).clip(-m, m).astype(dtype)
+
+        shift(w, s2, out=w)
+        np.left_shift(w, 6, out=w)
 
         ws = w // self.scale
         assert np.all(ws <= 255) and np.all(ws >= -256)

--- a/nengo_loihi/loihi_api.py
+++ b/nengo_loihi/loihi_api.py
@@ -99,6 +99,57 @@ def tracing_mag_int_frac(synapses):
     return mag_int, mag_frac
 
 
+def decay_int(x, decay, bits=12, offset=0, out=None):
+    """Decay integer values using a decay constant.
+
+    The decayed value is given by::
+
+        sign(x) * floor(abs(x) * (2**bits - offset - decay) / 2**bits)
+    """
+    if out is None:
+        out = np.zeros_like(x)
+    r = (2**bits - offset - np.asarray(decay)).astype(np.int64)
+    np.right_shift(np.abs(x) * r, bits, out=out)
+    return np.sign(x) * out
+
+
+def decay_magnitude(decay, x0=2**21, bits=12, offset=0):
+    """Estimate the sum of the series of rounded integer decays of ``x0``.
+
+    This can be used to estimate the total input current or voltage (summed
+    over time) caused by an input of magnitude ``x0``. In real values, this is
+    easy to calculate as the integral of an exponential. In integer values,
+    we need to account for the rounding down that happens each time the decay
+    is computed.
+
+    Specifically, we estimate the sum of the series::
+
+        x_i = floor(r x_{i-1})
+
+    where ``r = (2**bits - offset - decay)``.
+
+    To simulate the effects of rounding in decay, we subtract an expected loss
+    due to rounding (``q``) each iteration. Our estimated series is therefore::
+
+        y_i = r * y_{i-1} - q
+            = r^i * x_0 - sum_k^{i-1} q * r^k
+    """
+    # q: Expected loss per time step (found by empirical simulations). If the
+    # value being rounded down were uniformly distributed between 0 and 1, this
+    # should be 0.5 exactly, but empirically this does not appear to be the
+    # case and this value is better (see `test_decay_magnitude`).
+    q = 0.494
+
+    r = (2**bits - offset - np.asarray(decay)) / 2**bits  # decay ratio
+    n = -np.log1p(x0 * (1 - r) / q) / np.log(r)  # solve y_n = 0 for n
+
+    # principal_sum = (1./x0) sum_i^n x0 * r^i
+    # loss_sum = (1./x0) sum_i^n sum_k^{i-1} q * r^k
+    principal_sum = (1 - r**(n + 1)) / (1 - r)
+    loss_sum = q / ((1 - r) * x0) * (n + 1 - (1 - r**(n+1))/(1 - r))
+    return principal_sum - loss_sum
+
+
 def shift(x, s, **kwargs):
     if s < 0:
         return np.right_shift(x, -s, **kwargs)

--- a/nengo_loihi/loihi_cx.py
+++ b/nengo_loihi/loihi_cx.py
@@ -12,6 +12,8 @@ from nengo.utils.compat import is_integer, is_iterable
 from nengo_loihi.loihi_api import (
     BIAS_MAX,
     bias_to_manexp,
+    decay_int,
+    decay_magnitude,
     overflow_signed,
     SynapseFmt,
     tracing_mag_int_frac,
@@ -229,12 +231,16 @@ class CxGroup(object):
             target[:] = new
 
         # --- discretize decayU and decayV
-        u_infactor = (
-            self.decayU.copy() if self.scaleU else np.ones_like(self.decayU))
-        v_infactor = (
-            self.decayV.copy() if self.scaleV else np.ones_like(self.decayV))
         discretize(self.decayU, self.decayU * (2**12 - 1))
         discretize(self.decayV, self.decayV * (2**12 - 1))
+
+        # Compute factors for current and voltage decay. These factors
+        # counteract the fact that for longer decays, the current (or voltage)
+        # created by a single spike has a larger integral.
+        u_infactor = (1. / decay_magnitude(self.decayU, x0=2**21, offset=1)
+                      if self.scaleU else np.ones(self.decayU.shape))
+        v_infactor = (1. / decay_magnitude(self.decayV, x0=2**21)
+                      if self.scaleV else np.ones(self.decayV.shape))
         self.scaleU = False
         self.scaleV = False
 
@@ -824,27 +830,21 @@ class CxSimulator(object):
             group.decayV if group.scaleV else np.ones_like(group.decayV)
             for group in self.groups])
 
-        def decay_float(x, u, d, s):
-            return (1 - d)*x + s*u
-
-        def decay_int(x, u, d, s, a=12, b=0):
-            r = (2**a - b - np.asarray(d)).astype(np.int64)
-            x = np.sign(x) * np.right_shift(np.abs(x) * r, a)  # round to zero
-            return x + u  # no scaling on u
-
         if group_dtype == np.int32:
             assert (self.scaleU == 1).all()
             assert (self.scaleV == 1).all()
-            self.decayU_fn = lambda x, u: decay_int(
-                x, u, d=self.decayU, s=self.scaleU, b=1)
-            self.decayV_fn = lambda x, u: decay_int(
-                x, u, d=self.decayV, s=self.scaleV)
+            self.decayU_fn = (
+                lambda x, u: decay_int(x, self.decayU, offset=1) + u)
+            self.decayV_fn = lambda x, u: decay_int(x, self.decayV) + u
 
             def overflow(x, bits, name=None):
                 _, o = overflow_signed(x, bits=bits, out=x)
                 if np.any(o):
                     self.error("Overflow" + (" in %s" % name if name else ""))
         elif group_dtype == np.float32:
+            def decay_float(x, u, d, s):
+                return (1 - d)*x + s*u
+
             self.decayU_fn = lambda x, u: decay_float(
                 x, u, d=self.decayU, s=self.scaleU)
             self.decayV_fn = lambda x, u: decay_float(

--- a/nengo_loihi/loihi_cx.py
+++ b/nengo_loihi/loihi_cx.py
@@ -231,7 +231,9 @@ class CxGroup(object):
             target[:] = new
 
         # --- discretize decayU and decayV
-        discretize(self.decayU, self.decayU * (2**12 - 1))
+        # subtract 1 from decayU here because it gets added back by the chip
+        decayU = self.decayU * (2**12 - 1) - 1
+        discretize(self.decayU, np.clip(decayU, 0, 2**12 - 1))
         discretize(self.decayV, self.decayV * (2**12 - 1))
 
         # Compute factors for current and voltage decay. These factors

--- a/nengo_loihi/tests/test_conv.py
+++ b/nengo_loihi/tests/test_conv.py
@@ -165,7 +165,7 @@ def test_pop_tiny(
         ref_out = np.array([[0.0975, 0.02],
                             [0.0825, 0.02],
                             [0.125, 0.055],
-                            [0.1675, 0.0825]])
+                            [0.2475, 0.0825]])
     assert allclose(sim_out[:, :, 0], ref_out, rtol=0, atol=1e-7)
 
 

--- a/nengo_loihi/tests/test_loihi_api.py
+++ b/nengo_loihi/tests/test_loihi_api.py
@@ -1,7 +1,9 @@
+from nengo.utils.numpy import rms
 import numpy as np
 import pytest
 
 from nengo_loihi.loihi_api import overflow_signed
+from nengo_loihi.loihi_api import decay_int, decay_magnitude
 
 
 @pytest.mark.parametrize("b", (8, 16, 17, 23))
@@ -22,3 +24,66 @@ def test_overflow_signed(b):
     y, o = overflow_signed(x, bits=b)
     assert np.array_equal(y, z)
     assert np.array_equal(o, q)
+
+
+@pytest.mark.parametrize('offset', (0, 1))
+def test_decay_magnitude(offset, plt, logger):
+    bits = 12
+    decays = np.arange(1, 2**bits, 7)
+    ref = []
+    emp = []
+    est = []
+
+    for decay in decays:
+        def empirical_decay_magnitude(decay, x0):
+            x = x0 * np.ones(decay.shape, dtype=np.int32)
+            y = x
+            y_sum = np.zeros(decay.shape, dtype=np.int64)
+            for i in range(100000):
+                y_sum += y
+                if (y <= 0).all():
+                    break
+                y = decay_int(y, decay, bits=bits, offset=offset)
+            else:
+                raise RuntimeError("Exceeded max number of iterations")
+
+            return y_sum / x0
+
+        x0 = np.arange(2**21 - 1000, 2**21, step=41, dtype=np.int32)
+
+        m = empirical_decay_magnitude(decay * np.ones_like(x0), x0)
+        m0 = m.mean()
+        emp.append(m0)
+
+        # reference (naive) method, not accounting for truncation loss
+        r = (2**bits - offset - decay) / 2**bits
+        Sx1 = (1 - r/x0) / (1 - r)  # sum_i^n x_i/x_0, where x_n = r**n*x_0 = 1
+        ref.append(Sx1.mean())
+
+        m = decay_magnitude(decay, x0, bits=bits, offset=offset)
+        m2 = m.mean()
+        est.append(m2)
+
+    ref = np.array(ref)
+    emp = np.array(emp)
+    est = np.array(est)
+    rms_ref = rms(ref - emp) / rms(emp)
+    rms_est = rms(est - emp) / rms(emp)
+    logger.info("Ref rel RMSE: %0.3e, decay_magnitude rel RMSE: %0.3e" % (
+        rms_ref, rms_est))
+
+    abs_ref = np.abs(ref - emp)
+    abs_est = np.abs(est - emp)
+
+    # find places where ref is better than est
+    relative_diff = (abs_est - abs_ref) / emp
+
+    ax = plt.subplot(211)
+    plt.plot(abs_ref, 'b')
+    plt.plot(abs_est, 'g')
+    ax.set_yscale('log')
+
+    ax = plt.subplot(212)
+    plt.plot(relative_diff.clip(0, None))
+
+    assert np.all(relative_diff < 1e-6)

--- a/nengo_loihi/tests/test_neurons.py
+++ b/nengo_loihi/tests/test_neurons.py
@@ -81,5 +81,5 @@ def test_loihi_neurons(neuron_type, Simulator, plt, allclose):
     plt.legend(loc='best')
 
     atol = 1. / t_final  # the fundamental unit for our rates
-    assert allclose(nengo_rates, ref, atol=atol, rtol=0, xtol=0)
-    assert allclose(loihi_rates, ref, atol=atol, rtol=0, xtol=0)
+    assert allclose(nengo_rates, ref, atol=atol, rtol=0, xtol=1)
+    assert allclose(loihi_rates, ref, atol=atol, rtol=0, xtol=1)


### PR DESCRIPTION
Improving the accuracy of an integrator network. Fixes #114, namely an integrator using a recurrent weight connection.

The integrator network still does not work as expected when using a decoded (non-weight) connection (now documented in #125).