### PR TITLE
Test probes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,14 @@ Release history
 0.5.0 (unreleased)
 ==================
 
+**Added**
+
+- Allow ``LIF.min_voltage`` to have effect. The exact minimum voltage on the
+  chip is highly affected by discritization (since the chip only allows
+  minimum voltages in powers of two), but this will at least provide something
+  in the ballpark.
+  (`#169 <https://github.com/nengo/nengo-loihi/pull/169>`__)
+
 **Changed**
 
 - PES learning in Nengo Loihi more closely matches learning in core Nengo.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,10 @@ Release history
   instead of ``dict``, which is not). This makes debugging easier and seeding
   consistent.
   (`#151 <https://github.com/nengo/nengo-loihi/pull/151>`_)
+- Probes that use snips on the chip (when running with ``precompute=False``)
+  now deal with negative values correctly.
+  (`#169 <https://github.com/nengo/nengo-loihi/pull/124>`_,
+  `#141 <https://github.com/nengo/nengo-loihi/issues/141>`_)
 
 0.4.0 (December 6, 2018)
 ========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,11 @@ Release history
   now deal with negative values correctly.
   (`#169 <https://github.com/nengo/nengo-loihi/pull/124>`_,
   `#141 <https://github.com/nengo/nengo-loihi/issues/141>`_)
+- Filtering for probes on the chip
+  is guaranteed to use floating-point now (so that the filtered output
+  is correct, even if the underlying values are integers).
+  (`#169 <https://github.com/nengo/nengo-loihi/pull/124>`_,
+  `#141 <https://github.com/nengo/nengo-loihi/issues/141>`_)
 
 0.4.0 (December 6, 2018)
 ========================

--- a/nengo_loihi/builder/ensemble.py
+++ b/nengo_loihi/builder/ensemble.py
@@ -136,6 +136,7 @@ def build_lif(model, lif, neurons, block):
     block.compartment.configure_lif(
         tau_rc=lif.tau_rc,
         tau_ref=lif.tau_ref,
+        min_voltage=lif.min_voltage,
         dt=model.dt)
 
 

--- a/nengo_loihi/discretize.py
+++ b/nengo_loihi/discretize.py
@@ -222,12 +222,6 @@ def discretize_compartment(comp, w_max):
     comp.scaleU = False
     comp.scaleV = False
 
-    # --- vmin and vmax
-    vmine = np.clip(np.round(np.log2(-comp.vmin + 1)), 0, 2**5-1)
-    comp.vmin = -2**vmine + 1
-    vmaxe = np.clip(np.round((np.log2(comp.vmax + 1) - 9)*0.5), 0, 2**3-1)
-    comp.vmax = 2**(9 + 2*vmaxe) - 1
-
     # --- discretize weights and vth
     # To avoid overflow, we can either lower vth_max or lower w_exp_max.
     # Lowering vth_max is more robust, but has the downside that it may
@@ -294,6 +288,15 @@ def discretize_compartment(comp, w_max):
             "Noise amplitude exceeds upper limit (%d > 23)" % (noiseExp0,))
     comp.noiseExp0 = int(np.clip(noiseExp0, 0, 23))
     comp.noiseMantOffset0 = int(np.round(2*comp.noiseMantOffset0))
+
+    # --- vmin and vmax
+    assert (v_scale[0] == v_scale).all()
+    vmin = v_scale[0] * comp.vmin
+    vmax = v_scale[0] * comp.vmax
+    vmine = np.clip(np.round(np.log2(-vmin + 1)), 0, 2 ** 5 - 1)
+    comp.vmin = -2 ** vmine + 1
+    vmaxe = np.clip(np.round((np.log2(vmax + 1) - 9) * 0.5), 0, 2 ** 3 - 1)
+    comp.vmax = 2 ** (9 + 2 * vmaxe) - 1
 
     return dict(w_max=w_max,
                 w_scale=w_scale,

--- a/nengo_loihi/emulator/tests/test_emulator.py
+++ b/nengo_loihi/emulator/tests/test_emulator.py
@@ -50,7 +50,6 @@ def test_uv_overflow(n_axons, plt, allclose, monkeypatch):
     block = LoihiBlock(1)
     block.compartment.configure_relu()
     block.compartment.configure_filter(0.1)
-    block.compartment.vmin = -2**22
 
     synapse = Synapse(n_axons)
     synapse.set_full_weights(np.ones((n_axons, 1)))
@@ -70,7 +69,9 @@ def test_uv_overflow(n_axons, plt, allclose, monkeypatch):
     model.add_block(block)
     discretize_model(model)
 
-    block.compartment.vth[:] = VTH_MAX  # must set after `discretize`
+    # must set these after `discretize` to specify discretized values
+    block.compartment.vmin = -2 ** 22 + 1
+    block.compartment.vth[:] = VTH_MAX
 
     assert EmulatorInterface.strict  # Tests should be run in strict mode
     monkeypatch.setattr(EmulatorInterface, "strict", False)

--- a/nengo_loihi/hardware/interface.py
+++ b/nengo_loihi/hardware/interface.py
@@ -166,7 +166,7 @@ class HardwareInterface(object):
     def _chip2host_snips(self, probes_receivers):
         count = self.nengo_io_c2h_count
         data = self.nengo_io_c2h.read(count)
-        time_step, data = data[0], np.array(data[1:])
+        time_step, data = data[0], np.array(data[1:], dtype=np.int32)
         snip_range = self.nengo_io_snip_range
 
         for probe in self._snip_probe_data:

--- a/nengo_loihi/hardware/interface.py
+++ b/nengo_loihi/hardware/interface.py
@@ -306,7 +306,7 @@ class HardwareInterface(object):
             shape = data[0].shape
             synapse = probe.synapse
             rng = None
-            step = (synapse.make_step(shape, shape, dt, rng, dtype=data.dtype)
+            step = (synapse.make_step(shape, shape, dt, rng, dtype=np.float32)
                     if synapse is not None else None)
             self._probe_filters[probe] = step
         else:
@@ -328,6 +328,7 @@ class HardwareInterface(object):
         if probe.use_snip:
             data = self._snip_probe_data[probe]
             if probe.synapse is not None:
+                data = np.asarray(data, dtype=np.float32)
                 return probe.synapse.filt(data, dt=self.model.dt, y0=0)
             else:
                 return data

--- a/nengo_loihi/tests/test_neurons.py
+++ b/nengo_loihi/tests/test_neurons.py
@@ -86,3 +86,35 @@ def test_loihi_neurons(neuron_type, Simulator, plt, allclose):
     atol = 1. / t_final  # the fundamental unit for our rates
     assert allclose(nengo_rates, ref, atol=atol, rtol=0, xtol=1)
     assert allclose(loihi_rates, ref, atol=atol, rtol=0, xtol=1)
+
+
+def test_lif_min_voltage(Simulator, plt, allclose):
+    neuron_type = nengo.LIF(min_voltage=-0.5)
+    t_final = 0.4
+
+    with nengo.Network() as model:
+        u = nengo.Node(lambda t: np.sin(4*np.pi*t / t_final))
+        a = nengo.Ensemble(1, 1, neuron_type=neuron_type,
+                           encoders=np.ones((1, 1)),
+                           max_rates=[100],
+                           intercepts=[0.5])
+        nengo.Connection(u, a, synapse=None)
+        ap = nengo.Probe(a.neurons, 'voltage')
+
+    with nengo.Simulator(model) as nengo_sim:
+        nengo_sim.run(t_final)
+
+    with Simulator(model) as loihi_sim:
+        loihi_sim.run(t_final)
+
+    nengo_voltage = nengo_sim.data[ap]
+    loihi_voltage = loihi_sim.data[ap]
+    loihi_voltage = loihi_voltage / loihi_voltage.max()
+    plt.plot(nengo_sim.trange(), nengo_voltage)
+    plt.plot(loihi_sim.trange(), loihi_voltage)
+
+    nengo_min_voltage = nengo_voltage.min()
+    loihi_min_voltage = loihi_voltage.min()
+
+    # Close, but not exact, because loihi min voltage rounded to power of 2
+    assert allclose(loihi_min_voltage, nengo_min_voltage, atol=0.2)

--- a/nengo_loihi/tests/test_probe.py
+++ b/nengo_loihi/tests/test_probe.py
@@ -16,7 +16,6 @@ def test_spike_units(Simulator, seed):
     assert len(values) == 2
 
 
-@pytest.mark.hang
 @pytest.mark.parametrize('dim', [1, 3])
 def test_voltage_decode(allclose, Simulator, seed, plt, dim):
     with nengo.Network(seed=seed) as model:
@@ -47,3 +46,58 @@ def test_repeated_probes(Simulator):
     for _ in range(5):
         with Simulator(net) as sim:
             sim.run(0.1)
+
+
+@pytest.mark.parametrize('precompute', [True, False])
+@pytest.mark.parametrize('probe_target', ['input', 'voltage'])
+def test_neuron_probes(precompute, probe_target, Simulator, seed, plt,
+                       allclose):
+    simtime = 0.3
+
+    with nengo.Network(seed=seed) as model:
+        stim = nengo.Node(lambda t: [np.sin(t * 2 * np.pi / simtime)])
+
+        a = nengo.Ensemble(1, 1,
+                           neuron_type=nengo.LIF(min_voltage=-1),
+                           encoders=nengo.dists.Choice([[1]]),
+                           max_rates=nengo.dists.Choice([100]),
+                           intercepts=nengo.dists.Choice([0.]))
+        nengo.Connection(stim, a, synapse=None)
+
+        p_stim = nengo.Probe(stim, synapse=0.005)
+        p_neurons = nengo.Probe(a.neurons, probe_target)
+
+        probe_synapse = nengo.Alpha(0.01)
+        p_stim_f = nengo.Probe(
+            stim, synapse=probe_synapse.combine(nengo.Lowpass(0.005)))
+        p_neurons_f = nengo.Probe(a.neurons, probe_target,
+                                  synapse=probe_synapse)
+
+    with Simulator(model, precompute=precompute) as sim:
+        sim.run(simtime)
+
+    scale = float(sim.data[p_neurons].max())
+    t = sim.trange()
+    x = sim.data[p_stim]
+    xf = sim.data[p_stim_f]
+    y = sim.data[p_neurons] / scale
+    yf = sim.data[p_neurons_f] / scale
+    plt.plot(t, x, label='stim')
+    plt.plot(t, xf, label='stim filt')
+    plt.plot(t, y, label='loihi')
+    plt.plot(t, yf, label='loihi filt')
+    plt.legend()
+
+    if probe_target == 'input':
+        # shape of current input should roughly match stimulus
+        assert allclose(y, x, atol=0.4, rtol=0)  # noisy, so rough match
+        assert allclose(yf, xf, atol=0.05, rtol=0)  # tight match
+    elif probe_target == 'voltage':
+        # check for voltage fluctuations (spiking) when stimulus is positive,
+        # and negative voltage when stimulus is most negative
+        spos = (t > 0.1 * simtime) & (t < 0.4 * simtime)
+        assert allclose(yf[spos], 0.5, atol=0.1, rtol=0.1)
+        assert y[spos].std() > 0.25
+
+        sneg = (t > 0.7 * simtime) & (t < 0.9 * simtime)
+        assert np.all(y[sneg] < 0)


### PR DESCRIPTION
This adds a test for neuron input (current) probes, which were not working correctly (due to negative values not being cast correctly, and integers not being filtered correctly). This also corrects both these issues.

TODO:
- [x] Add a test for voltage probes as well. The voltage should go negative, to test that we're dealing with negatives correctly. Do we currently allow `min_voltage < 0` for e.g. LIF neurons?