### PR TITLE
Apply style checks to commit messages

### DIFF
--- a/.ci/static.sh
+++ b/.ci/static.sh
@@ -8,6 +8,8 @@ NAME=$0
 COMMAND=$1
 
 if [[ "$COMMAND" == "install" ]]; then
+    # pip installs a more recent entrypoints version than conda
+    pip install entrypoints
     conda install --quiet jupyter
     pip install codespell flake8 pylint
 elif [[ "$COMMAND" == "script" ]]; then

--- a/.ci/static.sh
+++ b/.ci/static.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
-set -e -v  # exit immediately on error, and print each line as it executes
+set -v  # print each line as it executes
 shopt -s globstar
 
 # This script runs the static style checks
 
 NAME=$0
 COMMAND=$1
+STATUS=0  # used to exit with non-zero status if any check fails
 
 if [[ "$COMMAND" == "install" ]]; then
     # pip installs a more recent entrypoints version than conda
     pip install entrypoints
     conda install --quiet jupyter
-    pip install codespell flake8 pylint
+    pip install codespell flake8 pylint gitlint
 elif [[ "$COMMAND" == "script" ]]; then
     # Convert notebooks to Python scripts
     jupyter-nbconvert \
@@ -20,10 +21,18 @@ elif [[ "$COMMAND" == "script" ]]; then
         --TemplateExporter.exclude_input_prompt=True \
         -- **/*.ipynb
     sed -i -e 's/# $/#/g' -e '/get_ipython()/d' -- docs/**/*.py
-    flake8 nengo_loihi
-    flake8 --ignore=E226,E703,W291,W391,W503 docs
-    pylint docs nengo_loihi
-    codespell -q 3 --skip="./build,./docs/_build,*-checkpoint.ipynb"
+    flake8 nengo_loihi || STATUS=1
+    flake8 --ignore=E226,E703,W291,W391,W503 docs || STATUS=1
+    pylint docs nengo_loihi || STATUS=1
+    codespell -q 3 --skip="./build,./docs/_build,*-checkpoint.ipynb" || STATUS=1
+    # undo single-branch cloning
+    git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
+    git fetch origin master
+    N_COMMITS=$(git rev-list --count HEAD ^origin/master)
+    for ((i=0; i<N_COMMITS; i++)) do
+        git log -n 1 --skip $i --pretty=%B | gitlint -vvv || STATUS=1
+    done
 else
     echo "$NAME does not define $COMMAND"
 fi
+exit $STATUS

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,12 @@
+[general]
+ignore=body-is-missing
+
+[title-max-length]
+line-length=50
+
+[B1]
+# body line length
+line-length=72
+
+[title-match-regex]
+regex=^[A-Z]


### PR DESCRIPTION
Uses `gitlint` to check for style on commit messages.  I added a bunch of example commits to verify that it catches the cases we want it to catch (see https://travis-ci.com/nengo/nengo-loihi/jobs/174091637#L1044).

I also changed our static check script back so that it runs all of the checks before exiting (rather than exiting immediately on error).  Particularly with the commit checking, it's helpful to see all of the commit message errors at once.

Also fixed an error in the `flake8` installation (unrelated to `gitlint`, just triggered by the new `flake8` release, but required to get the static checks passing again).