### PR TITLE
Communication refactoring

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -120,8 +120,8 @@ def allclose(request):
         return npext.rms(x) if x.size > 0 else np.nan
 
     def _allclose(a, b, rtol=1e-5, atol=1e-8, xtol=0,
-                  equal_nan=False, print_fail=True):
-        """Check for bounded equality of two arrays (mimicking np.allclose).
+                  equal_nan=False, print_fail=5):
+        """Check for bounded equality of two arrays (mimics ``np.allclose``).
 
         Parameters
         ----------
@@ -134,13 +134,13 @@ def allclose(request):
         atol : float
             Absolute tolerance between a and b
         xtol : int
-            Allow signals to be right or left shifted by up to *xtol*
+            Allow signals to be right or left shifted by up to ``xtol``
             indices along the first axis
         equal_nan : bool
             If True, nans will be considered equal to nans.
-        print_fail : bool
-            If True, print out the first 5 entries failing the allclose check
-            along the first axis.
+        print_fail : int
+            If > 0, print out the first ``print_fail`` entries failing
+            the allclose check along the first axis.
 
         Returns
         -------
@@ -178,13 +178,18 @@ def allclose(request):
 
         result = np.all(close)
 
-        if print_fail and not result:
+        if print_fail > 0 and not result:
             diffs = []
+            # broadcast a and b to have same shape as close for indexing
+            broadcast_a = a + np.zeros(b.shape, dtype=a.dtype)
+            broadcast_b = b + np.zeros(a.shape, dtype=b.dtype)
             for k, ind in enumerate(zip(*(~close).nonzero())):
-                diffs.append("%s: %s %s" % (ind, a[ind], b[ind]))
-                if k > 5:
+                diffs.append("%s: %s %s" % (
+                    ind, broadcast_a[ind], broadcast_b[ind]))
+                if k > print_fail:
                     break
-            print("allclose first 5 failures:\n  %s" % ("\n  ".join(diffs)))
+            print("allclose first %d failures:\n  %s" % (
+                print_fail, "\n  ".join(diffs)))
         return result
 
     return _allclose

--- a/nengo_loihi/builder.py
+++ b/nengo_loihi/builder.py
@@ -74,10 +74,7 @@ class Model(CxModel):
         Mapping from objects to the integer seed assigned to that object.
     """
     def __init__(self, dt=0.001, label=None, builder=None):
-        super(Model, self).__init__()
-
-        self.dt = dt
-        self.label = label
+        super(Model, self).__init__(dt=dt, label=label)
 
         self.objs = collections.defaultdict(dict)
         self.params = {}  # Holds data generated when building objects
@@ -113,9 +110,7 @@ class Model(CxModel):
         self.intercept_limit = 0.95
 
         # Will be provided by Simulator
-        self.chip2host_params = None
-        self.chip2host_receivers = None
-        self.host2chip_senders = None
+        self.chip2host_params = {}
 
     @property
     def inter_rate(self):
@@ -410,10 +405,10 @@ def build_relu(model, relu, neurons, group):
 @Builder.register(Node)
 def build_node(model, node):
     if isinstance(node, ChipReceiveNode):
-        cx_spiker = node.cx_spike_input
-        model.add_input(cx_spiker)
-        model.objs[node]['out'] = cx_spiker
-        return
+        spike_input = CxSpikeInput(node.raw_dimensions)
+        model.add_input(spike_input)
+        model.objs[node]['out'] = spike_input
+        node.cx_spike_input = spike_input
     else:
         raise NotImplementedError()
 

--- a/nengo_loihi/simulator.py
+++ b/nengo_loihi/simulator.py
@@ -331,8 +331,6 @@ class Simulator(object):
             network = self.networks.chip
 
             self.model.chip2host_params = self.networks.chip2host_params
-            self.model.chip2host_receivers = self.networks.chip2host_receivers
-            self.model.host2chip_senders = self.networks.host2chip_senders
 
             self.chip = self.networks.chip
             self.host = self.networks.host
@@ -450,16 +448,17 @@ class Simulator(object):
         self._probe_step_time()
 
         for probe in self.model.probes:
-            if probe in self.model.chip2host_params:
+            if probe in self.networks.chip2host_params:
                 continue
             assert probe.sample_every is None, (
                 "probe.sample_every not implemented")
             assert ("loihi" not in self.sims
                     or "emulator" not in self.sims)
+            cx_probe = self.model.objs[probe]['out']
             if "loihi" in self.sims:
-                data = self.sims["loihi"].get_probe_output(probe)
+                data = self.sims["loihi"].get_probe_output(cx_probe)
             elif "emulator" in self.sims:
-                data = self.sims["emulator"].get_probe_output(probe)
+                data = self.sims["emulator"].get_probe_output(cx_probe)
             # TODO: stop recomputing this all the time
             del self._probe_outputs[probe][:]
             self._probe_outputs[probe].extend(data)
@@ -529,6 +528,45 @@ class Simulator(object):
         """Advance the simulator by 1 step (``dt`` seconds)."""
         self.run_steps(1)
 
+    def _collect_receiver_info(self):
+        spikes = []
+        errors = {}
+        for sender, receiver in self.networks.host2chip_senders.items():
+            receiver.clear()
+            for t, x in sender.queue:
+                receiver.receive(t, x)
+            del sender.queue[:]
+
+            if hasattr(receiver, 'collect_spikes'):
+                for cx_spike_input, t, spike_idxs in receiver.collect_spikes():
+                    ti = round(t / self.model.dt)
+                    spikes.append((cx_spike_input, ti, spike_idxs))
+            if hasattr(receiver, 'collect_errors'):
+                for probe, t, e in receiver.collect_errors():
+                    conn = self.model.probe_conns[probe]
+                    synapses = self.model.objs[conn]['decoders']
+                    assert synapses.tracing
+                    ti = round(t / self.model.dt)
+                    errors_ti = errors.setdefault(ti, {})
+                    if synapses in errors_ti:
+                        errors_ti[synapses] += e
+                    else:
+                        errors_ti[synapses] = e.copy()
+
+        errors = [(synapses, ti, e) for ti, ee in errors.items()
+                  for synapses, e in ee.items()]
+        return spikes, errors
+
+    def _host2chip(self, sim):
+        spikes, errors = self._collect_receiver_info()
+        sim.host2chip(spikes, errors)
+
+    def _chip2host(self, sim):
+        probes_receivers = {  # map cx_probes to receivers
+            self.model.objs[probe]['out']: receiver
+            for probe, receiver in self.networks.chip2host_receivers.items()}
+        sim.chip2host(probes_receivers)
+
     def _make_run_steps(self):
         if self._run_steps is not None:
             return
@@ -548,9 +586,9 @@ class Simulator(object):
 
                 def emu_precomputed_host_pre_and_host(steps):
                     host_pre.run_steps(steps)
-                    emulator.host2chip()
+                    self._host2chip(emulator)
                     emulator.run_steps(steps)
-                    emulator.chip2host()
+                    self._chip2host(emulator)
                     host.run_steps(steps)
                 self._run_steps = emu_precomputed_host_pre_and_host
 
@@ -558,7 +596,7 @@ class Simulator(object):
 
                 def emu_precomputed_host_pre_only(steps):
                     host_pre.run_steps(steps)
-                    emulator.host2chip()
+                    self._host2chip(emulator)
                     emulator.run_steps(steps)
                 self._run_steps = emu_precomputed_host_pre_only
 
@@ -566,7 +604,7 @@ class Simulator(object):
 
                 def emu_precomputed_host_only(steps):
                     emulator.run_steps(steps)
-                    emulator.chip2host()
+                    self._chip2host(emulator)
                     host.run_steps(steps)
                 self._run_steps = emu_precomputed_host_only
 
@@ -579,9 +617,9 @@ class Simulator(object):
             def emu_bidirectional_with_host(steps):
                 for _ in range(steps):
                     host.step()
-                    emulator.host2chip()
+                    self._host2chip(emulator)
                     emulator.step()
-                    emulator.chip2host()
+                    self._chip2host(emulator)
             self._run_steps = emu_bidirectional_with_host
 
     def _make_loihi_run_steps(self):
@@ -594,9 +632,9 @@ class Simulator(object):
 
                 def loihi_precomputed_host_pre_and_host(steps):
                     host_pre.run_steps(steps)
-                    loihi.send_spikes()
+                    self._host2chip(loihi)
                     loihi.run_steps(steps, blocking=True)
-                    loihi.chip2host_precomputed()
+                    self._chip2host(loihi)
                     host.run_steps(steps)
                 self._run_steps = loihi_precomputed_host_pre_and_host
 
@@ -604,15 +642,15 @@ class Simulator(object):
 
                 def loihi_precomputed_host_pre_only(steps):
                     host_pre.run_steps(steps)
-                    loihi.send_spikes()
+                    self._host2chip(loihi)
                     loihi.run_steps(steps, blocking=True)
                 self._run_steps = loihi_precomputed_host_pre_only
 
             elif host is not None:
 
                 def loihi_precomputed_host_only(steps):
-                    loihi.run_steps(steps)
-                    loihi.chip2host_precomputed()
+                    loihi.run_steps(steps, blocking=True)
+                    self._chip2host(loihi)
                     host.run_steps(steps)
                 self._run_steps = loihi_precomputed_host_only
 
@@ -623,12 +661,11 @@ class Simulator(object):
             assert host is not None, "Model is precomputable"
 
             def loihi_bidirectional_with_host(steps):
-                loihi.create_io_snip()
                 loihi.run_steps(steps, blocking=False)
                 for _ in range(steps):
                     host.step()
-                    loihi.host2chip()
-                    loihi.chip2host()
+                    self._host2chip(loihi)
+                    self._chip2host(loihi)
                 logger.info("Waiting for run_steps to complete...")
                 loihi.wait_for_completion()
                 logger.info("run_steps completed")

--- a/nengo_loihi/tests/test_learning.py
+++ b/nengo_loihi/tests/test_learning.py
@@ -3,7 +3,6 @@ import numpy as np
 import pytest
 
 
-@pytest.mark.hang
 @pytest.mark.parametrize('n_per_dim', [120, 200])
 @pytest.mark.parametrize('dims', [1, 3])
 def test_pes_comm_channel(allclose, plt, seed, Simulator, n_per_dim, dims):

--- a/nengo_loihi/tests/test_learning.py
+++ b/nengo_loihi/tests/test_learning.py
@@ -59,7 +59,6 @@ def test_pes_comm_channel(allclose, plt, seed, Simulator, n_per_dim, dims):
     assert m_best > (0.3 if n_per_dim < 150 else 0.6)
 
 
-@pytest.mark.hang
 def test_multiple_pes(allclose, plt, seed, Simulator):
     n_errors = 5
     targets = np.linspace(-1, 1, n_errors)
@@ -91,4 +90,5 @@ def test_multiple_pes(allclose, plt, seed, Simulator):
         plt.axhline(target, **style)
 
     for i, target in enumerate(targets):
-        assert allclose(sim.data[probe][t > 0.8, i], target, atol=0.05)
+        assert allclose(sim.data[probe][t > 0.8, i], target,
+                        atol=0.05, rtol=0.05)

--- a/nengo_loihi/tests/test_testing.py
+++ b/nengo_loihi/tests/test_testing.py
@@ -26,7 +26,7 @@ def test_allclose(allclose, capsys):
                                        "  (0,): 0 1.0\n"
                                        "  (2,): 2 1.0\n"
                                        "  (3,): 3 1.0\n")
-    assert not allclose(np.arange(4), np.ones(4), print_fail=False)
+    assert not allclose(np.arange(4), np.ones(4), print_fail=0)
     assert capsys.readouterr().out == ""
-    assert allclose(np.arange(4), np.arange(4), print_fail=True)
+    assert allclose(np.arange(4), np.arange(4), print_fail=5)
     assert capsys.readouterr().out == ""


### PR DESCRIPTION
This refactors the host-to-chip and chip-to-host communication, so that LoihiSimulator and CxSimulator don't need to know anything about Nengo objects. This allows both simulators to work with general CxModels, making testing easier since we can create a custom CxModel and test it.

This is based off #121 and #133.