### PR TITLE
Learning matches Nengo learning more closely

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,13 @@ Release history
 0.5.0 (unreleased)
 ==================
 
+**Changed**
+
+- PES learning in Nengo Loihi more closely matches learning in core Nengo.
+  (`#139 <https://github.com/nengo/nengo-loihi/pull/139>`__)
+- Learning in the emulator more closely matches learning on hardware.
+  (`#139 <https://github.com/nengo/nengo-loihi/pull/139>`__)
+
 **Fixed**
 
 - We integrate current (U) and voltage (V) more accurately now by accounting

--- a/docs/examples/adaptive_motor_control.ipynb
+++ b/docs/examples/adaptive_motor_control.ipynb
@@ -427,9 +427,9 @@
    "source": [
     "## Running the network with Nengo Loihi\n",
     "\n",
-    "Loihi has some implicit gains included in it\n",
-    "so we use a learning rate of 1e-6 in Nengo Loihi,\n",
-    "instead of 1e-5, to match the performance of the standard Nengo backend."
+    "Loihi has limits on the magnitude of the \n",
+    "error signal, so we need to adjust the\n",
+    "`pes_error_scale` parameter to avoid too much overflow."
    ]
   },
   {
@@ -438,10 +438,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "adapt_loihi_model = add_adaptation(\n",
-    "    add_gravity(build_baseline_model()), learning_rate=1e-6)\n",
     "arm_sim.reset()\n",
-    "with nengo_loihi.Simulator(adapt_loihi_model) as sim:\n",
+    "\n",
+    "model = nengo_loihi.builder.Model()\n",
+    "model.pes_error_scale = 10\n",
+    "\n",
+    "with nengo_loihi.Simulator(adapt_model, model=model) as sim:\n",
     "    sim.run(runtime)\n",
     "adapt_loihi_t = sim.trange()\n",
     "adapt_loihi_data = sim.data"
@@ -453,10 +455,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "adapt_loihi_error = calculate_error(adapt_loihi_model, adapt_loihi_data)\n",
+    "adapt_loihi_error = calculate_error(adapt_model, adapt_loihi_data)\n",
     "plot_xy(\n",
     "    [adapt_loihi_t],\n",
-    "    [adapt_loihi_data[adapt_loihi_model.probe_hand]],\n",
+    "    [adapt_loihi_data[adapt_model.probe_hand]],\n",
     "    ['Adapt'])\n",
     "plot_data(\n",
     "    [baseline_t, gravity_t, adapt_t, adapt_loihi_t],\n",

--- a/nengo_loihi/allocators.py
+++ b/nengo_loihi/allocators.py
@@ -63,7 +63,7 @@ def core_stdp_pre_cfgs(core):
     profile_idxs = {}
     for synapses in core.synapses:
         if synapses.tracing:
-            mag_int, mag_frac = tracing_mag_int_frac(synapses)
+            mag_int, mag_frac = tracing_mag_int_frac(synapses.tracing_mag)
             tracecfg = TraceCfg(
                 tau=synapses.tracing_tau,
                 spikeLevelInt=mag_int,

--- a/nengo_loihi/config.py
+++ b/nengo_loihi/config.py
@@ -25,10 +25,10 @@ def add_params(network):
     """
     config = network.config
 
-    cfg = config[nengo.Ensemble]
-    if 'on_chip' not in cfg._extra_params:
-        cfg.set_param("on_chip",
-                      Parameter('on_chip', default=None, optional=True))
+    ens_cfg = config[nengo.Ensemble]
+    if 'on_chip' not in ens_cfg._extra_params:
+        ens_cfg.set_param("on_chip",
+                          Parameter('on_chip', default=None, optional=True))
 
 
 def set_defaults():

--- a/nengo_loihi/loihi_interface.py
+++ b/nengo_loihi/loihi_interface.py
@@ -137,9 +137,9 @@ def build_core(n2core, core):  # noqa: C901
             axons = np.array(core.synapse_axons[synapse])
             if synapse.tracing:
                 numStdp += len(axons)
-                assert np.all(len(axons) >= firstLearningIndex)
+                assert np.all(axons >= firstLearningIndex)
             else:
-                assert np.all(len(axons) < firstLearningIndex)
+                assert np.all(axons < firstLearningIndex)
 
     if numStdp > 0:
         logger.debug("- Configuring PES learning")

--- a/nengo_loihi/tests/test_learning.py
+++ b/nengo_loihi/tests/test_learning.py
@@ -1,14 +1,29 @@
 import nengo
+from nengo.exceptions import ValidationError, SimulationError
+from nengo.utils.numpy import rms
 import numpy as np
 import pytest
 
+import nengo_loihi.builder
 
-@pytest.mark.parametrize('n_per_dim', [120, 200])
-@pytest.mark.parametrize('dims', [1, 3])
-def test_pes_comm_channel(allclose, plt, seed, Simulator, n_per_dim, dims):
-    scale = np.linspace(1, 0, dims + 1)[:-1]
-    input_fn = lambda t: np.sin(t * 2 * np.pi) * scale
 
+def pes_network(
+        n_per_dim,
+        dims,
+        seed,
+        learning_rule_type=nengo.PES(learning_rate=1e-3),
+        input_scale=None,
+        error_scale=1.,
+        learn_synapse=0.005,
+        probe_synapse=0.02,
+):
+    if input_scale is None:
+        input_scale = np.linspace(1, 0, dims + 1)[:-1]
+    assert input_scale.size == dims
+
+    input_fn = lambda t: np.sin(t * 2 * np.pi) * input_scale
+
+    probes = {}
     with nengo.Network(seed=seed) as model:
         stim = nengo.Node(input_fn)
 
@@ -19,44 +34,150 @@ def test_pes_comm_channel(allclose, plt, seed, Simulator, n_per_dim, dims):
         conn = nengo.Connection(
             pre, post,
             function=lambda x: np.zeros(dims),
-            synapse=0.01,
-            learning_rule_type=nengo.PES(learning_rate=1e-3))
+            synapse=learn_synapse,
+            learning_rule_type=learning_rule_type)
 
-        nengo.Connection(post, conn.learning_rule)
-        nengo.Connection(stim, conn.learning_rule, transform=-1)
+        nengo.Connection(post, conn.learning_rule, transform=error_scale)
+        nengo.Connection(stim, conn.learning_rule, transform=-error_scale)
 
-        p_stim = nengo.Probe(stim, synapse=0.02)
-        p_pre = nengo.Probe(pre, synapse=0.02)
-        p_post = nengo.Probe(post, synapse=0.02)
+        probes['stim'] = nengo.Probe(stim, synapse=probe_synapse)
+        probes['pre'] = nengo.Probe(pre, synapse=probe_synapse)
+        probes['post'] = nengo.Probe(post, synapse=probe_synapse)
 
-    with Simulator(model) as sim:
-        sim.run(5.0)
+    return model, probes
 
-    t = sim.trange()
+
+@pytest.mark.parametrize('n_per_dim', [120, 200])
+@pytest.mark.parametrize('dims', [1, 3])
+def test_pes_comm_channel(allclose, plt, seed, Simulator, n_per_dim, dims):
+    tau = 0.01
+    model, probes = pes_network(n_per_dim, dims, seed, learn_synapse=tau)
+
+    simtime = 5.0
+    with nengo.Simulator(model) as nengo_sim:
+        nengo_sim.run(simtime)
+
+    with Simulator(model) as loihi_sim:
+        loihi_sim.run(simtime)
+
+    with Simulator(model, target='simreal') as real_sim:
+        real_sim.run(simtime)
+
+    t = nengo_sim.trange()
+    pre_tmask = t > 0.1
+    post_tmask = t > simtime - 1.0
+
+    inter_tau = loihi_sim.model.inter_tau
+    y = nengo_sim.data[probes['stim']]
+    y_dpre = nengo.Lowpass(inter_tau).filt(y)
+    y_dpost = nengo.Lowpass(tau).combine(nengo.Lowpass(inter_tau)).filt(y_dpre)
+    y_nengo = nengo_sim.data[probes['post']]
+    y_loihi = loihi_sim.data[probes['post']]
+    y_real = real_sim.data[probes['post']]
+
     plt.subplot(211)
-    plt.plot(t, sim.data[p_stim])
-    plt.plot(t, sim.data[p_pre])
-    plt.plot(t, sim.data[p_post])
-
-    # --- fit input_fn to output, determine magnitude
-    #     The larger the magnitude, the closer the output is to the input
-    x = np.array([input_fn(tt)[0] for tt in t[t > 4]])
-    y = sim.data[p_post][t > 4][:, 0]
-    m = np.linspace(0, 1, 21)
-    errors = np.abs(y - m[:, None]*x).mean(axis=1)
-    m_best = m[np.argmin(errors)]
+    plt.plot(t, y_dpost, 'k', label='target')
+    plt.plot(t, y_nengo, 'b', label='nengo')
+    plt.plot(t, y_loihi, 'g', label='loihi')
+    plt.plot(t, y_real, 'r:', label='real')
+    plt.legend()
 
     plt.subplot(212)
-    plt.plot(t[t > 4], x)
-    plt.plot(t[t > 4], y)
-    plt.plot(t[t > 4], m_best * x, ':')
+    plt.plot(t[post_tmask], y_loihi[post_tmask] - y_dpost[post_tmask], 'k')
+    plt.plot(t[post_tmask], y_loihi[post_tmask] - y_nengo[post_tmask], 'b')
 
-    assert allclose(sim.data[p_pre][t > 0.1],
-                    sim.data[p_stim][t > 0.1],
-                    atol=0.15,
-                    rtol=0.15)
-    assert np.min(errors) < 0.3, "Not able to fit correctly"
-    assert m_best > (0.3 if n_per_dim < 150 else 0.6)
+    x_loihi = loihi_sim.data[probes['pre']]
+    assert allclose(x_loihi[pre_tmask], y_dpre[pre_tmask],
+                    atol=0.1, rtol=0.05)
+
+    assert allclose(y_loihi[post_tmask], y_dpost[post_tmask],
+                    atol=0.1, rtol=0.05)
+    assert allclose(y_loihi, y_nengo, atol=0.2, rtol=0.2)
+
+    assert allclose(y_real[post_tmask], y_dpost[post_tmask],
+                    atol=0.1, rtol=0.05)
+    assert allclose(y_real, y_nengo, atol=0.2, rtol=0.2)
+
+
+def test_pes_overflow(allclose, plt, seed, Simulator):
+    dims = 3
+    n_per_dim = 120
+    tau = 0.01
+    model, probes = pes_network(n_per_dim, dims, seed, learn_synapse=tau,
+                                input_scale=np.linspace(1, 0.7, dims))
+
+    simtime = 3.0
+    loihi_model = nengo_loihi.builder.Model()
+    # set learning_wgt_exp low to create overflow in weight values
+    loihi_model.pes_wgt_exp = -1
+
+    with Simulator(model, model=loihi_model) as loihi_sim:
+        loihi_sim.run(simtime)
+
+    t = loihi_sim.trange()
+    post_tmask = t > simtime - 1.0
+
+    inter_tau = loihi_sim.model.inter_tau
+    y = loihi_sim.data[probes['stim']]
+    y_dpre = nengo.Lowpass(inter_tau).filt(y)
+    y_dpost = nengo.Lowpass(tau).combine(nengo.Lowpass(inter_tau)).filt(y_dpre)
+    y_loihi = loihi_sim.data[probes['post']]
+
+    plt.plot(t, y_dpost, 'k', label='target')
+    plt.plot(t, y_loihi, 'g', label='loihi')
+
+    # --- fit output to scaled version of target output
+    z_ref0 = y_dpost[post_tmask][:, 0]
+    z_loihi = y_loihi[post_tmask]
+    scale = np.linspace(0, 1, 50)
+    E = np.abs(z_loihi - scale[:, None, None]*z_ref0[:, None])
+    errors = E.mean(axis=1)  # average over time (errors is: scales x dims)
+    for j in range(dims):
+        errors_j = errors[:, j]
+        i = np.argmin(errors_j)
+        assert errors_j[i] < 0.1, ("Learning output for dim %d did not match "
+                                   "any scaled version of the target output"
+                                   % j)
+        assert scale[i] > 0.4, "Learning output for dim %d is too small" % j
+        assert scale[i] < 0.7, ("Learning output for dim %d is too large "
+                                "(weights or traces not clipping as expected)"
+                                % j)
+
+
+def test_pes_error_clip(allclose, plt, seed, Simulator):
+    dims = 2
+    n_per_dim = 120
+    tau = 0.01
+    error_scale = 5.  # scale up error signal so it clips
+    model, probes = pes_network(
+        n_per_dim, dims, seed, learn_synapse=tau,
+        learning_rule_type=nengo.PES(learning_rate=1e-3 / error_scale),
+        input_scale=np.array([1., -1.]),
+        error_scale=error_scale)
+
+    simtime = 3.0
+    with pytest.warns(UserWarning, match=r'.*PES error.*Clipping.'):
+        with Simulator(model) as loihi_sim:
+            loihi_sim.run(simtime)
+
+    t = loihi_sim.trange()
+    post_tmask = t > simtime - 1.0
+
+    inter_tau = loihi_sim.model.inter_tau
+    y = loihi_sim.data[probes['stim']]
+    y_dpre = nengo.Lowpass(inter_tau).filt(y)
+    y_dpost = nengo.Lowpass(tau).combine(nengo.Lowpass(inter_tau)).filt(y_dpre)
+    y_loihi = loihi_sim.data[probes['post']]
+
+    plt.plot(t, y_dpost, 'k', label='target')
+    plt.plot(t, y_loihi, 'g', label='loihi')
+
+    # --- assert that we've learned something, but not everything
+    error = (rms(y_loihi[post_tmask] - y_dpost[post_tmask])
+             / rms(y_dpost[post_tmask]))
+    assert error < 0.5
+    assert error > 0.05
+    # ^ error on emulator vs chip is quite different, hence large tolerances
 
 
 @pytest.mark.parametrize('init_function', [None, lambda x: 0])
@@ -74,19 +195,65 @@ def test_multiple_pes(init_function, allclose, plt, seed, Simulator):
                 pre_ea.ea_ensembles[i],
                 output[i],
                 function=init_function,
-                learning_rule_type=nengo.PES(learning_rate=5e-4),
+                learning_rule_type=nengo.PES(learning_rate=3e-3),
             )
             nengo.Connection(target[i], conn.learning_rule, transform=-1)
             nengo.Connection(output[i], conn.learning_rule)
 
         probe = nengo.Probe(output, synapse=0.1)
+
+    simtime = 2.5
     with Simulator(model) as sim:
-        sim.run(1.0)
+        sim.run(simtime)
+
     t = sim.trange()
+    tmask = t > simtime * 0.85
 
     plt.plot(t, sim.data[probe])
     for target, style in zip(targets, plt.rcParams["axes.prop_cycle"]):
         plt.axhline(target, **style)
 
     for i, target in enumerate(targets):
-        assert allclose(sim.data[probe][t > 0.8, i], target, atol=0.1)
+        assert allclose(sim.data[probe][tmask, i], target,
+                        atol=0.05, rtol=0.05), "Target %d not close" % i
+
+
+def test_pes_pre_synapse_type_error(Simulator):
+    with nengo.Network() as model:
+        pre = nengo.Ensemble(10, 1)
+        post = nengo.Node(size_in=1)
+        rule_type = nengo.PES(pre_synapse=nengo.Alpha(0.005))
+        conn = nengo.Connection(pre, post, learning_rule_type=rule_type)
+        nengo.Connection(post, conn.learning_rule)
+
+    with pytest.raises(ValidationError):
+        with Simulator(model):
+            pass
+
+
+def test_pes_trace_increment_clip_warning(seed, Simulator):
+    dims = 2
+    n_per_dim = 120
+    model, _ = pes_network(
+        n_per_dim, dims, seed,
+        learning_rule_type=nengo.PES(learning_rate=1e-1))
+
+    with pytest.warns(UserWarning, match="Trace increment exceeds upper"):
+        with Simulator(model):
+            pass
+
+
+def test_drop_trace_spikes(Simulator, seed):
+    with nengo.Network(seed=seed) as net:
+        a = nengo.Ensemble(10, 1, gain=nengo.dists.Choice([1]),
+                           bias=nengo.dists.Choice([2000]),
+                           neuron_type=nengo.SpikingRectifiedLinear())
+        b = nengo.Node(size_in=1)
+
+        conn = nengo.Connection(a, b, learning_rule_type=nengo.PES(1))
+
+        nengo.Connection(b, conn.learning_rule)
+
+    with Simulator(net, target="sim") as sim:
+        with pytest.raises(SimulationError):
+            sim.run(1.0)

--- a/nengo_loihi/tests/test_learning.py
+++ b/nengo_loihi/tests/test_learning.py
@@ -59,7 +59,8 @@ def test_pes_comm_channel(allclose, plt, seed, Simulator, n_per_dim, dims):
     assert m_best > (0.3 if n_per_dim < 150 else 0.6)
 
 
-def test_multiple_pes(allclose, plt, seed, Simulator):
+@pytest.mark.parametrize('init_function', [None, lambda x: 0])
+def test_multiple_pes(init_function, allclose, plt, seed, Simulator):
     n_errors = 5
     targets = np.linspace(-0.9, 0.9, n_errors)
     with nengo.Network(seed=seed) as model:
@@ -72,6 +73,7 @@ def test_multiple_pes(allclose, plt, seed, Simulator):
             conn = nengo.Connection(
                 pre_ea.ea_ensembles[i],
                 output[i],
+                function=init_function,
                 learning_rule_type=nengo.PES(learning_rate=5e-4),
             )
             nengo.Connection(target[i], conn.learning_rule, transform=-1)

--- a/nengo_loihi/tests/test_loihi_api.py
+++ b/nengo_loihi/tests/test_loihi_api.py
@@ -2,8 +2,8 @@ from nengo.utils.numpy import rms
 import numpy as np
 import pytest
 
-from nengo_loihi.loihi_api import overflow_signed
-from nengo_loihi.loihi_api import decay_int, decay_magnitude
+from nengo_loihi.loihi_api import (
+    overflow_signed, decay_int, decay_magnitude, SynapseFmt)
 
 
 @pytest.mark.parametrize("b", (8, 16, 17, 23))
@@ -87,3 +87,17 @@ def test_decay_magnitude(offset, plt, logger):
     plt.plot(relative_diff.clip(0, None))
 
     assert np.all(relative_diff < 1e-6)
+
+
+@pytest.mark.parametrize("lossy_shift", (True, False))
+def test_lossy_shift(lossy_shift, rng):
+    wgt_bits = 6
+    w = rng.uniform(-100, 100, size=(10, 10))
+    fmt = SynapseFmt(wgtBits=wgt_bits, wgtExp=0, fanoutType=0)
+
+    w2 = fmt.discretize_weights(w, lossy_shift=lossy_shift)
+
+    clipped = np.round(w / 4).clip(-2 ** wgt_bits, 2 ** wgt_bits).astype(
+        np.int32)
+
+    assert np.allclose(w2, np.left_shift(clipped, 8))


### PR DESCRIPTION
This improves both the match between emulator and Loihi learning, and emulator and Nengo learning. The result is that everything matches Nengo better.

Based off of #137. Replaces #98.

TODO: I haven't tested this in extreme cases where we actually see overflow in the weights. I think some of these cases were referenced in #98. I (or someone) should look at these cases.