### PR TITLE
Configure defaults for optimal Loihi performance

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -409,6 +409,10 @@ setup_cfg:
       test_solvers.py:test_non_compositional_solver_transform_error:
         1D convolution not supported
 
+      # sparse transforms not supported
+      test_transforms.py:test_sparse[*:
+        sparse transforms not supported
+
 
 docs_conf_py:
   intersphinx_mapping:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,9 @@ Release history
 - We no longer disable the Nengo decoder cache for all models.
   (`#202 <https://github.com/nengo/nengo-loihi/pull/202>`__,
   `#207 <https://github.com/nengo/nengo-loihi/issues/207>`__)
+- Transforms to on-chip neurons are now applied on-chip,
+  which avoids scaling issues and large off-chip transforms.
+  (`#126 <https://github.com/nengo/nengo-loihi/pull/126>`__)
 
 0.6.0 (February 22, 2019)
 =========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,9 @@ Release history
   `#209 <https://github.com/nengo/nengo-loihi/issues/209>`__)
 - Nengo Loihi now requires at least NxSDK version 0.8.0.
   (`#218 <https://github.com/nengo/nengo-loihi/pull/218>`__)
+- The default intercept range set by ``nengo_loihi.set_defaults()`` is now
+  (-1, 0.5), instead of (-0.5, 0.5).
+  (`#126 <https://github.com/nengo/nengo-loihi/pull/126>`__)
 
 **Fixed**
 

--- a/nengo_loihi/config.py
+++ b/nengo_loihi/config.py
@@ -42,4 +42,4 @@ def set_defaults():
 
     """
     nengo.Ensemble.max_rates.default = nengo.dists.Uniform(100, 120)
-    nengo.Ensemble.intercepts.default = nengo.dists.Uniform(-0.5, 0.5)
+    nengo.Ensemble.intercepts.default = nengo.dists.Uniform(-1.0, 0.5)

--- a/nengo_loihi/tests/test_learning.py
+++ b/nengo_loihi/tests/test_learning.py
@@ -114,7 +114,7 @@ def test_pes_overflow(plt, seed, Simulator):
 
     loihi_model = Model()
     # set learning_wgt_exp low to create overflow in weight values
-    loihi_model.pes_wgt_exp = -1
+    loihi_model.pes_wgt_exp = -2
 
     with Simulator(model, model=loihi_model) as loihi_sim:
         loihi_sim.run(simtime)
@@ -143,7 +143,7 @@ def test_pes_overflow(plt, seed, Simulator):
         assert errors_j[i] < 0.1, ("Learning output for dim %d did not match "
                                    "any scaled version of the target output"
                                    % j)
-        assert scale[i] > 0.4, "Learning output for dim %d is too small" % j
+        assert scale[i] > 0.25, "Learning output for dim %d is too small" % j
         assert scale[i] < 0.7, ("Learning output for dim %d is too large "
                                 "(weights or traces not clipping as expected)"
                                 % j)

--- a/nengo_loihi/tests/test_simulator.py
+++ b/nengo_loihi/tests/test_simulator.py
@@ -147,8 +147,8 @@ def test_nengo_comm_channel_compare(simtype, Simulator, seed, plt, allclose):
         nengo.Connection(a, b, function=lambda x: x**2,
                          solver=nengo.solvers.LstsqL2(weights=True))
 
-        ap = nengo.Probe(a, synapse=0.03)
-        bp = nengo.Probe(b, synapse=0.03)
+        ap = nengo.Probe(a, synapse=nengo.synapses.Alpha(0.02))
+        bp = nengo.Probe(b, synapse=nengo.synapses.Alpha(0.02))
 
     with nengo.Simulator(model) as nengo_sim:
         nengo_sim.run(simtime)
@@ -164,8 +164,8 @@ def test_nengo_comm_channel_compare(simtype, Simulator, seed, plt, allclose):
     plt.plot(nengo_sim.trange(), nengo_sim.data[bp])
     plt.plot(loihi_sim.trange(), loihi_sim.data[bp])
 
-    assert allclose(loihi_sim.data[ap], nengo_sim.data[ap], atol=0.1, rtol=0.2)
-    assert allclose(loihi_sim.data[bp], nengo_sim.data[bp], atol=0.1, rtol=0.2)
+    assert allclose(loihi_sim.data[ap], nengo_sim.data[ap], atol=0.07, xtol=3)
+    assert allclose(loihi_sim.data[bp], nengo_sim.data[bp], atol=0.07, xtol=6)
 
 
 @pytest.mark.parametrize("precompute", (True, False))

--- a/setup.cfg
+++ b/setup.cfg
@@ -327,6 +327,8 @@ nengo_test_unsupported =
         "decoded connection optimized away"
     test_solvers.py:test_non_compositional_solver_transform_error
         "1D convolution not supported"
+    test_transforms.py:test_sparse[*
+        "sparse transforms not supported"
 
 [pylint]
 # note: pylint doesn't look in setup.cfg by default, need to call it with


### PR DESCRIPTION
In #73, we started talking about whether the current defaults are actually the best. I chose them pretty arbitrarily, so it's unlikely that they are.

This PR is a place for us to collect changes to the defaults that improve performance across a variety of models. With many of the Nengo benchmarks now becoming available, those could be a good way to test potential changes. 

To start, I'm correcting something that was a mistake on my part. Since intercepts happen after encoders, we actually just need to lower the upper bound on intercepts (away from one) to avoid high gains. The lower bound can (and I think should) stay at -1. I'd like to test this change on some benchmarks, though, to see if it's actually better.

EDIT: I just went and rebased this to the `integrator-accuracy` branch (#124), since that makes some pretty significant changes to how we choose weights that could have an effect on accuracy measurements.