### PR TITLE
Neurons to ensemble connections with interneurons

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -282,8 +282,6 @@ setup_cfg:
         inaccurate
 
       # builder inconsistencies
-      test_connection.py:test_neurons_to_ensemble*:
-        transform shape not implemented
       test_connection.py:test_transform_probe:
         transform shape not implemented
       test_connection.py:test_list_indexing*:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@ Release history
   in a round-robin format. This allocator can be selected using the
   ``hardware_options`` argument when creating ``nengo_loihi.Simulator``.
   (`#197 <https://github.com/nengo/nengo-loihi/pull/197>`__)
+- Added support for ``Ensemble.neurons -> Ensemble`` connections.
+  (`#156 <https://github.com/nengo/nengo-loihi/pull/156>`__)
 
 **Changed**
 

--- a/nengo_loihi/builder/tests/test_connection.py
+++ b/nengo_loihi/builder/tests/test_connection.py
@@ -5,6 +5,8 @@ from nengo.exceptions import BuildError
 import numpy as np
 import pytest
 
+from nengo_loihi.builder.connection import expand_to_2d
+
 
 @pytest.mark.skipif(LooseVersion(nengo.__version__) <= LooseVersion('2.8.0'),
                     reason="requires more recent Nengo version")
@@ -66,3 +68,9 @@ def test_manual_decoders(
         assert np.mean(sim.data[pre_probe]) > 100
         # But that post has no activity due to the zero weights
         assert np.all(sim.data[post_probe] == 0)
+
+
+def test_expand_to_2d():
+    assert np.allclose(expand_to_2d(np.array(2.0), 3, 3), np.eye(3) * 2)
+    assert np.allclose(expand_to_2d(np.arange(3), 3, 3), np.diag(np.arange(3)))
+    assert np.allclose(expand_to_2d(np.ones((2, 3)), 3, 2), np.ones((2, 3)))

--- a/setup.cfg
+++ b/setup.cfg
@@ -225,8 +225,6 @@ nengo_test_unsupported =
         "inaccurate"
     test_actionselection.py:test_thalamus
         "inaccurate"
-    test_connection.py:test_neurons_to_ensemble*
-        "transform shape not implemented"
     test_connection.py:test_transform_probe
         "transform shape not implemented"
     test_connection.py:test_list_indexing*


### PR DESCRIPTION
An alternative to #71.

In #71, I feel like I cheated, and specifically implemented neurons->ensemble connections that only have a scalar transform. In that case, the dimensionality of the post-ensemble has to be the same as the pre neurons.

In this PR, I do it in a more general way, by including interneurons in the case when we're connecting from neurons to ensemble. This allows us to put arbitrary transforms in there.

HOWEVER, I did find that for the case where we have neurons->ensemble connections of the first type, with scalar transforms, this new method does not work well. I think that's because each group of interneurons (i.e. each dimension in the interneurons population) is being driven only by one input neuron, so its input is very noisy and it just doesn't perform well. Furthermore, this would only work for small numbers of input neurons (less than 50 or so), since we use 20 interneurons to represent each dimension so for greater numbers of pre neurons we'd just run out of neurons on a single core for the interneurons.

Anyway, I feel like this is not a big limitation, since if you have the encoders for the post population, you can just do a neurons->neurons connection with the encoders as the transform to get behaviour (without interneurons) like I had implemented before. It can be a bit annoying to get the encoders, since essentially it means you have to generate them yourself at model creation time, but this isn't a huge burden.

Also, this is much simpler than #71 was, since there I had to allow for different encoders depending on whether we were connecting from interneurons (i.e. another ensemble) or neurons.