### PR TITLE
Include snips directory when building dist

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,10 @@ Release history
 - An error is now raised if
   a learning rule is applied to a non-decoded connection.
 
+**Fixed**
+
+- Snips directory included when pip installing nengo-loihi.
+
 0.3.0 (September 28, 2018)
 ==========================
 

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,8 @@ setup(
     long_description=read("README.rst"),
     zip_safe=False,
     python_requires=">=3.4",
+    package_data = {"nengo_loihi": ["nengo_loihi/snips/*"]},
+    include_package_data = True,
     setup_requires=[
         "nengo",
     ],


### PR DESCRIPTION
The `snips` folder is included in our pypi release, but by default it doesn't get included in the installation when you actually `pip install nengo-loihi` (because it doesn't contain any python files).  This modifies `setup.py` to tell it to include the `snips` folder.