### PR TITLE
Support other null values for progress_bar

### DIFF
--- a/nengo_loihi/simulator.py
+++ b/nengo_loihi/simulator.py
@@ -327,7 +327,7 @@ class Simulator(object):
             remove_passthrough=True
     ):
         self.closed = True  # Start closed in case constructor raises exception
-        if progress_bar is not None:
+        if progress_bar:
             raise NotImplementedError("progress bars not implemented")
 
         if model is None:

--- a/nengo_loihi/tests/test_simulator.py
+++ b/nengo_loihi/tests/test_simulator.py
@@ -259,3 +259,20 @@ def test_all_onchip(Simulator):
     assert sim._run_steps.__name__ == "run_steps"
     assert sim.data[out_p].shape[0] == sim.trange().shape[0]
     assert np.all(sim.data[out_p][-1] > 100)
+
+
+def test_progressbar_values(Simulator):
+    with nengo.Network() as model:
+        nengo.Ensemble(1, 1)
+
+    # both `None` and `False` are valid ways of specifying no progress bar
+    with Simulator(model, progress_bar=None):
+        pass
+
+    with Simulator(model, progress_bar=False):
+        pass
+
+    # progress bar not yet implemented
+    with pytest.raises(NotImplementedError):
+        with Simulator(model, progress_bar=True):
+            pass


### PR DESCRIPTION
`False` is also a valid value to indicate no `Simulator.progress_bar`.

Currently, `pytry` passes `False` if no progress bar is requested, and because of this the benchmarks notebook is not working without this change.