### PR TITLE
Ensure things happen in consistent order

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,11 @@ Release history
   like integrators.
   (`#124 <https://github.com/nengo/nengo-loihi/pull/124>`_,
   `#114 <https://github.com/nengo/nengo-loihi/issues/114>`_)
+- Ensure things in the build and execution happen in a consistent order from
+  one build/run to the next (by using ``OrderedDict``, which is deterministic,
+  instead of ``dict``, which is not). This makes debugging easier and seeding
+  consistent.
+  (`#151 <https://github.com/nengo/nengo-loihi/pull/151>`_)
 
 0.4.0 (December 6, 2018)
 ========================

--- a/nengo_loihi/inputs.py
+++ b/nengo_loihi/inputs.py
@@ -2,6 +2,7 @@ from __future__ import division
 
 from nengo import Node
 from nengo.exceptions import SimulationError
+from nengo.params import Default
 from nengo.utils.compat import is_integer
 import numpy as np
 
@@ -80,12 +81,12 @@ class HostReceiveNode(Node):
 class ChipReceiveNode(Node):
     """For receiving host->chip messages"""
 
-    def __init__(self, dimensions, size_out, **kwargs):
+    def __init__(self, dimensions, size_out, label=Default):
         self.raw_dimensions = dimensions
         self.spikes = []
         self.spike_input = None  # set by builder
         super(ChipReceiveNode, self).__init__(
-            self.update, size_in=0, size_out=size_out, **kwargs)
+            self.update, size_in=0, size_out=size_out, label=label)
 
     def clear(self):
         self.spikes.clear()
@@ -106,7 +107,7 @@ class ChipReceiveNode(Node):
 
 class ChipReceiveNeurons(ChipReceiveNode):
     """Passes spikes directly (no on-off neuron encoding)"""
-    def __init__(self, dimensions, neuron_type=None, **kwargs):
+    def __init__(self, dimensions, neuron_type=None, label=Default):
         self.neuron_type = neuron_type
         super(ChipReceiveNeurons, self).__init__(
-            dimensions, dimensions, **kwargs)
+            dimensions, dimensions, label=label)

--- a/nengo_loihi/simulator.py
+++ b/nengo_loihi/simulator.py
@@ -512,7 +512,7 @@ class Simulator(object):
 
     def _collect_receiver_info(self):
         spikes = []
-        errors = {}
+        errors = OrderedDict()
         for sender, receiver in self.networks.host2chip_senders.items():
             receiver.clear()
             for t, x in sender.queue:
@@ -529,7 +529,7 @@ class Simulator(object):
                     synapse = self.model.objs[conn]['decoders']
                     assert synapse.learning
                     ti = round(t / self.model.dt)
-                    errors_ti = errors.setdefault(ti, {})
+                    errors_ti = errors.setdefault(ti, OrderedDict())
                     if synapse in errors_ti:
                         errors_ti[synapse] += e
                     else:
@@ -544,9 +544,9 @@ class Simulator(object):
         sim.host2chip(spikes, errors)
 
     def _chip2host(self, sim):
-        probes_receivers = {  # map probes to receivers
-            self.model.objs[probe]['out']: receiver
-            for probe, receiver in self.networks.chip2host_receivers.items()}
+        probes_receivers = OrderedDict(  # map probes to receivers
+            (self.model.objs[probe]['out'], receiver)
+            for probe, receiver in self.networks.chip2host_receivers.items())
         sim.chip2host(probes_receivers)
 
     def _make_run_steps(self):

--- a/nengo_loihi/splitter.py
+++ b/nengo_loihi/splitter.py
@@ -69,11 +69,11 @@ class SplitNetworks(object):
 
         # Used later in the build process
         self.chip2host_params = {}
-        self.chip2host_receivers = {}
-        self.host2chip_senders = {}
+        self.chip2host_receivers = OrderedDict()
+        self.host2chip_senders = OrderedDict()
 
-        self.adds = {}
-        self.moves = {}
+        self.adds = OrderedDict()
+        self.moves = OrderedDict()
         self.removes = []
 
     def __contains__(self, obj):


### PR DESCRIPTION
- Splitter preserves object order from original network.
- Host/chip receivers are always called in same order.

This makes sure that seeds are always set the same as well. Right now, setting a seed on a network does not actually guarantee it will be the same from one run to the next, because the splitter dictionaries change the order that everything gets built in in a non-deterministic way.