### PR TITLE
nengo_dl builders for Loihi neurons

### DIFF
--- a/.ci/emulator.sh
+++ b/.ci/emulator.sh
@@ -11,7 +11,7 @@ NAME=$0
 COMMAND=$1
 
 if [[ "$COMMAND" == "install" ]]; then
-    exe conda install --quiet matplotlib mkl numpy scipy tensorflow
+    conda install --quiet mkl numpy
     exe pip install nengo-dl
     exe pip install -e ".[tests]"
     exe pip install "$NENGO_VERSION"

--- a/.ci/hardware.sh
+++ b/.ci/hardware.sh
@@ -25,6 +25,7 @@ elif [[ "$COMMAND" == "script" ]]; then
         cd /tmp/nengo-loihi-$TRAVIS_JOB_NUMBER
         conda create -y -n travis-ci-$TRAVIS_JOB_NUMBER python=3.5.2 scipy
         source activate travis-ci-$TRAVIS_JOB_NUMBER
+        pip install nengo-dl
         pip install -e .[tests]
         pip install $NENGO_VERSION
         pip install ~/travis-ci/nxsdk-0.8.0.tar.gz

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,9 @@ Release history
   emulator. Previously, the emulator did not allow very small exponents, and
   such exponents produced noise with the wrong magnitude on the chip.
   (`#185 <https://github.com/nengo/nengo-loihi/pull/185>`__)
+- Models trained using NengoDL use tuning curves more similar to those
+  of neuron on the chip, improving the accuracy of these model.
+  (`#140 <https://github.com/nengo/nengo-loihi/pull/140>`__)
 
 **Fixed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,10 @@ Release history
   nengo core (and therefore any randomly generated parameters, such as
   ensemble encoders, will be generated in the same way).
   (`#70 <https://github.com/nengo/nengo-loihi/pull/70>`_)
+- Seeded networks that have learning are now deterministic on both
+  emulator and hardware.
+  (`#140 <https://github.com/nengo/nengo-loihi/pull/140>`__)
+
 
 0.5.0 (February 12, 2019)
 =========================

--- a/nengo_loihi/block.py
+++ b/nengo_loihi/block.py
@@ -5,7 +5,7 @@ from nengo.exceptions import BuildError
 import numpy as np
 
 
-class LoihiBlock(object):
+class LoihiBlock:
     """Class holding Loihi objects that can be placed on the chip.
 
     This class can be thought of as a block of the Loihi board, and is how
@@ -63,7 +63,7 @@ class LoihiBlock(object):
         self.probes.append(probe)
 
 
-class Profile(object):
+class Profile:
     def __eq__(self, obj):
         return isinstance(obj, type(self)) and all(
             self.__dict__[key] == obj.__dict__[key] for key in self.params)
@@ -72,7 +72,7 @@ class Profile(object):
         return hash(tuple(self.__dict__[key] for key in self.params))
 
 
-class Compartment(object):
+class Compartment:
     """Stores information for configuring Loihi compartments.
 
     The information stored here will be associated with some block,
@@ -271,7 +271,7 @@ class Compartment(object):
         self.scaleV = False
 
 
-class Axon(object):
+class Axon:
     """A group of axons targeting a specific Synapse object.
 
     Attributes
@@ -286,7 +286,7 @@ class Axon(object):
         Target synapses for these axons.
     """
 
-    class Spike(object):
+    class Spike:
         """A spike targeting a particular axon within a Synapse object.
 
         The Synapse target is implicit, given by the Axon object that
@@ -452,7 +452,7 @@ class SynapseFmt(Profile):
             setattr(self, key, value)
 
 
-class Synapse(object):
+class Synapse:
     """A group of Loihi synapses that share some properties.
 
     Attributes
@@ -642,7 +642,7 @@ class Synapse(object):
         return sum(w.size for w in self.weights)
 
 
-class Probe(object):
+class Probe:
     _slice = slice
 
     def __init__(self, target=None, key=None, slice=None, weights=None,

--- a/nengo_loihi/builder/builder.py
+++ b/nengo_loihi/builder/builder.py
@@ -16,7 +16,7 @@ from nengo_loihi.inputs import LoihiInput
 logger = logging.getLogger(__name__)
 
 
-class Model(object):
+class Model:
     """The data structure for the emulator/hardware simulator.
 
     Defines methods for adding inputs and blocks. Also handles build

--- a/nengo_loihi/builder/nengo_dl.py
+++ b/nengo_loihi/builder/nengo_dl.py
@@ -1,0 +1,367 @@
+import logging
+import warnings
+
+import numpy as np
+
+from nengo_loihi.compat import HAS_DL
+from nengo_loihi.neurons import (
+    AlphaRCNoise,
+    discretize_tau_rc,
+    discretize_tau_ref,
+    LoihiLIF,
+    LoihiSpikingRectifiedLinear,
+    LowpassRCNoise,
+)
+
+if HAS_DL:
+    import nengo_dl
+    import nengo_dl.neuron_builders
+    import tensorflow as tf
+else:
+    # Empty classes so that we can define the subclasses even though
+    # we will never use them, as they are only used in the `install`
+    # function that can only run if nengo_dl is importable.
+    class nengo_dl:
+        class neuron_builders:
+            class LIFBuilder:
+                pass
+
+            class SpikingRectifiedLinearBuilder:
+                pass
+
+logger = logging.getLogger(__name__)
+
+
+class NoiseBuilder:
+    """Build noise classes in ``nengo_dl``.
+
+    Attributes
+    ----------
+    noise_models : list of NeuronOutputNoise
+        The noise models used for each op/signal.
+    """
+
+    builders = {}
+
+    def __init__(self, ops, signals, config, noise_models):
+        self.noise_models = noise_models
+        self.dtype = signals.dtype
+        self.np_dtype = self.dtype.as_numpy_dtype()
+
+    @classmethod
+    def build(cls, ops, signals, config):
+        """Create a NoiseBuilder for the provided ops."""
+
+        noise_models = [getattr(op.neurons, 'nengo_dl_noise', None)
+                        for op in ops]
+        model_type = (type(noise_models[0]) if len(noise_models) > 0
+                      else None)
+        equal_types = all(type(m) is model_type for m in noise_models)
+
+        if not equal_types:
+            raise NotImplementedError(
+                "Multiple noise models for the same neuron type is "
+                "not supported")
+
+        return cls.builders[model_type](ops, signals, config, noise_models)
+
+    @classmethod
+    def register(cls, noise_builder):
+        """A decorator for adding a class to the list of builders.
+
+        Raises a warning if a builder already exists for the class.
+
+        Parameters
+        ----------
+        noise_builder : NoiseBuilder
+            The NoiseBuilder subclass that the decorated class builds.
+        """
+        def register_builder(build_cls):
+            if noise_builder in cls.builders:
+                warnings.warn("Type '%s' already has a builder. Overwriting."
+                              % noise_builder)
+            cls.builders[noise_builder] = build_cls
+            return build_cls
+        return register_builder
+
+    def generate(self, period, tau_rc=None):
+        """Generate TensorFlow code to implement these noise models.
+
+        Parameters
+        ----------
+        period : tf.Tensor
+            The inter-spike periods of the neurons to add noise to.
+        tau_rc : tf.Tensor
+            The membrane time constant of the neurons (used by some noise
+            models).
+        """
+        raise NotImplementedError("Subclass must implement")
+
+
+@NoiseBuilder.register(type(None))
+class NoNoiseBuilder(NoiseBuilder):
+    """nengo_dl builder for if there is no noise model."""
+
+    def generate(self, period, tau_rc=None):
+        return tf.reciprocal(period)
+
+
+@NoiseBuilder.register(LowpassRCNoise)
+class LowpassRCNoiseBuilder(NoiseBuilder):
+    """nengo_dl builder for the LowpassRCNoise model."""
+
+    def __init__(self, ops, signals, *args, **kwargs):
+        super(LowpassRCNoiseBuilder, self).__init__(
+            ops, signals, *args, **kwargs)
+
+        # tau_s is the time constant of the synaptic filter
+        tau_s = np.concatenate([
+            model.tau_s * np.ones((op.J.shape[0], 1),
+                                  dtype=self.np_dtype)
+            for model, op in zip(self.noise_models, ops)])
+        self.tau_s = signals.constant(tau_s, dtype=self.dtype)
+
+    def generate(self, period, tau_rc=None):
+        d = tau_rc - self.tau_s
+        u01 = tf.random_uniform(tf.shape(period))
+        t = u01 * period
+        q_rc = tf.exp(-t / tau_rc)
+        q_s = tf.exp(-t / self.tau_s)
+        r_rc1 = -tf.expm1(-period / tau_rc)  # 1 - exp(-period/tau_rc)
+        r_s1 = -tf.expm1(-period / self.tau_s)  # 1 - exp(-period/tau_s)
+        return (1./d) * (q_rc/r_rc1 - q_s/r_s1)
+
+
+@NoiseBuilder.register(AlphaRCNoise)
+class AlphaRCNoiseBuilder(NoiseBuilder):
+    """nengo_dl builder for the AlphaRCNoise model."""
+
+    def __init__(self, ops, signals, *args, **kwargs):
+        super(AlphaRCNoiseBuilder, self).__init__(
+            ops, signals, *args, **kwargs)
+
+        # tau_s is the time constant of the synaptic filter
+        tau_s = np.concatenate([
+            model.tau_s * np.ones((op.J.shape[0], 1),
+                                  dtype=self.np_dtype)
+            for model, op in zip(self.noise_models, ops)])
+        self.tau_s = signals.constant(tau_s, dtype=self.dtype)
+
+    def generate(self, period, tau_rc=None):
+        d = tau_rc - self.tau_s
+        u01 = tf.random_uniform(tf.shape(period))
+        t = u01 * period
+        q_rc = tf.exp(-t / tau_rc)
+        q_s = tf.exp(-t / self.tau_s)
+        r_rc1 = -tf.expm1(-period / tau_rc)  # 1 - exp(-period/tau_rc)
+        r_s1 = -tf.expm1(-period / self.tau_s)  # 1 - exp(-period/tau_s)
+
+        pt = tf.where(period < 100*self.tau_s, (period - t)*(1 - r_s1),
+                      tf.zeros_like(period))
+        qt = tf.where(t < 100*self.tau_s, q_s*(t + pt), tf.zeros_like(t))
+        rt = qt / (self.tau_s * d * r_s1**2)
+        rn = tau_rc*(q_rc/(d*d*r_rc1) - q_s/(d*d*r_s1)) - rt
+        return rn
+
+
+class LoihiLIFBuilder(nengo_dl.neuron_builders.LIFBuilder):
+    """nengo_dl builder for the LoihiLIF neuron type.
+
+    Attributes
+    ----------
+    spike_noise : NoiseBuilder
+        Generator for any output noise associated with these neurons.
+    """
+    def __init__(self, ops, signals, config):
+        super(LoihiLIFBuilder, self).__init__(ops, signals, config)
+        self.spike_noise = NoiseBuilder.build(ops, signals, config)
+
+    def _rate_step(self, J, dt):
+        tau_ref = discretize_tau_ref(self.tau_ref, dt)
+        tau_rc = discretize_tau_rc(self.tau_rc, dt)
+        # Since LoihiLIF takes `ceil(period/dt)` the firing rate is
+        # always below the LIF rate. Using `tau_ref1` in LIF curve makes
+        # it the average of the LoihiLIF curve (rather than upper bound).
+        tau_ref1 = tau_ref + 0.5*dt
+
+        J -= self.one
+
+        # --- compute Loihi rates (for forward pass)
+        period = tau_ref + tau_rc*tf.log1p(tf.reciprocal(
+            tf.maximum(J, self.epsilon)))
+        period = dt * tf.ceil(period / dt)
+        loihi_rates = self.spike_noise.generate(period, tau_rc=tau_rc)
+        loihi_rates = tf.where(J > self.zero,
+                               self.amplitude * loihi_rates,
+                               self.zeros)
+
+        # --- compute LIF rates (for backward pass)
+        if self.config.lif_smoothing:
+            js = J / self.sigma
+            j_valid = js > -20
+            js_safe = tf.where(j_valid, js, self.zeros)
+
+            # softplus(js) = log(1 + e^js)
+            z = tf.nn.softplus(js_safe) * self.sigma
+
+            # as z->0
+            #   z = s*log(1 + e^js) = s*e^js
+            #   log(1 + 1/z) = log(1/z) = -log(s*e^js) = -js - log(s)
+            q = tf.where(j_valid,
+                         tf.log1p(tf.reciprocal(z)),
+                         -js - tf.log(self.sigma))
+
+            rates = self.amplitude / (tau_ref1 + tau_rc*q)
+        else:
+            rates = self.amplitude / (
+                tau_ref1 + tau_rc*tf.log1p(tf.reciprocal(
+                    tf.maximum(J, self.epsilon))))
+            rates = tf.where(J > self.zero, rates, self.zeros)
+
+        # rates + stop_gradient(loihi_rates - rates) =
+        #     loihi_rates on forward pass, rates on backwards
+        return rates + tf.stop_gradient(loihi_rates - rates)
+
+    def _step(self, J, voltage, refractory, dt):
+        tau_ref = discretize_tau_ref(self.tau_ref, dt)
+        tau_rc = discretize_tau_rc(self.tau_rc, dt)
+
+        delta_t = tf.clip_by_value(dt - refractory, self.zero, dt)
+        voltage -= (J - voltage) * tf.expm1(-delta_t / tau_rc)
+
+        spiked = voltage > self.one
+        spikes = tf.cast(spiked, J.dtype) * self.alpha
+
+        refractory = tf.where(spiked,
+                              tau_ref + self.zeros,
+                              refractory - dt)
+        voltage = tf.where(spiked,
+                           self.zeros,
+                           tf.maximum(voltage, self.min_voltage))
+
+        # we use stop_gradient to avoid propagating any nans (those get
+        # propagated through the cond even if the spiking version isn't
+        # being used at all)
+        return (tf.stop_gradient(spikes), tf.stop_gradient(voltage),
+                tf.stop_gradient(refractory))
+
+    def build_step(self, signals):
+        J = signals.gather(self.J_data)
+        voltage = signals.gather(self.voltage_data)
+        refractory = signals.gather(self.refractory_data)
+
+        spike_out, spike_voltage, spike_ref = self._step(
+            J, voltage, refractory, signals.dt)
+
+        if self.config.inference_only:
+            spikes, voltage, refractory = (
+                spike_out, spike_voltage, spike_ref)
+        else:
+            rate_out = self._rate_step(J, signals.dt)
+
+            spikes, voltage, refractory = tf.cond(
+                signals.training,
+                lambda: (rate_out, voltage, refractory),
+                lambda: (spike_out, spike_voltage, spike_ref)
+            )
+
+        signals.scatter(self.output_data, spikes)
+        signals.mark_gather(self.J_data)
+        signals.scatter(self.refractory_data, refractory)
+        signals.scatter(self.voltage_data, voltage)
+
+
+class LoihiSpikingRectifiedLinearBuilder(
+        nengo_dl.neuron_builders.SpikingRectifiedLinearBuilder):
+    """nengo_dl builder for the LoihiSpikingRectifiedLinear neuron type.
+    """
+
+    def __init__(self, ops, signals, config):
+        super(LoihiSpikingRectifiedLinearBuilder, self).__init__(
+            ops, signals, config)
+
+        self.amplitude = signals.op_constant(
+            [op.neurons for op in ops], [op.J.shape[0] for op in ops],
+            "amplitude", signals.dtype)
+
+        self.zeros = tf.zeros(
+            self.J_data.shape + (signals.minibatch_size,),
+            signals.dtype)
+
+        self.epsilon = tf.constant(1e-15, dtype=signals.dtype)
+
+        # copy these so that they're easily accessible in _step functions
+        self.zero = signals.zero
+        self.one = signals.one
+
+    def _rate_step(self, J, dt):
+        # Since LoihiLIF takes `ceil(period/dt)` the firing rate is
+        # always below the LIF rate. Using `tau_ref1` in LIF curve makes
+        # it the average of the LoihiLIF curve (rather than upper bound).
+        tau_ref1 = 0.5*dt
+
+        # --- compute Loihi rates (for forward pass)
+        period = tf.reciprocal(tf.maximum(J, self.epsilon))
+        loihi_rates = self.alpha / tf.ceil(period / dt)
+        loihi_rates = tf.where(J > self.zero, loihi_rates, self.zeros)
+
+        # --- compute RectifiedLinear rates (for backward pass)
+        rates = self.amplitude / (
+            tau_ref1 + tf.reciprocal(tf.maximum(J, self.epsilon)))
+        rates = tf.where(J > self.zero, rates, self.zeros)
+
+        # rates + stop_gradient(loihi_rates - rates) =
+        #     loihi_rates on forward pass, rates on backwards
+        return rates + tf.stop_gradient(loihi_rates - rates)
+
+    def _step(self, J, voltage, dt):
+        voltage += J * dt
+        spiked = voltage > self.one
+        spikes = tf.cast(spiked, J.dtype) * self.alpha
+        voltage = tf.where(spiked, self.zeros, tf.maximum(voltage, 0))
+
+        # we use stop_gradient to avoid propagating any nans (those get
+        # propagated through the cond even if the spiking version isn't
+        # being used at all)
+        return tf.stop_gradient(spikes), tf.stop_gradient(voltage)
+
+    def build_step(self, signals):
+        J = signals.gather(self.J_data)
+        voltage = signals.gather(self.voltage_data)
+
+        spike_out, spike_voltage = self._step(J, voltage, signals.dt)
+
+        if self.config.inference_only:
+            out, voltage = spike_out, spike_voltage
+        else:
+            rate_out = self._rate_step(J, signals.dt)
+
+            out, voltage = tf.cond(
+                signals.training,
+                lambda: (rate_out, voltage),
+                lambda: (spike_out, spike_voltage))
+
+        signals.scatter(self.output_data, out)
+        signals.scatter(self.voltage_data, voltage)
+
+
+class Installer:
+    def __init__(self):
+        self.installed = False
+
+    def __call__(self):
+        if not HAS_DL:
+            warnings.warn("nengo_dl cannot be imported")
+        elif not self.installed:
+            logger.debug("Installing NengoDL neuron builders")
+            nengo_dl.neuron_builders.SimNeuronsBuilder.TF_NEURON_IMPL[
+                LoihiLIF] = LoihiLIFBuilder
+            nengo_dl.neuron_builders.SimNeuronsBuilder.TF_NEURON_IMPL[
+                LoihiSpikingRectifiedLinear] = (
+                    LoihiSpikingRectifiedLinearBuilder)
+            self.installed = True
+        else:
+            logger.debug("NengoDL neuron builders already installed")
+
+
+install_dl_builders = Installer()

--- a/nengo_loihi/builder/probe.py
+++ b/nengo_loihi/builder/probe.py
@@ -19,9 +19,12 @@ def conn_probe(model, nengo_probe):
     # get any extra arguments if this probe was created to send data
     #  to an off-chip Node via the splitter
 
+    conn_label = (None if nengo_probe.label is None
+                  else "%s_conn" % nengo_probe.label)
     kwargs = model.chip2host_params.get(nengo_probe, None)
     if kwargs is not None:
         # this probe is for sending data to a Node
+        kwargs.setdefault('label', conn_label)
 
         # determine the dimensionality
         input_dim = nengo_probe.target.size_out
@@ -43,15 +46,24 @@ def conn_probe(model, nengo_probe):
 
         target = nengo.Node(size_in=output_dim, add_to_container=False)
 
-        conn = Connection(nengo_probe.target, target, synapse=synapse,
-                          solver=nengo_probe.solver, add_to_container=False,
-                          **kwargs
-                          )
+        conn = Connection(
+            nengo_probe.target,
+            target,
+            synapse=synapse,
+            solver=nengo_probe.solver,
+            add_to_container=False,
+            **kwargs
+        )
         model.probe_conns[nengo_probe] = conn
     else:
-        conn = Connection(nengo_probe.target, nengo_probe, synapse=synapse,
-                          solver=nengo_probe.solver, add_to_container=False,
-                          )
+        conn = Connection(
+            nengo_probe.target,
+            nengo_probe,
+            synapse=synapse,
+            solver=nengo_probe.solver,
+            add_to_container=False,
+            label=conn_label,
+        )
         target = nengo_probe
 
     # Set connection's seed to probe's (which isn't used elsewhere)

--- a/nengo_loihi/builder/tests/test_nengo_dl.py
+++ b/nengo_loihi/builder/tests/test_nengo_dl.py
@@ -1,0 +1,43 @@
+import logging
+
+import pytest
+
+from nengo_loihi.builder import nengo_dl as builder_nengo_dl
+
+
+def test_installer_with_no_dl(monkeypatch):
+    """Ensures that the installer works as expected with no Nengo DL.
+
+    If Nengo DL is installed, other tests will test the installer as
+    it is used in ``Simulator.__init__``.
+    """
+    monkeypatch.setattr(builder_nengo_dl, "HAS_DL", False)
+    install = builder_nengo_dl.Installer()
+    with pytest.warns(UserWarning, match="nengo_dl cannot be imported"):
+        install()
+
+
+def test_installer_called_twice(caplog, monkeypatch):
+    """Ensures that the installer prints debug messages when called twice."""
+    monkeypatch.setattr(builder_nengo_dl, "HAS_DL", True)
+    install = builder_nengo_dl.Installer()
+    install.installed = True
+    with caplog.at_level(logging.DEBUG):
+        install()
+    assert [rec.message for rec in caplog.records] == [
+        "NengoDL neuron builders already installed",
+    ]
+
+
+def test_register_twice_warning():
+    class MockNoiseBuilder:
+        pass
+
+    # First time does not warn
+    with pytest.warns(None) as record:
+        builder_nengo_dl.NoiseBuilder.register(int)(MockNoiseBuilder)
+    assert len(record) == 0
+
+    # Second time warns
+    with pytest.warns(UserWarning, match="already has a builder"):
+        builder_nengo_dl.NoiseBuilder.register(int)(MockNoiseBuilder)

--- a/nengo_loihi/compat.py
+++ b/nengo_loihi/compat.py
@@ -1,7 +1,11 @@
 from distutils.version import LooseVersion
+import logging
 
 import nengo
 import numpy as np
+
+logger = logging.getLogger(__name__)
+
 
 if LooseVersion(nengo.__version__) > LooseVersion('2.8.0'):
     from nengo.builder.network import seed_network
@@ -42,3 +46,20 @@ else:
         # nengo <= 2.8.0 will overwrite any seeds set on the model, so no
         # point doing anything in this function
         pass
+
+try:
+    import tensorflow as tf
+    HAS_TF = True
+except ImportError as err:  # pragma: no cover
+    tf = None
+    HAS_TF = False
+    logger.debug("Error importing TensorFlow:\n%s", err)
+
+try:
+    import nengo_dl
+    HAS_DL = True
+    assert HAS_TF, "NengoDL installed without Tensorflow"
+except ImportError as err:  # pragma: no cover
+    nengo_dl = None
+    HAS_DL = False
+    logger.debug("Error importing Nengo DL:\n%s", err)

--- a/nengo_loihi/decode_neurons.py
+++ b/nengo_loihi/decode_neurons.py
@@ -5,7 +5,7 @@ from nengo_loihi.block import LoihiBlock, Synapse
 from nengo_loihi.neurons import LoihiSpikingRectifiedLinear
 
 
-class DecodeNeurons(object):
+class DecodeNeurons:
     """Defines parameters for a group of decode neurons.
 
     DecodeNeurons are used on the chip to facilitate NEF-style connections,

--- a/nengo_loihi/emulator/interface.py
+++ b/nengo_loihi/emulator/interface.py
@@ -24,7 +24,7 @@ from nengo_loihi.validate import validate_model
 logger = logging.getLogger(__name__)
 
 
-class EmulatorInterface(object):
+class EmulatorInterface:
     """Software emulator for Loihi chip behaviour.
 
     Parameters
@@ -123,7 +123,7 @@ class EmulatorInterface(object):
         return self.probes[probe]
 
 
-class BlockInfo(object):
+class BlockInfo:
     """Provide information about all the LoihiBlocks in the model.
 
     Attributes
@@ -162,7 +162,7 @@ class BlockInfo(object):
         return self.blocks[0].compartment.vth.dtype
 
 
-class IterableState(object):
+class IterableState:
     """Base class for aspects of the emulator state.
 
     This class takes the name of a LoihiBlock attribute as the
@@ -551,7 +551,7 @@ class AxonState(IterableState):
         super(AxonState, self).__init__(block_info, "axons")
 
 
-class ProbeState(object):
+class ProbeState:
     """State representing all probes.
 
     Attributes

--- a/nengo_loihi/emulator/interface.py
+++ b/nengo_loihi/emulator/interface.py
@@ -1,7 +1,6 @@
 from __future__ import division
 
-import collections
-from collections import OrderedDict
+from collections import defaultdict, OrderedDict
 import logging
 import warnings
 
@@ -144,7 +143,7 @@ class BlockInfo(object):
 
     def __init__(self, blocks):
         self.blocks = list(blocks)
-        self.slices = {}
+        self.slices = OrderedDict()
 
         assert self.dtype in (np.float32, np.int32)
 
@@ -193,9 +192,10 @@ class IterableState(object):
 
         blocks_items = list(
             self._blocks_items(block_info.blocks, block_key))
-        self.block_map = {item: block for block, item in blocks_items}
-        self.slices = {item: block_info.slices[block]
-                       for block, item in blocks_items}
+        self.block_map = OrderedDict(
+            (item, block) for block, item in blocks_items)
+        self.slices = OrderedDict(
+            (item, block_info.slices[block]) for block, item in blocks_items)
 
     @staticmethod
     def _blocks_items(blocks, block_key):
@@ -409,10 +409,10 @@ class SynapseState(IterableState):
 
         self.pes_error_scale = pes_error_scale
 
-        self.spikes_in = {}
-        self.traces = {}
-        self.trace_spikes = {}
-        self.pes_errors = {}
+        self.spikes_in = OrderedDict()
+        self.traces = OrderedDict()
+        self.trace_spikes = OrderedDict()
+        self.pes_errors = OrderedDict()
         for synapse in self.slices:
             n = synapse.n_axons
             self.spikes_in[synapse] = []
@@ -594,7 +594,7 @@ class ProbeState(object):
                 )
                 self.filter_pos[probe] = 0
 
-        self.outputs = collections.defaultdict(list)
+        self.outputs = defaultdict(list)
 
     def __getitem__(self, probe):
         assert isinstance(probe, Probe)

--- a/nengo_loihi/hardware/interface.py
+++ b/nengo_loihi/hardware/interface.py
@@ -1,5 +1,6 @@
 from __future__ import division
 
+import collections
 from distutils.version import LooseVersion
 import logging
 import os
@@ -49,7 +50,7 @@ class HardwareInterface(object):
         self.nengo_io_c2h = None  # IO snip chip-to-host channel
         self._probe_filters = {}
         self._probe_filter_pos = {}
-        self._snip_probe_data = {}
+        self._snip_probe_data = collections.OrderedDict()
         self._chip2host_sent_steps = 0
 
         # Maximum number of spikes that can be sent through
@@ -62,9 +63,6 @@ class HardwareInterface(object):
         self.cwd = os.getcwd()
         logger.debug("cd to %s", nxsdk_dir)
         os.chdir(nxsdk_dir)
-
-        if seed is not None:
-            warnings.warn("Seed will be ignored when running on Loihi")
 
         # probeDict is a class attribute, so might contain things left over
         # from previous simulators
@@ -121,7 +119,7 @@ class HardwareInterface(object):
         self.board = allocator(self.model)
 
         # --- build
-        self.n2board = build_board(self.board)
+        self.n2board = build_board(self.board, seed=seed)
 
     def run_steps(self, steps, blocking=True):
         if self.use_snips and self.nengo_io_h2c is None:

--- a/nengo_loihi/hardware/interface.py
+++ b/nengo_loihi/hardware/interface.py
@@ -26,7 +26,7 @@ from nengo_loihi.validate import validate_model
 logger = logging.getLogger(__name__)
 
 
-class HardwareInterface(object):
+class HardwareInterface:
     """Simulator to place a Model onto a Loihi board and run it.
 
     Parameters
@@ -426,7 +426,7 @@ class HardwareInterface(object):
         self.nengo_io_snip_range = snip_range
 
 
-class SpikePacker(object):
+class SpikePacker:
     """Packs spikes for sending to chip
 
     Currently represents a spike as two int32s.

--- a/nengo_loihi/hardware/nxsdk_objects.py
+++ b/nengo_loihi/hardware/nxsdk_objects.py
@@ -12,7 +12,7 @@ VTH_PROFILES_MAX = 8
 SYNAPSE_FMTS_MAX = 16
 
 
-class Board(object):
+class Board:
     def __init__(self, board_id=1):
         self.board_id = board_id
 
@@ -59,7 +59,7 @@ class Board(object):
                 for chip in self.chips]
 
 
-class Chip(object):
+class Chip:
     def __init__(self, board):
         self.board = board
 
@@ -83,7 +83,7 @@ class Chip(object):
         return len(self.cores)
 
 
-class Core(object):
+class Core:
     def __init__(self, chip):
         self.chip = chip
         self.blocks = []
@@ -189,7 +189,7 @@ class Core(object):
             return len(self.synapseFmts) - 1  # index
 
 
-class LoihiSpikeInput(object):
+class LoihiSpikeInput:
     """Stores information needed to send spikes to the actual chip.
 
     This acts as a bridge between a SpikeInput and the actual chip.
@@ -202,7 +202,7 @@ class LoihiSpikeInput(object):
         particular locations on the chip.
     """
 
-    class LoihiAxon(object):
+    class LoihiAxon:
         """Represents an axon going to the chip.
 
         Parameters
@@ -238,7 +238,7 @@ class LoihiSpikeInput(object):
         def __repr__(self):
             return "%s(%s)" % (type(self).__name__, self._slots_str())
 
-    class LoihiSpike(object):
+    class LoihiSpike:
         """Represents a spike going to the chip.
 
         Parameters

--- a/nengo_loihi/inputs.py
+++ b/nengo_loihi/inputs.py
@@ -7,7 +7,7 @@ from nengo.utils.compat import is_integer
 import numpy as np
 
 
-class LoihiInput(object):
+class LoihiInput:
     def __init__(self, label=None):
         self.label = label
         self.axons = []

--- a/nengo_loihi/inputs.py
+++ b/nengo_loihi/inputs.py
@@ -39,10 +39,14 @@ class SpikeInput(LoihiInput):
 class HostSendNode(Node):
     """For sending host->chip messages"""
 
-    def __init__(self, dimensions):
+    def __init__(self, dimensions, label=Default):
         self.queue = []
-        super(HostSendNode, self).__init__(self.update,
-                                           size_in=dimensions, size_out=0)
+        super(HostSendNode, self).__init__(
+            self.update,
+            size_in=dimensions,
+            size_out=0,
+            label=label,
+        )
 
     def update(self, t, x):
         assert len(self.queue) == 0 or t > self.queue[-1][0]
@@ -52,11 +56,15 @@ class HostSendNode(Node):
 class HostReceiveNode(Node):
     """For receiving chip->host messages"""
 
-    def __init__(self, dimensions):
+    def __init__(self, dimensions, label=Default):
         self.queue = [(0, np.zeros(dimensions))]
         self.queue_index = 0
-        super(HostReceiveNode, self).__init__(self.update,
-                                              size_in=0, size_out=dimensions)
+        super(HostReceiveNode, self).__init__(
+            self.update,
+            size_in=0,
+            size_out=dimensions,
+            label=label,
+        )
 
     def update(self, t):
         while (len(self.queue) > self.queue_index + 1

--- a/nengo_loihi/neurons.py
+++ b/nengo_loihi/neurons.py
@@ -1,16 +1,44 @@
-
 from nengo.neurons import LIF, SpikingRectifiedLinear
 import numpy as np
 
+from nengo_loihi.compat import HAS_TF, tf
+
+
+def discretize_tau_rc(tau_rc, dt):
+    """Discretize tau_rc as per discretize_compartment.
+
+    Parameters
+    ----------
+    tau_rc : float
+        The neuron membrane time constant.
+    dt : float
+        The simulator time step.
+    """
+    lib = tf if HAS_TF and isinstance(tau_rc, tf.Tensor) else np
+
+    decay_rc = -lib.expm1(-dt / tau_rc)
+    decay_rc = lib.round(decay_rc * (2**12 - 1)) / (2**12 - 1)
+    return -dt / lib.log1p(-decay_rc)
+
+
+def discretize_tau_ref(tau_ref, dt):
+    """Discretize tau_ref as per Compartment.configure_lif.
+
+    Parameters
+    ----------
+    tau_rc : float
+        The neuron membrane time constant.
+    dt : float
+        The simulator time step.
+    """
+    lib = tf if HAS_TF and isinstance(tau_ref, tf.Tensor) else np
+
+    return dt * lib.round(tau_ref / dt)
+
 
 def loihi_lif_rates(neuron_type, x, gain, bias, dt):
-    # discretize tau_ref as per Compartment.configure_lif
-    tau_ref = dt * np.round(neuron_type.tau_ref / dt)
-
-    # discretize tau_rc as per Compartment.discretize
-    decay_rc = -np.expm1(-dt/neuron_type.tau_rc)
-    decay_rc = np.round(decay_rc * (2**12 - 1)) / (2**12 - 1)
-    tau_rc = -dt/np.log1p(-decay_rc)
+    tau_ref = discretize_tau_ref(neuron_type.tau_ref, dt)
+    tau_rc = discretize_tau_rc(neuron_type.tau_rc, dt)
 
     j = neuron_type.current(x, gain, bias) - 1
     out = np.zeros_like(j)
@@ -42,13 +70,51 @@ loihi_rate_functions = {
 
 
 class LoihiLIF(LIF):
+    """Simulate LIF neurons as done by Loihi.
+
+    On Loihi, the inter-spike interval has to be an integer. This causes
+    aliasing the firing rates where a wide variety of inputs can produce the
+    same output firing rate. This class reproduces this effect, as well as
+    the discretization of some of the neuron parameters. It can be used in
+    e.g. ``nengo`` or ``nengo_dl`` to reproduce these unique Loihi effects.
+
+    Parameters
+    ----------
+    nengo_dl_noise : NeuronOutputNoise
+        Noise added to the rate-neuron output when training with this neuron
+        type in ``nengo_dl``.
+    """
+
+    def __init__(
+            self,
+            tau_rc=0.02,
+            tau_ref=0.002,
+            min_voltage=0,
+            amplitude=1,
+            nengo_dl_noise=None,
+    ):
+        super(LoihiLIF, self).__init__(
+            tau_rc=tau_rc,
+            tau_ref=tau_ref,
+            min_voltage=min_voltage,
+            amplitude=amplitude,
+        )
+        self.nengo_dl_noise = nengo_dl_noise
+
+    @property
+    def _argreprs(self):
+        args = super(LoihiLIF, self)._argreprs
+        if self.nengo_dl_noise is not None:
+            args.append("nengo_dl_noise=%s" % self.nengo_dl_noise)
+        return args
+
     def rates(self, x, gain, bias, dt=0.001):
         return loihi_lif_rates(self, x, gain, bias, dt)
 
     def step_math(self, dt, J, spiked, voltage, refractory_time):
-        tau_ref = dt * np.round(self.tau_ref / dt)
-        refractory_time -= dt
+        tau_ref = discretize_tau_ref(self.tau_ref, dt)
 
+        refractory_time -= dt
         delta_t = (dt - refractory_time).clip(0, dt)
         voltage -= (J - voltage) * np.expm1(-delta_t / self.tau_rc)
 
@@ -61,6 +127,14 @@ class LoihiLIF(LIF):
 
 
 class LoihiSpikingRectifiedLinear(SpikingRectifiedLinear):
+    """Simulate spiking rectified linear neurons as done by Loihi.
+
+    On Loihi, the inter-spike interval has to be an integer. This causes
+    aliasing in the firing rates such that a wide variety of inputs produce the
+    same output firing rate. This class reproduces this effect. It can be used
+    in e.g. ``nengo`` or ``nengo_dl`` to reproduce these unique Loihi effects.
+    """
+
     def rates(self, x, gain, bias, dt=0.001):
         return loihi_spikingrectifiedlinear_rates(self, x, gain, bias, dt)
 
@@ -72,3 +146,75 @@ class LoihiSpikingRectifiedLinear(SpikingRectifiedLinear):
 
         voltage[voltage < 0] = 0
         voltage[spiked_mask] = 0
+
+
+class NeuronOutputNoise:
+    """Noise added to the output of a rate neuron.
+
+    Often used when training deep networks with rate neurons for final
+    implementation in spiking neurons to simulate the variability
+    caused by spiking.
+    """
+    pass
+
+
+class LowpassRCNoise(NeuronOutputNoise):
+    """Noise model combining Lowpass synapse and neuron membrane filters.
+
+    Samples "noise" (i.e. variability) from a regular spike train filtered
+    by the following transfer function, where :math:`\tau_{rc}` is the
+    membrane time constant and :math:`\tau_s` is the synapse time constant:
+
+    .. math::
+
+        H(s) = [(\tau_s s + 1) (\tau_{rc} s + 1)]^{-1}
+
+    See [1]_ for background and derivations.
+
+    Attributes
+    ----------
+    tau_s : float
+        Time constant for Lowpass synaptic filter.
+
+    References
+    ----------
+    .. [1] E. Hunsberger (2018) "Spiking Deep Neural Networks: Engineered and
+       Biological Approaches to Object Recognition." PhD thesis. pp. 106--113.
+       (http://compneuro.uwaterloo.ca/publications/hunsberger2018.html)
+    """
+    def __init__(self, tau_s):
+        self.tau_s = tau_s
+
+    def __repr__(self):
+        return "%s(tau_s=%s)" % (type(self).__name__, self.tau_s)
+
+
+class AlphaRCNoise(NeuronOutputNoise):
+    """Noise model combining Alpha synapse and neuron membrane filters.
+
+    Samples "noise" (i.e. variability) from a regular spike train filtered
+    by the following transfer function, where :math:`\tau_{rc}` is the
+    membrane time constant and :math:`\tau_s` is the synapse time constant:
+
+    .. math::
+
+        H(s) = [(\tau_s s + 1)^2 (\tau_rc s + 1)]^{-1}
+
+    See [1]_ for background and derivations.
+
+    Attributes
+    ----------
+    tau_s : float
+        Time constant for Alpha synaptic filter.
+
+    References
+    ----------
+    .. [1] E. Hunsberger (2018) "Spiking Deep Neural Networks: Engineered and
+       Biological Approaches to Object Recognition." PhD thesis. pp. 106--113.
+       (http://compneuro.uwaterloo.ca/publications/hunsberger2018.html)
+    """
+    def __init__(self, tau_s):
+        self.tau_s = tau_s
+
+    def __repr__(self):
+        return "%s(tau_s=%s)" % (type(self).__name__, self.tau_s)

--- a/nengo_loihi/passthrough.py
+++ b/nengo_loihi/passthrough.py
@@ -26,7 +26,7 @@ class ClusterException(NengoException):
     pass
 
 
-class Cluster(object):
+class Cluster:
     """A collection of passthrough Nodes directly connected to each other.
 
     When removing passthrough Nodes, we often have large chains of Nodes that

--- a/nengo_loihi/passthrough.py
+++ b/nengo_loihi/passthrough.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import warnings
 
 from nengo import Connection, Lowpass, Node
@@ -212,7 +213,7 @@ def find_clusters(net, offchip):
     # find which objects have Probes, as we need to make sure to keep them
     probed_objs = set(base_obj(p.target) for p in net.all_probes)
 
-    clusters = {}   # mapping from object to its Cluster
+    clusters = OrderedDict()  # mapping from object to its Cluster
     for c in net.all_connections:
         base_pre = base_obj(c.pre_obj)
         base_post = base_obj(c.post_obj)

--- a/nengo_loihi/passthrough.py
+++ b/nengo_loihi/passthrough.py
@@ -186,8 +186,8 @@ class Cluster(object):
 
         for c in self.conns_in:
             assert c.post_obj in self.objs
-            for pre_slice, transform, synapse, post in self.generate_from(
-                    c.post_obj, outputs):
+            for k, (pre_slice, transform, synapse, post) in enumerate(
+                    self.generate_from(c.post_obj, outputs)):
                 syn = self.merge_synapses(c.synapse, synapse)
                 trans = self.merge_transforms(
                     c.post_obj,
@@ -204,7 +204,10 @@ class Cluster(object):
                         scale_eval_points=c.scale_eval_points,
                         synapse=syn,
                         transform=trans,
-                        add_to_container=False)
+                        add_to_container=False,
+                        label=(None if c.label is None
+                               else "%s_%d" % (c.label, k)),
+                    )
 
 
 def find_clusters(net, offchip):

--- a/nengo_loihi/passthrough.py
+++ b/nengo_loihi/passthrough.py
@@ -22,7 +22,7 @@ def base_obj(obj):
     return obj
 
 
-class ClusterException(NengoException):
+class ClusterError(NengoException):
     pass
 
 
@@ -150,11 +150,11 @@ class Cluster:
             assert c.learning_rule_type is None
 
             if isinstance(c.post_obj, LearningRule):
-                raise ClusterException("no error signals allowed")
+                raise ClusterError("no error signals allowed")
             elif c.post_obj in previous:
                 # cycles of passthrough Nodes are possible in Nengo, but
                 # cannot be compiled away
-                raise ClusterException("no loops allowed")
+                raise ClusterError("no loops allowed")
 
             if c in self.conns_out:
                 # this is an output from the Cluster, so stop iterating
@@ -291,7 +291,7 @@ def convert_passthroughs(network, offchip):
             if has_input and ((onchip_input and onchip_output) or no_output):
                 try:
                     new_conns = list(cluster.generate_conns())
-                except ClusterException:
+                except ClusterError:
                     # this Cluster has an issue, so don't remove it
                     continue
 

--- a/nengo_loihi/simulator.py
+++ b/nengo_loihi/simulator.py
@@ -15,6 +15,7 @@ import nengo.utils.numpy as npext
 import numpy as np
 
 from nengo_loihi.builder import Model
+from nengo_loihi.builder.nengo_dl import HAS_DL, install_dl_builders
 from nengo_loihi.compat import seed_network
 from nengo_loihi.discretize import discretize_model
 from nengo_loihi.emulator import EmulatorInterface
@@ -291,6 +292,9 @@ class Simulator:
         self.closed = True  # Start closed in case constructor raises exception
         if progress_bar:
             warnings.warn("nengo-loihi does not support progress bars")
+
+        if HAS_DL:
+            install_dl_builders()
 
         if model is None:
             # Call the builder to make a model

--- a/nengo_loihi/simulator.py
+++ b/nengo_loihi/simulator.py
@@ -25,7 +25,7 @@ import nengo_loihi.config as config
 logger = logging.getLogger(__name__)
 
 
-class Simulator(object):
+class Simulator:
     """Nengo Loihi simulator for Loihi hardware and emulator.
 
     The simulator takes a `nengo.Network` and builds internal data structures

--- a/nengo_loihi/splitter.py
+++ b/nengo_loihi/splitter.py
@@ -22,7 +22,7 @@ from nengo_loihi.passthrough import convert_passthroughs
 logger = logging.getLogger(__name__)
 
 
-class PESModulatoryTarget(object):
+class PESModulatoryTarget:
     def __init__(self, target):
         self.target = target
         self.errors = OrderedDict()
@@ -52,7 +52,7 @@ def base_obj(obj):
     return obj
 
 
-class SplitNetworks(object):
+class SplitNetworks:
     def __init__(self, original, node_neurons=None, node_tau=0.005):
         self.original = original
         self.node_neurons = node_neurons

--- a/nengo_loihi/splitter.py
+++ b/nengo_loihi/splitter.py
@@ -282,21 +282,34 @@ def split_host_neurons_to_chip(networks, conn):
     receive = ChipReceiveNeurons(
         dim,
         neuron_type=conn.pre_obj.ensemble.neuron_type,
+        label=None if conn.label is None else "%s_neurons" % conn.label,
         add_to_container=False,
     )
     networks.add(receive, "chip")
     receive2post = Connection(
-        receive, conn.post,
+        receive,
+        conn.post,
         transform=conn.transform,
         synapse=conn.synapse,
+        label=None if conn.label is None else "%s_chip" % conn.label,
         add_to_container=False,
     )
     networks.add(receive2post, "chip")
 
     logger.debug("Creating HostSendNode for %s", conn)
-    send = HostSendNode(dim, add_to_container=False)
+    send = HostSendNode(
+        dim,
+        label=None if conn.label is None else "%s_send" % conn.label,
+        add_to_container=False,
+    )
     networks.add(send, "host")
-    pre2send = Connection(conn.pre, send, synapse=None, add_to_container=False)
+    pre2send = Connection(
+        conn.pre,
+        send,
+        synapse=None,
+        label=None if conn.label is None else "%s_host" % conn.label,
+        add_to_container=False,
+    )
     networks.add(pre2send, "host")
 
     networks.host2chip_senders[send] = receive
@@ -307,11 +320,19 @@ def split_host_to_chip(networks, conn):
     dim = conn.size_out
     logger.debug("Creating ChipReceiveNode for %s", conn)
     receive = ChipReceiveNode(
-        dim * 2, size_out=dim, add_to_container=False)
+        dim * 2,
+        size_out=dim,
+        label=None if conn.label is None else "%s_node" % conn.label,
+        add_to_container=False,
+    )
     networks.add(receive, "chip")
-    receive2post = Connection(receive, conn.post,
-                              synapse=networks.node_tau,
-                              add_to_container=False)
+    receive2post = Connection(
+        receive,
+        conn.post,
+        synapse=networks.node_tau,
+        label=None if conn.label is None else "%s_chip" % conn.label,
+        add_to_container=False,
+    )
     networks.add(receive2post, "chip")
 
     logger.debug("Creating DecodeNeuron ensemble for %s", conn)
@@ -319,6 +340,7 @@ def split_host_to_chip(networks, conn):
         raise BuildError(
             "DecodeNeurons must be specified for host->chip connection.")
     ens = networks.node_neurons.get_ensemble(dim)
+    ens.label = None if conn.label is None else "%s_ens" % conn.label
     networks.add(ens, "host")
 
     if nengo_transforms is not None and isinstance(
@@ -341,21 +363,34 @@ def split_host_to_chip(networks, conn):
         transform = copy.copy(conn.transform)
         type(transform).init.data[transform] = weights
 
-    pre2ens = Connection(conn.pre, ens,
-                         function=conn.function,
-                         solver=conn.solver,
-                         eval_points=conn.eval_points,
-                         scale_eval_points=conn.scale_eval_points,
-                         synapse=conn.synapse,
-                         transform=transform,
-                         add_to_container=False)
+    pre2ens = Connection(
+        conn.pre,
+        ens,
+        function=conn.function,
+        solver=conn.solver,
+        eval_points=conn.eval_points,
+        scale_eval_points=conn.scale_eval_points,
+        synapse=conn.synapse,
+        transform=transform,
+        label=None if conn.label is None else "%s_enc" % conn.label,
+        add_to_container=False,
+    )
     networks.add(pre2ens, "host")
 
     logger.debug("Creating HostSendNode for %s", conn)
-    send = HostSendNode(dim * 2, add_to_container=False)
+    send = HostSendNode(
+        dim * 2,
+        label=None if conn.label is None else "%s_send" % conn.label,
+        add_to_container=False,
+    )
     networks.add(send, "host")
     ensneurons2send = Connection(
-        ens.neurons, send, synapse=None, add_to_container=False)
+        ens.neurons,
+        send,
+        synapse=None,
+        label=None if conn.label is None else "%s_host" % conn.label,
+        add_to_container=False,
+    )
     networks.add(ensneurons2send, "host")
     networks.remove(conn)
 
@@ -380,10 +415,19 @@ def split_chip_to_host(networks, conn):
     dim = conn.size_out
 
     logger.debug("Creating HostReceiveNode for %s", conn)
-    receive = HostReceiveNode(dim, add_to_container=False)
+    receive = HostReceiveNode(
+        dim,
+        label=None if conn.label is None else "%s_receive" % conn.label,
+        add_to_container=False,
+    )
     networks.add(receive, "host")
     receive2post = Connection(
-        receive, conn.post, synapse=conn.synapse, add_to_container=False)
+        receive,
+        conn.post,
+        synapse=conn.synapse,
+        label=None if conn.label is None else "%s_host" % conn.label,
+        add_to_container=False,
+    )
     networks.add(receive2post, "host")
 
     logger.debug("Creating Probe for %s", conn)
@@ -400,6 +444,7 @@ def split_chip_to_host(networks, conn):
         eval_points=conn.eval_points,
         scale_eval_points=conn.scale_eval_points,
         transform=transform,
+        label=None if conn.label is None else "%s_probe" % conn.label,
     )
     networks.add(probe, "chip")
     networks.chip2host_receivers[probe] = receive
@@ -429,17 +474,25 @@ def split_host_to_learning_rules(networks, conns):
 def split_host_to_learning_rule(networks, conn):
     dim = conn.size_out
     logger.debug("Creating HostSendNode for %s", conn)
-    send = HostSendNode(dim, add_to_container=False)
+    send = HostSendNode(
+        dim,
+        label=None if conn.label is None else "%s_send" % conn.label,
+        add_to_container=False,
+    )
     networks.add(send, "host")
 
-    pre2send = Connection(conn.pre, send,
-                          function=conn.function,
-                          solver=conn.solver,
-                          eval_points=conn.eval_points,
-                          scale_eval_points=conn.scale_eval_points,
-                          synapse=conn.synapse,
-                          transform=conn.transform,
-                          add_to_container=False)
+    pre2send = Connection(
+        conn.pre,
+        send,
+        function=conn.function,
+        solver=conn.solver,
+        eval_points=conn.eval_points,
+        scale_eval_points=conn.scale_eval_points,
+        synapse=conn.synapse,
+        transform=conn.transform,
+        label=conn.label,
+        add_to_container=False,
+    )
     networks.add(pre2send, "host")
     pes_target = networks.needs_sender[conn.post_obj]
     networks.host2chip_senders[send] = pes_target

--- a/nengo_loihi/tests/test_conv.py
+++ b/nengo_loihi/tests/test_conv.py
@@ -10,15 +10,10 @@ import numpy as np
 import pytest
 import scipy.signal
 
-try:
-    import nengo_dl
-except ImportError:
-    nengo_dl = None
-
 import nengo_loihi
 from nengo_loihi.block import Axon, LoihiBlock, Probe, Synapse
 from nengo_loihi.builder import Model
-from nengo_loihi.compat import nengo_transforms
+from nengo_loihi.compat import HAS_DL, nengo_dl, nengo_transforms
 from nengo_loihi import conv
 from nengo_loihi.discretize import discretize_model
 from nengo_loihi.emulator import EmulatorInterface
@@ -412,7 +407,7 @@ def test_conv_connection(channels, channels_last, Simulator, seed, rng, plt,
     ref_out = sim.data[bp].mean(axis=0).reshape(output_shape.shape)
 
     # Currently, non-gpu TensorFlow does not support channels first in conv
-    use_nengo_dl = nengo_dl is not None and channels_last
+    use_nengo_dl = HAS_DL and channels_last
     ndl_out = np.zeros_like(ref_out)
     if use_nengo_dl:
         with nengo_dl.Simulator(model, dt=dt) as sim_dl:

--- a/nengo_loihi/tests/test_neurons.py
+++ b/nengo_loihi/tests/test_neurons.py
@@ -2,10 +2,17 @@ import numpy as np
 import nengo
 import pytest
 
+from nengo_loihi.builder.nengo_dl import install_dl_builders
+from nengo_loihi.compat import HAS_DL, nengo_dl
+from nengo_loihi import neurons
 from nengo_loihi.neurons import (
+    AlphaRCNoise,
+    discretize_tau_rc,
+    discretize_tau_ref,
     loihi_rates,
     LoihiLIF,
-    LoihiSpikingRectifiedLinear
+    LoihiSpikingRectifiedLinear,
+    LowpassRCNoise,
 )
 
 
@@ -74,9 +81,12 @@ def test_loihi_neurons(neuron_type, Simulator, plt, allclose):
         bias = np.linspace(0, 30, n)
 
     with nengo.Network() as model:
-        a = nengo.Ensemble(n, 1, neuron_type=neuron_type,
-                           encoders=encoders, gain=gain, bias=bias)
-        ap = nengo.Probe(a.neurons)
+        ens = nengo.Ensemble(n, 1,
+                             neuron_type=neuron_type,
+                             encoders=encoders,
+                             gain=gain,
+                             bias=bias)
+        probe = nengo.Probe(ens.neurons)
 
     t_final = 1.0
     with nengo.Simulator(model, dt=dt) as nengo_sim:
@@ -85,8 +95,8 @@ def test_loihi_neurons(neuron_type, Simulator, plt, allclose):
     with Simulator(model, dt=dt) as loihi_sim:
         loihi_sim.run(t_final)
 
-    nengo_rates = (nengo_sim.data[ap] > 0).sum(axis=0) / t_final
-    loihi_rates = (loihi_sim.data[ap] > 0).sum(axis=0) / t_final
+    nengo_rates = (nengo_sim.data[probe] > 0).sum(axis=0) / t_final
+    loihi_rates = (loihi_sim.data[probe] > 0).sum(axis=0) / t_final
 
     ref = neuron_type.rates(0., gain, bias, dt=dt)
     plt.plot(bias, loihi_rates, 'r', label='loihi sim')
@@ -96,6 +106,54 @@ def test_loihi_neurons(neuron_type, Simulator, plt, allclose):
 
     atol = 1. / t_final  # the fundamental unit for our rates
     assert allclose(nengo_rates, ref, atol=atol, rtol=0, xtol=1)
+    assert allclose(loihi_rates, ref, atol=atol, rtol=0, xtol=1)
+
+
+@pytest.mark.skipif(not HAS_DL, reason="requires nengo-dl")
+@pytest.mark.parametrize('neuron_type', [
+    LoihiLIF(),
+    LoihiSpikingRectifiedLinear(),
+])
+@pytest.mark.parametrize("inference_only", (True, False))
+def test_nengo_dl_neurons(
+        neuron_type, inference_only, Simulator, plt, allclose):
+    install_dl_builders()
+
+    dt = 0.0007
+
+    n = 256
+    encoders = np.ones((n, 1))
+    gain = np.zeros(n)
+    if isinstance(neuron_type, nengo.SpikingRectifiedLinear):
+        bias = np.linspace(0, 1001, n)
+    else:
+        bias = np.linspace(0, 30, n)
+
+    with nengo.Network() as model:
+        nengo_dl.configure_settings(inference_only=inference_only)
+
+        a = nengo.Ensemble(n, 1, neuron_type=neuron_type,
+                           encoders=encoders, gain=gain, bias=bias)
+        ap = nengo.Probe(a.neurons)
+
+    t_final = 1.0
+    with nengo_dl.Simulator(model, dt=dt) as dl_sim:
+        dl_sim.run(t_final)
+
+    with Simulator(model, dt=dt) as loihi_sim:
+        loihi_sim.run(t_final)
+
+    dl_rates = (dl_sim.data[ap] > 0).sum(axis=0) / t_final
+    loihi_rates = (loihi_sim.data[ap] > 0).sum(axis=0) / t_final
+
+    ref = neuron_type.rates(0., gain, bias, dt=dt)
+    plt.plot(bias, loihi_rates, 'r', label='loihi sim')
+    plt.plot(bias, dl_rates, 'b-.', label='dl sim')
+    plt.plot(bias, ref, 'k--', label='ref')
+    plt.legend(loc='best')
+
+    atol = 1. / t_final  # the fundamental unit for our rates
+    assert allclose(dl_rates, ref, atol=atol, rtol=0, xtol=1)
     assert allclose(loihi_rates, ref, atol=atol, rtol=0, xtol=1)
 
 
@@ -129,3 +187,248 @@ def test_lif_min_voltage(Simulator, plt, allclose):
 
     # Close, but not exact, because loihi min voltage rounded to power of 2
     assert allclose(loihi_min_voltage, nengo_min_voltage, atol=0.2)
+
+
+def rate_nengo_dl_net(
+        neuron_type, discretize=True, dt=0.001, nx=256, gain=1., bias=0.):
+    """Create a network for determining rate curves with Nengo DL.
+
+    Arguments
+    ---------
+    neuron_type : NeuronType
+        The neuron type used in the network's ensemble.
+    discretize : bool, optional (Default: True)
+        Whether the tau_ref and tau_rc values should be discretized
+        before generating rate curves.
+    dt : float, optional (Default: 0.001)
+        Simulator timestep.
+    nx : int, optional (Default: 256)
+        Number of x points in the rate curve.
+    gain : float, optional (Default: 1.)
+        Gain of all neurons.
+    bias : float, optional (Default: 0.)
+        Bias of all neurons.
+    """
+    net = nengo.Network()
+    net.dt = dt
+    net.bias = bias
+    net.gain = gain
+    lif_kw = dict(amplitude=neuron_type.amplitude)
+    if isinstance(neuron_type, LoihiLIF):
+        net.x = np.linspace(-1, 30, nx)
+
+        net.sigma = 0.02
+        lif_kw['tau_rc'] = neuron_type.tau_rc
+        lif_kw['tau_ref'] = neuron_type.tau_ref
+
+        if discretize:
+            lif_kw['tau_ref'] = discretize_tau_ref(lif_kw['tau_ref'], dt)
+            lif_kw['tau_rc'] = discretize_tau_rc(lif_kw['tau_rc'], dt)
+        lif_kw['tau_ref'] += 0.5*dt
+
+    elif isinstance(neuron_type, LoihiSpikingRectifiedLinear):
+        net.x = np.linspace(-1, 999, nx)
+
+        net.tau_ref1 = 0.5*dt
+        net.j = neuron_type.current(net.x, gain, bias) - 1
+
+    with net:
+        if isinstance(neuron_type, LoihiLIF) and discretize:
+            nengo_dl.configure_settings(lif_smoothing=net.sigma)
+
+        net.stim = nengo.Node(np.zeros(nx))
+        net.ens = nengo.Ensemble(nx, 1,
+                                 neuron_type=neuron_type,
+                                 gain=nengo.dists.Choice([gain]),
+                                 bias=nengo.dists.Choice([bias]))
+        nengo.Connection(net.stim, net.ens.neurons, synapse=None)
+        net.probe = nengo.Probe(net.ens.neurons)
+
+    rates = dict(ref=loihi_rates(neuron_type, net.x, gain, bias, dt=dt))
+    # rates['med'] is an approximation of the smoothed Loihi tuning curve
+    if isinstance(neuron_type, LoihiLIF):
+        rates['med'] = nengo.LIF(**lif_kw).rates(net.x, gain, bias)
+    elif isinstance(neuron_type, LoihiSpikingRectifiedLinear):
+        rates['med'] = np.zeros_like(net.j)
+        rates['med'][net.j > 0] = (
+            neuron_type.amplitude / (net.tau_ref1 + 1./net.j[net.j > 0]))
+
+    return net, rates, lif_kw
+
+
+@pytest.mark.skipif(not HAS_DL, reason="requires nengo-dl")
+@pytest.mark.skipif(pytest.config.getoption("--target") == "loihi",
+                    reason="only uses nengo-dl")
+@pytest.mark.parametrize('neuron_type', [
+    LoihiLIF(amplitude=1.0, tau_rc=0.02, tau_ref=0.002),
+    LoihiLIF(amplitude=0.063, tau_rc=0.05, tau_ref=0.001),
+    LoihiSpikingRectifiedLinear(),
+    LoihiSpikingRectifiedLinear(amplitude=0.42),
+])
+def test_nengo_dl_neuron_grads(neuron_type, plt):
+    from nengo_extras.neurons import SoftLIFRate
+    import tensorflow as tf
+    from tensorflow.python.ops import gradient_checker
+    install_dl_builders()
+
+    net, rates, lif_kw = rate_nengo_dl_net(neuron_type)
+    with nengo_dl.Simulator(net, dt=net.dt) as sim:
+        sim.run_steps(1,
+                      input_feeds={net.stim: net.x[None, None, :]},
+                      extra_feeds={sim.tensor_graph.signals.training: True})
+        y = sim.data[net.probe][0]
+
+    # --- compute spiking rates
+    n_spike_steps = 1000
+    x_spikes = net.x + np.zeros((1, n_spike_steps, 1), dtype=net.x.dtype)
+    with nengo_dl.Simulator(net, dt=net.dt) as sim:
+        sim.run_steps(n_spike_steps,
+                      input_feeds={net.stim: x_spikes},
+                      extra_feeds={sim.tensor_graph.signals.training: False})
+        y_spikes = sim.data[net.probe]
+        y_spikerate = y_spikes.mean(axis=0)
+
+    # --- compute derivatives
+    if isinstance(neuron_type, LoihiLIF):
+        dy_ref = SoftLIFRate(sigma=net.sigma, **lif_kw).derivative(
+            net.x, net.gain, net.bias)
+    else:
+        # use the derivative of rates['med'] (the smoothed Loihi tuning curve)
+        dy_ref = np.zeros_like(net.j)
+        dy_ref[net.j > 0] = (
+            neuron_type.amplitude / (net.j[net.j > 0]*net.tau_ref1 + 1) ** 2)
+
+    with nengo_dl.Simulator(net, dt=net.dt) as sim:
+        n_steps = sim.unroll
+        assert n_steps == 1
+
+        inp = sim.tensor_graph.input_ph[net.stim]
+        inp_shape = inp.get_shape().as_list()
+        inp_shape = [n_steps if s is None else s for s in inp_shape]
+        inp_data = np.zeros(inp_shape) + net.x[None, :, None]
+
+        out = sim.tensor_graph.probe_arrays[net.probe] + 0
+        out_shape = out.get_shape().as_list()
+        out_shape = [n_steps if s is None else s for s in out_shape]
+
+        data = {n: np.zeros((sim.minibatch_size, n_steps, n.size_out))
+                for n in sim.tensor_graph.invariant_inputs}
+        data.update({p: np.zeros((sim.minibatch_size, n_steps, p.size_in))
+                     for p in sim.tensor_graph.target_phs})
+        feed = sim._fill_feed(n_steps, data, training=True)
+
+        with tf.variable_scope(tf.get_variable_scope()) as scope:
+            dx, dy = gradient_checker._compute_dx_and_dy(inp, out, out_shape)
+            sim.sess.run(tf.variables_initializer(
+                scope.get_collection("gradient_vars")))
+
+        with sim.sess.as_default():
+            analytic = gradient_checker._compute_theoretical_jacobian(
+                inp, inp_shape, inp_data, dy, out_shape, dx,
+                extra_feed_dict=feed)
+
+        dy = np.array(np.diag(analytic))
+
+    dx = net.x[1] - net.x[0]
+    dy_est = np.diff(
+        nengo.synapses.Alpha(10).filtfilt(rates["ref"], dt=1)
+    ) / dx
+    x1 = 0.5 * (net.x[:-1] + net.x[1:])
+
+    # --- plots
+    plt.subplot(211)
+    plt.plot(net.x, rates["med"], '--', label='LIF(tau_ref += 0.5*dt)')
+    plt.plot(net.x, y, label='nengo_dl')
+    plt.plot(net.x, y_spikerate, label='nengo_dl spikes')
+    plt.plot(net.x, rates["ref"], 'k--', label='LoihiLIF')
+    plt.legend(loc=4)
+
+    plt.subplot(212)
+    plt.plot(x1, dy_est, '--', label='diff(smoothed_y)')
+    plt.plot(net.x, dy, label='nengo_dl')
+    plt.plot(net.x, dy_ref, 'k--', label='diff(SoftLIF)')
+    plt.legend(loc=1)
+
+    np.fill_diagonal(analytic, 0)
+    assert np.all(analytic == 0)
+
+    assert np.allclose(y, rates["ref"], atol=1e-3, rtol=1e-5)
+    assert np.allclose(dy, dy_ref, atol=1e-3, rtol=1e-5)
+    assert np.allclose(y_spikerate, rates["ref"], atol=1, rtol=1e-2)
+
+
+@pytest.mark.skipif(not HAS_DL, reason="requires nengo-dl")
+@pytest.mark.skipif(pytest.config.getoption("--target") == "loihi",
+                    reason="only uses nengo-dl")
+@pytest.mark.parametrize('neuron_type', [
+    LoihiLIF(amplitude=0.3, nengo_dl_noise=LowpassRCNoise(0.001)),
+    LoihiLIF(amplitude=0.3, nengo_dl_noise=AlphaRCNoise(0.001)),
+])
+def test_nengo_dl_noise(neuron_type, seed, plt):
+    install_dl_builders()
+
+    net, rates, lif_kw = rate_nengo_dl_net(neuron_type)
+    n_noise = 1000  # number of noise samples per x point
+
+    with nengo_dl.Simulator(
+            net, dt=net.dt, minibatch_size=n_noise, seed=seed) as sim:
+        input_data = {net.stim: np.tile(net.x[None, None, :], (n_noise, 1, 1))}
+        sim.step(input_feeds=input_data,
+                 extra_feeds={sim.tensor_graph.signals.training: True})
+        y = sim.data[net.probe][:, 0, :]
+
+    ymean = y.mean(axis=0)
+    y25 = np.percentile(y, 25, axis=0)
+    y75 = np.percentile(y, 75, axis=0)
+    dy25 = y25 - rates["ref"]
+    dy75 = y75 - rates["ref"]
+
+    # exponential models roughly fitted to 25/75th percentiles
+    x1mask = net.x > 1.5
+    x1 = net.x[x1mask]
+    if isinstance(neuron_type.nengo_dl_noise, AlphaRCNoise):
+        exp_model = 0.7 + 2.8*np.exp(-0.22*(x1 - 1))
+        atol = 0.12 * exp_model.max()
+    elif isinstance(neuron_type.nengo_dl_noise, LowpassRCNoise):
+        exp_model = 1.5 + 2.2*np.exp(-0.22*(x1 - 1))
+        atol = 0.2 * exp_model.max()
+
+    rtol = 0.2
+    mu_atol = 0.6  # depends on n_noise and variance of noise
+
+    # --- plots
+    plt.subplot(211)
+    plt.plot(net.x, rates["med"], '--', label='LIF(tau_ref += 0.5*dt)')
+    plt.plot(net.x, ymean, label='nengo_dl')
+    plt.plot(net.x, y25, ':', label='25th')
+    plt.plot(net.x, y75, ':', label='75th')
+    plt.plot(net.x, rates["ref"], 'k--', label='LoihiLIF')
+    plt.legend()
+
+    plt.subplot(212)
+    plt.plot(net.x, ymean - rates["ref"], 'b', label='mean')
+    plt.plot(net.x, mu_atol*np.ones_like(net.x), 'b:')
+    plt.plot(net.x, -mu_atol*np.ones_like(net.x), 'b:')
+    plt.plot(net.x, y25 - rates["ref"], ':', label='25th')
+    plt.plot(net.x, y75 - rates["ref"], ':', label='75th')
+    plt.plot(x1, exp_model, 'k--')
+    plt.plot(x1, exp_model*(1 + rtol) + atol, 'k:')
+    plt.plot(x1, exp_model*(1 - rtol) - atol, 'k:')
+    plt.plot(x1, -exp_model, 'k--')
+    plt.legend()
+
+    assert np.allclose(ymean, rates["ref"], atol=mu_atol)
+    assert np.allclose(dy25[x1mask], -exp_model, atol=atol, rtol=rtol)
+    assert np.allclose(dy75[x1mask], exp_model, atol=atol, rtol=rtol)
+
+
+def test_no_nengo_dl(Simulator, monkeypatch):
+    # check that things still work without nengo_dl / tf
+    monkeypatch.setattr(neurons, "HAS_TF", False)
+
+    with nengo.Network() as net:
+        a = nengo.Ensemble(10, 1, neuron_type=LoihiLIF())
+        nengo.Probe(a)
+
+    with Simulator(net) as sim:
+        sim.step()

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
             "nengo-extras",
             "pytest>=3.4,<4",
             "matplotlib>=2.0",
+            "scipy",
         ],
     },
     entry_points={


### PR DESCRIPTION
This adds nengo_dl TensorFlow builders for the LoihiLIF and LoihiSpikingRectifiedLinear neuron types. This allows nengo_dl networks to train with tuning curves like those of the chip neurons, allowing for more accurate conversion of ANNs for the chip.

Based off #133 