### PR TITLE
Interneuron improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@ Release history
   (`#139 <https://github.com/nengo/nengo-loihi/pull/139>`__)
 - Learning in the emulator more closely matches learning on hardware.
   (`#139 <https://github.com/nengo/nengo-loihi/pull/139>`__)
+- The neurons used to transmit decoded values on-chip can be configured.
+  By default, we use ten pairs of heterogeneous neurons per dimension.
+  (`#132 <https://github.com/nengo/nengo-loihi/pull/132>`_)
 
 **Fixed**
 

--- a/nengo_loihi/simulator.py
+++ b/nengo_loihi/simulator.py
@@ -8,7 +8,7 @@ import numpy as np
 import nengo
 import nengo.utils.numpy as npext
 from nengo.exceptions import (
-    BuildError, ReadonlyError, SimulatorClosed, ValidationError)
+    ReadonlyError, SimulatorClosed, ValidationError)
 from nengo.simulator import ProbeDict as NengoProbeDict
 
 from nengo_loihi.builder import Model
@@ -339,11 +339,6 @@ class Simulator(object):
             self.model = model
             assert self.model.dt == dt
 
-        max_rate = self.model.inter_rate * self.model.inter_n
-        rtol = 1e-8  # allow for floating point inaccuracies
-        if max_rate > (1. / self.dt) * (1 + rtol):
-            raise BuildError("Simulator `dt` must be <= %s (got %s)"
-                             % (1. / max_rate, self.dt))
         self.precompute = precompute
         self.networks = None
         self.sims = OrderedDict()
@@ -356,9 +351,9 @@ class Simulator(object):
             # split the host into one, two or three networks
             self.networks = split(
                 network,
-                precompute,
-                max_rate,
-                self.model.inter_tau,
+                precompute=precompute,
+                node_neurons=self.model.node_neurons,
+                node_tau=self.model.decode_tau,
                 remove_passthrough=remove_passthrough,
             )
             network = self.networks.chip

--- a/nengo_loihi/tests/test_builder.py
+++ b/nengo_loihi/tests/test_builder.py
@@ -2,7 +2,15 @@ import nengo
 import numpy as np
 import pytest
 
-from nengo_loihi.builder import get_gain_bias, Model
+from nengo_loihi.builder import (
+    DecodeNeurons,
+    get_gain_bias,
+    Model,
+    NoisyDecodeNeurons,
+    OnOffDecodeNeurons,
+    Preset5DecodeNeurons,
+    Preset10DecodeNeurons,
+)
 
 
 @pytest.mark.parametrize("passed_intercepts", [
@@ -18,3 +26,15 @@ def test_intercept_limit(passed_intercepts, rng):
     with pytest.warns(UserWarning):
         _, _, _, intercepts = get_gain_bias(ens, rng, model.intercept_limit)
     assert np.all(intercepts <= model.intercept_limit)
+
+
+def test_decode_neuron_str():
+    assert str(DecodeNeurons(dt=0.005)) == "DecodeNeurons(dt=0.005)"
+    assert str(OnOffDecodeNeurons(pairs_per_dim=2, dt=0.002, rate=None)) == (
+        "OnOffDecodeNeurons(pairs_per_dim=2, dt=0.002, rate=250)")
+    assert str(NoisyDecodeNeurons(1, rate=20)) == (
+        "NoisyDecodeNeurons(pairs_per_dim=1, dt=0.001, rate=20, noise_exp=-2)")
+    assert str(Preset5DecodeNeurons()) == (
+        "Preset5DecodeNeurons(dt=0.001, rate=200)")
+    assert str(Preset10DecodeNeurons(dt=0.0001, rate=0.5)) == (
+        "Preset10DecodeNeurons(dt=0.0001, rate=0.5)")

--- a/nengo_loihi/tests/test_communication.py
+++ b/nengo_loihi/tests/test_communication.py
@@ -6,7 +6,7 @@ import pytest
 
 # This test sometimes (but not consistently) fails on the chip for various
 # combinations of the parameter values. This possibly has to do with
-# interneuron noise and not representing the values well.
+# DecodeNeuron noise and not representing the values well.
 @pytest.mark.xfail
 @pytest.mark.parametrize("val", (-0.75, -0.5, 0, 0.5, 0.75))
 @pytest.mark.parametrize("type", ("array", "func"))
@@ -110,7 +110,7 @@ def test_neurons2node(Simulator, seed, plt):
                             size_in=a.n_neurons, size_out=0)
         nengo.Connection(a.neurons, output, synapse=None)
 
-    with Simulator(model) as sim:
+    with Simulator(model, precompute=True) as sim:
         sim.run(1.0)
 
     rasterplot(sim.trange(), np.array(data), ax=plt.gca())

--- a/nengo_loihi/tests/test_decode_neurons.py
+++ b/nengo_loihi/tests/test_decode_neurons.py
@@ -1,0 +1,109 @@
+import nengo
+import numpy as np
+import pytest
+
+from nengo_loihi.builder import (
+    Model, NoisyDecodeNeurons, OnOffDecodeNeurons,
+    Preset5DecodeNeurons, Preset10DecodeNeurons,
+)
+
+
+@pytest.mark.parametrize('decode_neurons, tolerance', [
+    (OnOffDecodeNeurons(), 0.33),
+    (NoisyDecodeNeurons(5), 0.12),
+    (NoisyDecodeNeurons(10), 0.10),
+    (Preset5DecodeNeurons(), 0.06),
+    (Preset10DecodeNeurons(), 0.03),
+])
+def test_add_inputs(decode_neurons, tolerance, Simulator, seed, plt):
+    sim_time = 2.
+    pres_time = 0.5
+    eval_time = 0.25
+
+    stim_values = [[0.5, 0.5], [0.5, -0.9], [-0.7, -0.3], [-0.3, 1.0]]
+    stim_times = np.arange(0, sim_time, pres_time)
+    stim_fn_a = nengo.processes.Piecewise({
+        t: stim_values[i][0] for i, t in enumerate(stim_times)})
+    stim_fn_b = nengo.processes.Piecewise({
+        t: stim_values[i][1] for i, t in enumerate(stim_times)})
+
+    with nengo.Network(seed=seed) as model:
+        stim_a = nengo.Node(stim_fn_a)
+        stim_b = nengo.Node(stim_fn_b)
+
+        a = nengo.Ensemble(n_neurons=100, dimensions=1)
+        b = nengo.Ensemble(n_neurons=100, dimensions=1)
+
+        nengo.Connection(stim_a, a)
+        nengo.Connection(stim_b, b)
+
+        c = nengo.Ensemble(n_neurons=100, dimensions=1)
+        nengo.Connection(a, c)
+        nengo.Connection(b, c)
+
+        out_synapse = nengo.Alpha(0.03)
+        stim_synapse = out_synapse.combine(
+            nengo.Alpha(0.005)).combine(
+                nengo.Alpha(0.005))
+        p_stim_a = nengo.Probe(stim_a, synapse=stim_synapse)
+        p_stim_b = nengo.Probe(stim_b, synapse=stim_synapse)
+        p_c = nengo.Probe(c, synapse=out_synapse)
+
+    build_model = Model()
+    build_model.decode_neurons = decode_neurons
+
+    with Simulator(model, model=build_model) as sim:
+        sim.run(sim_time)
+
+    t = sim.trange()
+    tmask = np.zeros(t.shape, dtype=bool)
+    for pres_t in np.arange(0, sim_time, pres_time):
+        t0 = pres_t + pres_time - eval_time
+        t1 = pres_t + pres_time
+        tmask |= (t >= t0) & (t <= t1)
+
+    target = sim.data[p_stim_a] + sim.data[p_stim_b]
+    error = np.abs(sim.data[p_c][tmask] - target[tmask]).mean()
+
+    plt.plot(t, target)
+    plt.plot(t, sim.data[p_c])
+    plt.ylim([-1.1, 1.1])
+    plt.title("error = %0.2e" % error)
+
+    assert error < tolerance
+
+
+@pytest.mark.parametrize('decode_neurons, tolerance', [
+    (OnOffDecodeNeurons(), 0.01),
+])
+def test_node_neurons(decode_neurons, tolerance, Simulator, seed, plt):
+    sim_time = 2.
+
+    stim_fn = lambda t: 0.9*np.sin(2*np.pi*t)
+    out_synapse = nengo.Alpha(0.03)
+    stim_synapse = out_synapse.combine(nengo.Alpha(0.005))
+
+    with nengo.Network(seed=seed) as model:
+        stim = nengo.Node(stim_fn)
+        a = nengo.Ensemble(n_neurons=100, dimensions=1)
+        nengo.Connection(stim, a)
+
+        p_stim = nengo.Probe(stim, synapse=stim_synapse)
+        p_a = nengo.Probe(a, synapse=out_synapse)
+
+    build_model = Model()
+    build_model.node_neurons = decode_neurons
+
+    with Simulator(model, model=build_model) as sim:
+        sim.run(sim_time)
+
+    t = sim.trange()
+    target = sim.data[p_stim]
+    error = np.abs(sim.data[p_a] - target).mean()
+
+    plt.plot(t, target)
+    plt.plot(t, sim.data[p_a])
+    plt.ylim([-1.1, 1.1])
+    plt.title("error = %0.2e" % error)
+
+    assert error < tolerance

--- a/nengo_loihi/tests/test_learning.py
+++ b/nengo_loihi/tests/test_learning.py
@@ -67,10 +67,10 @@ def test_pes_comm_channel(allclose, plt, seed, Simulator, n_per_dim, dims):
     pre_tmask = t > 0.1
     post_tmask = t > simtime - 1.0
 
-    inter_tau = loihi_sim.model.inter_tau
+    dec_tau = loihi_sim.model.decode_tau
     y = nengo_sim.data[probes['stim']]
-    y_dpre = nengo.Lowpass(inter_tau).filt(y)
-    y_dpost = nengo.Lowpass(tau).combine(nengo.Lowpass(inter_tau)).filt(y_dpre)
+    y_dpre = nengo.Lowpass(dec_tau).filt(y)
+    y_dpost = nengo.Lowpass(tau).combine(nengo.Lowpass(dec_tau)).filt(y_dpre)
     y_nengo = nengo_sim.data[probes['post']]
     y_loihi = loihi_sim.data[probes['post']]
     y_real = real_sim.data[probes['post']]
@@ -117,10 +117,10 @@ def test_pes_overflow(allclose, plt, seed, Simulator):
     t = loihi_sim.trange()
     post_tmask = t > simtime - 1.0
 
-    inter_tau = loihi_sim.model.inter_tau
+    dec_tau = loihi_sim.model.decode_tau
     y = loihi_sim.data[probes['stim']]
-    y_dpre = nengo.Lowpass(inter_tau).filt(y)
-    y_dpost = nengo.Lowpass(tau).combine(nengo.Lowpass(inter_tau)).filt(y_dpre)
+    y_dpre = nengo.Lowpass(dec_tau).filt(y)
+    y_dpost = nengo.Lowpass(tau).combine(nengo.Lowpass(dec_tau)).filt(y_dpre)
     y_loihi = loihi_sim.data[probes['post']]
 
     plt.plot(t, y_dpost, 'k', label='target')
@@ -163,10 +163,10 @@ def test_pes_error_clip(allclose, plt, seed, Simulator):
     t = loihi_sim.trange()
     post_tmask = t > simtime - 1.0
 
-    inter_tau = loihi_sim.model.inter_tau
+    dec_tau = loihi_sim.model.decode_tau
     y = loihi_sim.data[probes['stim']]
-    y_dpre = nengo.Lowpass(inter_tau).filt(y)
-    y_dpost = nengo.Lowpass(tau).combine(nengo.Lowpass(inter_tau)).filt(y_dpre)
+    y_dpre = nengo.Lowpass(dec_tau).filt(y)
+    y_dpost = nengo.Lowpass(tau).combine(nengo.Lowpass(dec_tau)).filt(y_dpre)
     y_loihi = loihi_sim.data[probes['post']]
 
     plt.plot(t, y_dpost, 'k', label='target')

--- a/nengo_loihi/tests/test_multiple.py
+++ b/nengo_loihi/tests/test_multiple.py
@@ -18,7 +18,7 @@ def test_multiple_stims(allclose, Simulator, seed, precompute):
         sim.run(0.1)
 
     # Note: these should ideally be identical,
-    #  but noise in the spiking interneurons will
+    #  but noise in the spiking DecodeNeurons will
     #  make them different.  If spiking decoders are
     #  implemented, then these should be identical.
     assert allclose(np.mean(sim.data[p_a]),

--- a/nengo_loihi/tests/test_passthrough.py
+++ b/nengo_loihi/tests/test_passthrough.py
@@ -2,8 +2,11 @@ import pytest
 import nengo
 import numpy as np
 
-from nengo_loihi import splitter
 import nengo_loihi
+from nengo_loihi.builder import OnOffDecodeNeurons
+from nengo_loihi import splitter
+
+default_node_neurons = OnOffDecodeNeurons()
 
 
 def test_passthrough_placement():
@@ -28,9 +31,9 @@ def test_passthrough_placement():
     nengo_loihi.add_params(model)
     networks = splitter.split(model,
                               precompute=False,
-                              remove_passthrough=True,
-                              max_rate=1000,
-                              inter_tau=0.005)
+                              node_neurons=default_node_neurons,
+                              node_tau=0.005,
+                              remove_passthrough=True)
     chip = networks.chip
     host = networks.host
 
@@ -64,9 +67,9 @@ def test_transform_merging(d1, d2, d3):
     nengo_loihi.add_params(model)
     networks = splitter.split(model,
                               precompute=False,
-                              remove_passthrough=True,
-                              max_rate=1000,
-                              inter_tau=0.005)
+                              node_neurons=default_node_neurons,
+                              node_tau=0.005,
+                              remove_passthrough=True)
     chip = networks.chip
 
     assert len(chip.connections) == 1
@@ -85,9 +88,9 @@ def test_identity_array(n_ensembles, ens_dimensions):
     nengo_loihi.add_params(model)
     networks = splitter.split(model,
                               precompute=False,
-                              remove_passthrough=True,
-                              max_rate=1000,
-                              inter_tau=0.005)
+                              node_neurons=default_node_neurons,
+                              node_tau=0.005,
+                              remove_passthrough=True)
 
     # ignore the a.input -> a.ensemble connections
     connections = [c for c in networks.chip.connections
@@ -119,9 +122,9 @@ def test_full_array(n_ensembles, ens_dimensions):
     nengo_loihi.add_params(model)
     networks = splitter.split(model,
                               precompute=False,
-                              remove_passthrough=True,
-                              max_rate=1000,
-                              inter_tau=0.005)
+                              node_neurons=default_node_neurons,
+                              node_tau=0.005,
+                              remove_passthrough=True)
 
     # ignore the a.input -> a.ensemble connections
     connections = [c for c in networks.chip.connections
@@ -154,9 +157,9 @@ def test_synapse_merging(Simulator, seed):
     nengo_loihi.add_params(model)
     networks = splitter.split(model,
                               precompute=False,
-                              remove_passthrough=True,
-                              max_rate=1000,
-                              inter_tau=0.005)
+                              node_neurons=default_node_neurons,
+                              node_tau=0.005,
+                              remove_passthrough=True)
 
     # ignore the a.input -> a.ensemble connections
     connections = [c for c in networks.chip.connections


### PR DESCRIPTION
This helps to address #129.

Rather than using homogeneous interneurons with noise, this uses heterogeneous interneurons. However, they are designed so that they all use the same decoder, which means that the size of encoders in target populations can remain small (otherwise it would scale with the number of interneurons).

Based off #124.