### PR TITLE
CIFAR-10 on Loihi

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,10 @@ Release history
   minimum voltages in powers of two), but this will at least provide something
   in the ballpark.
   (`#169 <https://github.com/nengo/nengo-loihi/pull/169>`__)
+- Population spikes can now be used to send information more efficiently
+  to the chip. Population spikes are necessary for larger models
+  like those using CIFAR-10 data.
+  (`#161 <https://github.com/nengo/nengo-loihi/pull/161>`__)
 
 **Changed**
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -20,3 +20,15 @@ We compare performance with Nengo core where appropriate.
    examples/keyword_spotting
    examples/mnist_convnet
    examples/adaptive_motor_control
+
+Model zoo
+=========
+
+These are models that have been developed using Nengo Loihi.
+They are not actively maintained by the Nengo Loihi team,
+and they are not intended as teaching examples.
+But if you'd like to see Nengo Loihi
+used in real-world projects, check them out.
+
+- `CIFAR-10 vision network
+  <https://github.com/nengo/nengo-examples/blob/master/loihi-dl/cifar10_convnet.ipynb>`__

--- a/nengo_loihi/hardware/snips/nengo_io.c.template
+++ b/nengo_loihi/hardware/snips/nengo_io.c.template
@@ -17,11 +17,13 @@ void nengo_io(runState *s) {
 {% for core in cores %}
     NeuronCore *core{{ core }} = NEURON_PTR((CoreId){ .id={{ core }} });
 {% endfor %}
-    CoreId coreId;
-    int32_t axonType, axonId, atom;
+    CoreId core_id;
+    int in_channel = getChannelID("nengo_io_h2c");
+    int out_channel = getChannelID("nengo_io_c2h");
 
-    int inChannel = getChannelID("nengo_io_h2c");
-    int outChannel = getChannelID("nengo_io_c2h");
+    int32_t axon_type;
+    int32_t axon_id;
+    int32_t atom;
     int32_t count[1];
     int32_t spike[SPIKE_SIZE];
     int32_t error_info[ERROR_INFO_SIZE];
@@ -29,7 +31,7 @@ void nengo_io(runState *s) {
     int32_t error_index;
     int32_t output[N_OUTPUTS];
 
-    if (inChannel == -1 || outChannel == -1) {
+    if (in_channel == -1 || out_channel == -1) {
         printf("Got an invalid channel ID\n");
         return;
     }
@@ -38,30 +40,30 @@ void nengo_io(runState *s) {
         printf("time %d\n", s->time);
     }
 
-    readChannel(inChannel, count, 1);
+    readChannel(in_channel, count, 1);
     if (DEBUG) {
         printf("count %d\n", count[0]);
     }
 
     for (int i=0; i < count[0]; i++) {
-        readChannel(inChannel, spike, SPIKE_SIZE);
+        readChannel(in_channel, spike, SPIKE_SIZE);
         if (DEBUG) {
             printf("send spike %d.%d\n", spike[0], spike[1]);
         }
-        coreId = (CoreId) { .id=(spike[0] >> 16) };
-        axonId = spike[0] & 0x0000FFFF;
-        axonType = spike[1] >> 16;
+        core_id = (CoreId) { .id=(spike[0] >> 16) };
+        axon_id = spike[0] & 0x0000FFFF;
+        axon_type = spike[1] >> 16;
         atom = spike[1] & 0x0000FFFF;
         if (DEBUG) {
             printf("send spike core=%d, axon=%d, type=%d atom=%d\n",
-                   coreId.id, axonId, axonType, atom);
+                   core_id.id, axon_id, axon_type, atom);
         }
-        if (axonType == 0) {
-            nx_send_discrete_spike(s->time, coreId, axonId);
-        } else if (axonType == 32) {
-            nx_send_pop32_spike(s->time, coreId, axonId, atom, 0, 0, 0);
+        if (axon_type == 0) {
+            nx_send_discrete_spike(s->time, core_id, axon_id);
+        } else if (axon_type == 32) {
+            nx_send_pop32_spike(s->time, core_id, axon_id, atom, 0, 0, 0);
         } else {
-            printf("Got invalid axonType: %d\n", axonType);
+            printf("Got invalid axon_type: %d\n", axon_type);
             return;
         }
     }
@@ -70,8 +72,8 @@ void nengo_io(runState *s) {
     s->userData[0] = N_ERRORS;
     error_index = 1;
     for (int i=0; i < N_ERRORS; i++) {
-        readChannel(inChannel, error_info, ERROR_INFO_SIZE);
-        readChannel(inChannel, error_data, error_info[1]);
+        readChannel(in_channel, error_info, ERROR_INFO_SIZE);
+        readChannel(in_channel, error_data, error_info[1]);
         s->userData[error_index] = error_info[0];
         s->userData[error_index + 1] = error_info[1];
         for (int j=0; j < error_info[1]; j++) {
@@ -89,5 +91,5 @@ void nengo_io(runState *s) {
 {% endif %}
 {% endfor %}
 
-    writeChannel(outChannel, output, N_OUTPUTS);
+    writeChannel(out_channel, output, N_OUTPUTS);
 }

--- a/nengo_loihi/hardware/snips/nengo_io.c.template
+++ b/nengo_loihi/hardware/snips/nengo_io.c.template
@@ -2,6 +2,7 @@
 #include <string.h>
 #include "nengo_io.h"
 
+#define DEBUG 0
 #define N_OUTPUTS {{ n_outputs }}
 #define N_ERRORS {{ n_errors }}
 #define MAX_ERROR_LEN {{ max_error_len }}
@@ -37,17 +38,23 @@ void nengo_io(runState *s) {
     }
 
     readChannel(inChannel, count, 1);
-    // printf("count %d\n", count[0]);
+    if (DEBUG) {
+        printf("count %d\n", count[0]);
+    }
 
     for (int i=0; i < count[0]; i++) {
         readChannel(inChannel, spike, SPIKE_SIZE);
-        // printf("send spike %d.%d\n", spike[0], spike[1]);
+        if (DEBUG) {
+            printf("send spike %d.%d\n", spike[0], spike[1]);
+        }
         coreId = (CoreId) { .id=(spike[0] >> 16) };
         axonId = spike[0] & 0x0000FFFF;
         axonType = spike[1] >> 16;
         atom = spike[1] & 0x0000FFFF;
-        // printf("send spike core=%d, axon=%d, type=%d atom=%d\n",
-        //        coreId.id, axonId, axonType, atom);
+        if (DEBUG) {
+            printf("send spike core=%d, axon=%d, type=%d atom=%d\n",
+                   coreId.id, axonId, axonType, atom);
+        }
         if (axonType == 0) {
             nx_send_discrete_spike(s->time, coreId, axonId);
         } else if (axonType == 32) {

--- a/nengo_loihi/hardware/snips/nengo_io.c.template
+++ b/nengo_loihi/hardware/snips/nengo_io.c.template
@@ -5,6 +5,7 @@
 #define N_OUTPUTS {{ n_outputs }}
 #define N_ERRORS {{ n_errors }}
 #define MAX_ERROR_LEN {{ max_error_len }}
+#define SPIKE_SIZE 2
 
 int guard_io(runState *s) {
     return 1;
@@ -15,10 +16,12 @@ void nengo_io(runState *s) {
     NeuronCore *core{{ core }} = NEURON_PTR((CoreId){ .id={{ core }} });
 {% endfor %}
     CoreId coreId;
+    int32_t axonType, axonId, atom;
+
     int inChannel = getChannelID("nengo_io_h2c");
     int outChannel = getChannelID("nengo_io_c2h");
     int32_t count[1];
-    int32_t spike[2];
+    int32_t spike[SPIKE_SIZE];
     int32_t error_info[2];
     int32_t error_data[MAX_ERROR_LEN];
     int32_t error_index;
@@ -37,10 +40,22 @@ void nengo_io(runState *s) {
     // printf("count %d\n", count[0]);
 
     for (int i=0; i < count[0]; i++) {
-        readChannel(inChannel, spike, 2);
+        readChannel(inChannel, spike, SPIKE_SIZE);
         // printf("send spike %d.%d\n", spike[0], spike[1]);
-        coreId = (CoreId) { .id=spike[0] };
-        nx_send_discrete_spike(s->time, coreId, spike[1]);
+        coreId = (CoreId) { .id=(spike[0] >> 16) };
+        axonId = spike[0] & 0x0000FFFF;
+        axonType = spike[1] >> 16;
+        atom = spike[1] & 0x0000FFFF;
+        // printf("send spike core=%d, axon=%d, type=%d atom=%d\n",
+        //        coreId.id, axonId, axonType, atom);
+        if (axonType == 0) {
+            nx_send_discrete_spike(s->time, coreId, axonId);
+        } else if (axonType == 32) {
+            nx_send_pop32_spike(s->time, coreId, axonId, atom, 0, 0, 0);
+        } else {
+            printf("Got invalid axonType: %d\n", axonType);
+            return;
+        }
     }
 
     // Communicate with learning snip

--- a/nengo_loihi/hardware/snips/nengo_io.c.template
+++ b/nengo_loihi/hardware/snips/nengo_io.c.template
@@ -7,6 +7,7 @@
 #define N_ERRORS {{ n_errors }}
 #define MAX_ERROR_LEN {{ max_error_len }}
 #define SPIKE_SIZE 2
+#define ERROR_INFO_SIZE 2
 
 int guard_io(runState *s) {
     return 1;
@@ -23,7 +24,7 @@ void nengo_io(runState *s) {
     int outChannel = getChannelID("nengo_io_c2h");
     int32_t count[1];
     int32_t spike[SPIKE_SIZE];
-    int32_t error_info[2];
+    int32_t error_info[ERROR_INFO_SIZE];
     int32_t error_data[MAX_ERROR_LEN];
     int32_t error_index;
     int32_t output[N_OUTPUTS];
@@ -69,14 +70,14 @@ void nengo_io(runState *s) {
     s->userData[0] = N_ERRORS;
     error_index = 1;
     for (int i=0; i < N_ERRORS; i++) {
-        readChannel(inChannel, error_info, 2);
+        readChannel(inChannel, error_info, ERROR_INFO_SIZE);
         readChannel(inChannel, error_data, error_info[1]);
         s->userData[error_index] = error_info[0];
         s->userData[error_index + 1] = error_info[1];
         for (int j=0; j < error_info[1]; j++) {
-            s->userData[error_index + 2 + j] = error_data[j];
+            s->userData[error_index + ERROR_INFO_SIZE + j] = error_data[j];
         }
-        error_index += 2 + error_info[1];
+        error_index += ERROR_INFO_SIZE + error_info[1];
     }
 
     output[0] = s->time;

--- a/nengo_loihi/tests/test_model.py
+++ b/nengo_loihi/tests/test_model.py
@@ -1,11 +1,11 @@
 import numpy as np
 
-from nengo_loihi.block import LoihiBlock
+from nengo_loihi.block import Axon, LoihiBlock, Probe, Synapse
 from nengo_loihi.builder import Model
-from nengo_loihi.builder.probe import Probe
 from nengo_loihi.discretize import discretize_model
 from nengo_loihi.emulator import EmulatorInterface
 from nengo_loihi.hardware import HardwareInterface
+from nengo_loihi.inputs import SpikeInput
 
 
 def test_simulator_noise(request, plt, seed):
@@ -40,3 +40,71 @@ def test_simulator_noise(request, plt, seed):
 
     plt.plot(y)
     plt.yticks(())
+
+
+def test_population_input(request, allclose):
+    target = request.config.getoption("--target")
+    dt = 0.001
+
+    n_inputs = 3
+    n_axons = 1
+    n_cx = 2
+
+    steps = 6
+    spike_times_inds = [(1, [0]),
+                        (3, [1]),
+                        (5, [2])]
+
+    model = Model()
+
+    input = SpikeInput(n_inputs)
+    model.add_input(input)
+    spikes = [(input, ti, inds) for ti, inds in spike_times_inds]
+
+    input_axon = Axon(n_axons)
+    axon_map = np.zeros(n_inputs, dtype=int)
+    atoms = np.arange(n_inputs)
+    input_axon.set_axon_map(axon_map, atoms)
+    input.add_axon(input_axon)
+
+    block = LoihiBlock(n_cx)
+    block.compartment.configure_lif(tau_rc=0., tau_ref=0., dt=dt)
+    block.compartment.configure_filter(0, dt=dt)
+    model.add_block(block)
+
+    synapse = Synapse(n_axons)
+    weights = 0.1 * np.array([[[1, 2], [2, 3], [4, 5]]], dtype=float)
+    indices = np.array([[[0, 1], [0, 1], [0, 1]]], dtype=int)
+    axon_to_weight_map = np.zeros(n_axons, dtype=int)
+    cx_bases = np.zeros(n_axons, dtype=int)
+    synapse.set_population_weights(
+        weights, indices, axon_to_weight_map, cx_bases, pop_type=32)
+    block.add_synapse(synapse)
+    input_axon.target = synapse
+
+    probe = Probe(target=block, key='voltage')
+    block.add_probe(probe)
+
+    discretize_model(model)
+
+    if target == 'loihi':
+        with HardwareInterface(model, use_snips=True) as sim:
+            sim.run_steps(steps, blocking=False)
+            for ti in range(1, steps+1):
+                spikes_i = [spike for spike in spikes if spike[1] == ti]
+                sim.host2chip(spikes_i, [])
+                sim.chip2host()
+
+            y = sim.get_probe_output(probe)
+    else:
+        for inp, ti, inds in spikes:
+            inp.add_spikes(ti, inds)
+
+        with EmulatorInterface(model) as sim:
+            sim.run_steps(steps)
+            y = sim.get_probe_output(probe)
+
+    vth = block.compartment.vth[0]
+    assert (block.compartment.vth == vth).all()
+    z = y / vth
+    assert allclose(z[[1, 3, 5]], weights[0], atol=4e-2, rtol=0)

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
             "matplotlib>=2.0",
             "nbsphinx",
             "nbconvert<5.4",
+            "nengo-extras",
             "nengo_sphinx_theme>=0.7",
             "numpydoc>=0.6",
             "sphinx>=1.8",


### PR DESCRIPTION
This has CIFAR-10 running on Loihi. It replaces #117.

The main feature addition here is allowing population spikes on inputs. This allows us to re-use axons in the three-channel CIFAR-10 input images, making it much easier to get things on the chip.

A lot of these commits can probably be squashed together. The script in the sandbox should also be moved to the sandbox repository.