### PR TITLE
Enable codecov status checks

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+codecov:
+  notify:
+    require_ci_to_pass: no
+
+coverage:
+  status:
+    patch:
+      default:
+        enabled: yes
+        target: 100%


### PR DESCRIPTION
We won't require these checks to pass (as right now our CI can't cover the loihi hardware-specific code), but probably still useful to have the information readily displayed (and we would expect them to pass for things that don't touch the hardware).