### PR TITLE
Binary spike encoding

### DIFF
--- a/nengo_loihi/builder.py
+++ b/nengo_loihi/builder.py
@@ -16,6 +16,7 @@ from nengo.utils.builder import default_n_eval_points
 import nengo.utils.numpy as npext
 
 from nengo_loihi import conv
+from nengo_loihi.loihi_api import ENC_BITS
 from nengo_loihi.loihi_cx import (
     ChipReceiveNeurons,
     ChipReceiveNode,
@@ -366,13 +367,28 @@ def build_ensemble(model, ens):
 
 def build_interencoders(model, ens):
     """Build encoders accepting on/off interneuron input."""
+    # TODO: the logic here mirrors that of splitter.py's _BinaryEncoder
     group = model.objs[ens.neurons]['in']
     scaled_encoders = model.params[ens].scaled_encoders
 
-    synapses = CxSynapses(2*scaled_encoders.shape[1], label="inter_encoders")
+    # create binary-encoding weights with +/- sign
+    weights = np.zeros(
+        (2, ENC_BITS, scaled_encoders.shape[1], scaled_encoders.shape[0]))
     interscaled_encoders = scaled_encoders * model.inter_scale
-    synapses.set_full_weights(
-        np.vstack([interscaled_encoders.T, -interscaled_encoders.T]))
+    for i, sign in enumerate([+1, -1]):
+        for bit in range(ENC_BITS):
+            weights[i, bit, :, :] = sign / 2.**(1 + bit) * interscaled_encoders.T
+
+    # the flat_weights passed to set_full_weights is a 2D matrix, where the
+    # first dimension is flattened (sign, bit, vector_dimension)
+    # and the second is the neuron
+    flat_weights = weights.reshape(-1, weights.shape[-1])
+    assert flat_weights.shape == (
+        2 * ENC_BITS * scaled_encoders.shape[1],
+        scaled_encoders.shape[0])
+
+    synapses = CxSynapses(flat_weights.shape[0], label="inter_encoders")
+    synapses.set_full_weights(flat_weights)
     group.add_synapses(synapses, name='inter_encoders')
 
 
@@ -549,6 +565,8 @@ def build_connection(model, conn):
             assert transform.ndim == 2, "transform shape not handled yet"
             assert transform.shape[1] == conn.pre.size_out
 
+        # TODO: the weights aren't used anywhere if post is an Ensemble
+        # in vector space? handled by build_interencoders instead.
         assert transform.shape[1] == conn.pre.size_out
         if isinstance(conn.pre_obj, ChipReceiveNeurons):
             weights = transform / model.dt

--- a/nengo_loihi/loihi_api.py
+++ b/nengo_loihi/loihi_api.py
@@ -22,6 +22,8 @@ BIAS_MAX = BIAS_MAN_MAX * 2**BIAS_EXP_MAX
 Q_BITS = 21  # number of bits for synapse accumulator
 U_BITS = 23  # number of bits for cx input (u)
 
+ENC_BITS = 16  # number of bits to encode each sign of each input node dimension
+
 
 def overflow_signed(x, bits=7, out=None):
     """Compute overflow on an array of signed integers.

--- a/nengo_loihi/splitter.py
+++ b/nengo_loihi/splitter.py
@@ -6,6 +6,7 @@ import nengo
 from nengo.exceptions import BuildError
 import numpy as np
 
+from nengo_loihi.loihi_api import ENC_BITS
 from nengo_loihi.conv import Conv2D
 from nengo_loihi.loihi_cx import (
     ChipReceiveNode, ChipReceiveNeurons, HostSendNode, HostReceiveNode,
@@ -277,26 +278,47 @@ def split_host_neurons_to_chip(networks, conn):
     networks.remove(conn)
 
 
+class _BinaryEncoder(object):
+    """Node function for encoding a (-1, 1) vector in binary."""
+
+    def __init__(self, n_bits, amplitude=1000):
+        # TODO: don't hardcode amplitude (1/dt)?
+        #       logic is currently split across build_interencoders
+        self.n_bits = n_bits
+        self.amplitude = amplitude
+
+    def __call__(self, dummy_time, x):
+        spiked = np.zeros((2, self.n_bits, len(x)))
+        for i, x_i in enumerate(x):
+            sign_bit = 0 if x_i >= 0 else 1
+            f = np.abs(x_i)
+            v = 0.5  # to represent [0, 1)
+            for j in range(self.n_bits):
+                if f >= v:
+                    f -= v
+                    spiked[sign_bit, j, i] = self.amplitude
+                v /= 2.
+        return spiked.flatten()
+
+
 def split_host_to_chip(networks, conn):
     dim = conn.size_out
+    size_enc = 2 * ENC_BITS * dim
+
     logger.debug("Creating ChipReceiveNode for %s", conn)
     receive = ChipReceiveNode(
-        dim * 2, size_out=dim, add_to_container=False)
+        size_enc, size_out=dim, add_to_container=False)
     networks.add(receive, "chip")
     receive2post = nengo.Connection(receive, conn.post,
-                                    synapse=networks.inter_tau,
+                                    synapse=None,
                                     add_to_container=False)
     networks.add(receive2post, "chip")
 
-    logger.debug("Creating NIF ensemble for %s", conn)
-    ens = nengo.Ensemble(
-        2 * dim, dim,
-        neuron_type=NIF(tau_ref=0.0),
-        encoders=np.vstack([np.eye(dim), -np.eye(dim)]),
-        max_rates=np.ones(dim * 2) * networks.max_rate,
-        intercepts=np.ones(dim * 2) * -1,
-        add_to_container=False)
-    networks.add(ens, "host")
+    logger.debug("Creating spike-encoder for %s", conn)
+    encoder = nengo.Node(size_in=dim,
+                         output=_BinaryEncoder(n_bits=ENC_BITS),
+                         add_to_container=False)
+    networks.add(encoder, "host")
 
     if isinstance(conn.transform, Conv2D):
         raise BuildError(
@@ -313,22 +335,24 @@ def split_host_to_chip(networks, conn):
         rng=np.random.RandomState(seed=seed))
     if isinstance(conn.post_obj, nengo.Ensemble):
         transform = transform / conn.post_obj.radius
-    pre2ens = nengo.Connection(conn.pre, ens,
-                               function=conn.function,
-                               solver=conn.solver,
-                               eval_points=conn.eval_points,
-                               scale_eval_points=conn.scale_eval_points,
-                               synapse=conn.synapse,
-                               transform=transform,
-                               add_to_container=False)
-    networks.add(pre2ens, "host")
+
+    pre2encoder = nengo.Connection(
+        conn.pre, encoder,
+        function=conn.function,
+        solver=conn.solver,
+        eval_points=conn.eval_points,
+        scale_eval_points=conn.scale_eval_points,
+        synapse=conn.synapse,
+        transform=transform,
+        add_to_container=False)
+    networks.add(pre2encoder, "host")
 
     logger.debug("Creating HostSendNode for %s", conn)
-    send = HostSendNode(dim * 2, add_to_container=False)
+    send = HostSendNode(size_enc, add_to_container=False)
     networks.add(send, "host")
-    ensneurons2send = nengo.Connection(
-        ens.neurons, send, synapse=None, add_to_container=False)
-    networks.add(ensneurons2send, "host")
+    spikes2send = nengo.Connection(
+        encoder, send, synapse=None, add_to_container=False)
+    networks.add(spikes2send, "host")
     networks.remove(conn)
 
     networks.host2chip_senders[send] = receive


### PR DESCRIPTION
This is a work-in-progress / proof-of-concept that improves the accuracy of a single layer encode/decode by roughly 5-fold, which helps close the gap between the `nengo_loihi` emulator and the reference `nengo` simulator (see figure below). In particular, the benchmark from #155 sees an improvement from 5% error to about 1% error.

This idea is courtesy of @tcstewar who suggested that the spike generator could be implemented using a binary code where each spike represents a bit of information in the binary representation of the node's input vector. This uses `2*dims*k` spike generators to represent the input vector with `2**k` precision. There is no variability from the ideal PSC, because the synapse is `None` and the code is transmitted precisely every time-step. All of the error (on the encoding side) comes from quantizing the signed input values to `k` bits.

The trade-off is this requires `O(k)` spikes to be multicast to all input neurons every time-step, whereas the previous on/off encoding scheme was sparse in time (i.e., trading between spike density, dt, tau, and input frequency). To further explore this trade-off, the on/off code should be extended to support `k` heterogeneous spike trains (i.e., inflate the generator's total spike count by a factor of `k` to reduce variability).

![binary-encoding](https://user-images.githubusercontent.com/5420057/50125867-97d12100-0238-11e9-9bf0-df713924be5b.png)

The implementation is a work-in-progress; I took the path-of-least-resistance in order to test this out as quickly as possible. At the very least this should help provide a starting template for what different encoding schemes might look like in code.

TODO:
 - Why is there a degradation in performance at `600 <= n_neurons <= 800` (note: 10 trials)? 
 - How should this be generalized to support user-configurable/pluggable spike generators?
 - Unify the encoding logic in the same class (currently split across files).
 - How to get the right scaling factor where it's needed?
 - Compare to on/off encoding replicated `k` times.
 - Unit test.
 - Regression test.

Figure code is from #155, modified as follows:

```python
data = defaultdict(list)
for trial in range(10):
    for simulator in (nengo_loihi.Simulator, nengo.Simulator):
        print("Trial #", trial)
        for n_neurons in np.arange(100, 1100, 100, dtype=int):
            data['Trial'].append(trial)
            data['Simulator'].append(simulator.__module__)
            data['# Neurons'].append(n_neurons)
            data['RMSE'].append(go(n_neurons, simulator=simulator))

df = DataFrame(data)
plt.figure(figsize=(14, 6))
sns.lineplot(data=df, x='# Neurons', y='RMSE', hue='Simulator')
plt.show()
```