### PR TITLE
Unset bash settings after scripts

### DIFF
--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Small snippets common to all CI scripts.
+# All CI scripts should source this script.
+
+exe() {
+    echo "\$ $*";
+    "$@";
+}

--- a/.ci/conda.sh
+++ b/.ci/conda.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-set -e -v  # exit immediately on error, and print each line as it executes
+set -e  # exit immediately on error
+if [[ ! -e .ci/common.sh || ! -e nengo_loihi ]]; then
+    echo "Run this script from the root directory of this repository"
+    exit 1
+fi
+source .ci/common.sh
 
 # This script sets up the conda environment for all the other scripts
 
@@ -8,14 +13,18 @@ COMMAND=$1
 MINICONDA="http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh"
 
 if [[ "$COMMAND" == "install" ]]; then
-    wget "$MINICONDA" --quiet -O miniconda.sh
-    bash miniconda.sh -b -p "$HOME/miniconda"
+    exe wget "$MINICONDA" --quiet -O miniconda.sh
+    exe bash miniconda.sh -b -p "$HOME/miniconda"
     export PATH="$HOME/miniconda/bin:$PATH"
-    conda config --set always_yes yes --set changeps1 no
-    conda update -q conda
-    conda info -a
-    conda create -q -n test python="$PYTHON" pip
-    source activate test
+    exe conda config --set always_yes yes --set changeps1 no
+    exe conda update -q conda
+    exe conda info -a
+    exe conda create -q -n test python="$PYTHON" pip
+    exe source activate test
+elif [[ -z "$COMMAND" ]]; then
+    echo "$NAME requires a command like 'install' or 'script'"
 else
     echo "$NAME does not define $COMMAND"
 fi
+
+set +e  # reset options in case this is sourced

--- a/.ci/docs.sh
+++ b/.ci/docs.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-set -e -v  # exit immediately on error, and print each line as it executes
+set -e  # exit immediately on error
+if [[ ! -e .ci/common.sh || ! -e nengo_loihi ]]; then
+    echo "Run this script from the root directory of this repository"
+    exit 1
+fi
+source .ci/common.sh
 
 # This script builds the documentation and uploads it to GitHub pages
 
@@ -7,22 +12,22 @@ NAME=$0
 COMMAND=$1
 
 if [[ "$COMMAND" == "install" ]]; then
-    conda install --quiet numpy "pandoc<2"
-    pip install cython jupyter matplotlib pillow requests scipy
-    pip install "git+https://github.com/nengo/nengo-dl.git@conv_transform"
-    pip install "git+https://github.com/abr/abr_control.git"
-    pip install -e .[docs]
+    exe conda install --quiet numpy "pandoc<2"
+    exe pip install cython jupyter matplotlib pillow requests scipy
+    exe pip install "git+https://github.com/nengo/nengo-dl.git@conv_transform"
+    exe pip install "git+https://github.com/abr/abr_control.git"
+    exe pip install -e .[docs]
 elif [[ "$COMMAND" == "script" ]]; then
-    sphinx-build -b linkcheck -v -W -D nbsphinx_execute=never docs docs/_build
+    exe sphinx-build -b linkcheck -v -W -D nbsphinx_execute=never docs docs/_build
 
     git clone -b gh-pages-release https://github.com/nengo/nengo-loihi.git ../nengo-docs
     RELEASES=$(find ../nengo-docs -maxdepth 1 -type d -name "v[0-9].*" -printf "%f,")
 
     if [[ "$TRAVIS_BRANCH" == "$TRAVIS_TAG" ]]; then
         RELEASES="$RELEASES$TRAVIS_TAG"
-        sphinx-build -b html docs ../nengo-docs/"$TRAVIS_TAG" -vW -A building_version="$TRAVIS_TAG" -A releases="$RELEASES"
+        exe sphinx-build -b html docs ../nengo-docs/"$TRAVIS_TAG" -vW -A building_version="$TRAVIS_TAG" -A releases="$RELEASES"
     else
-        sphinx-build -b html docs ../nengo-docs -vW -A building_version=latest -A releases="$RELEASES"
+        exe sphinx-build -b html docs ../nengo-docs -vW -A building_version=latest -A releases="$RELEASES"
     fi
 elif [[ "$COMMAND" == "after_success" ]]; then
     cd ../nengo-docs
@@ -30,15 +35,19 @@ elif [[ "$COMMAND" == "after_success" ]]; then
     git config --global user.name "TravisCI"
     git add --all
     if [[ "$TRAVIS_BRANCH" == "$TRAVIS_TAG" ]]; then
-        git commit -m "Documentation for release $TRAVIS_TAG"
-        git push -q "https://$GH_TOKEN@github.com/nengo/nengo-loihi.git" gh-pages-release
+        exe git commit -m "Documentation for release $TRAVIS_TAG"
+        exe git push -q "https://$GH_TOKEN@github.com/nengo/nengo-loihi.git" gh-pages-release
     elif [[ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" == "master" ]]; then
-        git commit -m "Last update at $(date '+%Y-%m-%d %T')"
-        git push -fq "https://$GH_TOKEN@github.com/nengo/nengo-loihi.git" gh-pages-release:gh-pages
+        exe git commit -m "Last update at $(date '+%Y-%m-%d %T')"
+        exe git push -fq "https://$GH_TOKEN@github.com/nengo/nengo-loihi.git" gh-pages-release:gh-pages
     elif [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-        git commit -m "Documentation for branch $TRAVIS_BRANCH"
-        git push -fq "https://$GH_TOKEN@github.com/nengo/nengo-loihi.git" gh-pages-release:gh-pages-test
+        exe git commit -m "Documentation for branch $TRAVIS_BRANCH"
+        exe git push -fq "https://$GH_TOKEN@github.com/nengo/nengo-loihi.git" gh-pages-release:gh-pages-test
     fi
+elif [[ -z "$COMMAND" ]]; then
+    echo "$NAME requires a command like 'install' or 'script'"
 else
     echo "$NAME does not define $COMMAND"
 fi
+
+set +e  # reset options in case this is sourced

--- a/.ci/emulator.sh
+++ b/.ci/emulator.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-set -e -v  # exit immediately on error, and print each line as it executes
+set -e  # exit immediately on error
+if [[ ! -e .ci/common.sh || ! -e nengo_loihi ]]; then
+    echo "Run this script from the root directory of this repository"
+    exit 1
+fi
+source .ci/common.sh
 
 # This script runs the test suite on the emulator
 
@@ -7,15 +12,19 @@ NAME=$0
 COMMAND=$1
 
 if [[ "$COMMAND" == "install" ]]; then
-    conda install --quiet matplotlib mkl numpy scipy tensorflow
-    pip install "git+https://github.com/nengo/nengo-dl.git@conv_transform"
-    pip install -e .[tests]
+    exe conda install --quiet matplotlib mkl numpy scipy tensorflow
+    exe pip install "git+https://github.com/nengo/nengo-dl.git@conv_transform"
+    exe pip install -e ".[tests]"
 elif [[ "$COMMAND" == "script" ]]; then
-    coverage run -m pytest nengo_loihi -v --duration 20 --plots --color=yes
-    coverage run -a -m pytest --pyargs nengo -v --duration 20 --color=yes
-    coverage report -m
+    exe coverage run -m pytest nengo_loihi -v --duration 20 --plots --color=yes
+    exe coverage run -a -m pytest --pyargs nengo -v --duration 20 --color=yes
+    exe coverage report -m
 elif [[ "$COMMAND" == "after_success" ]]; then
     eval "bash <(curl -s https://codecov.io/bash)"
+elif [[ -z "$COMMAND" ]]; then
+    echo "$NAME requires a command like 'install' or 'script'"
 else
     echo "$NAME does not define $COMMAND"
 fi
+
+set +e  # reset options in case this is sourced

--- a/.ci/hardware.sh
+++ b/.ci/hardware.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-set -e -v  # exit immediately on error, and print each line as it executes
+set -e  # exit immediately on error
+if [[ ! -e .ci/common.sh || ! -e nengo_loihi ]]; then
+    echo "Run this script from the root directory of this repository"
+    exit 1
+fi
+source .ci/common.sh
 
 # This script runs the test suite on the Loihi hardware (on the INRC cloud)
 
@@ -7,12 +12,12 @@ NAME=$0
 COMMAND=$1
 
 if [[ "$COMMAND" == "install" ]]; then
-    pip install coverage  # needed for the uploading in after_success
-    openssl aes-256-cbc -K $encrypted_e0365add3e93_key -iv $encrypted_e0365add3e93_iv -in .ci/travis_rsa.enc -out ~/.ssh/id_rsa -d  # decrypt private key, see https://docs.travis-ci.com/user/encrypting-files/
+    exe pip install coverage  # needed for the uploading in after_success
+    openssl aes-256-cbc -K "${encrypted_e0365add3e93_key:?}" -iv "${encrypted_e0365add3e93_iv:?}" -in .ci/travis_rsa.enc -out ~/.ssh/id_rsa -d  # decrypt private key, see https://docs.travis-ci.com/user/encrypting-files/
     chmod 600 ~/.ssh/id_rsa
     echo -e "$INTELHOST_INFO" >> ~/.ssh/config  # ssh config, stored in travis-ci settings
     ssh -o StrictHostKeyChecking=no loihihost "echo 'Connected to loihihost'"
-    scp -r . loihihost:/tmp/nengo-loihi-$TRAVIS_JOB_NUMBER
+    exe scp -r . "loihihost:/tmp/nengo-loihi-$TRAVIS_JOB_NUMBER"
 elif [[ "$COMMAND" == "script" ]]; then
     ssh loihihost << EOF
         sh /etc/profile
@@ -27,10 +32,14 @@ elif [[ "$COMMAND" == "script" ]]; then
         coverage xml
 EOF
 elif [[ "$COMMAND" == "after_success" ]]; then
-    scp loihihost:/tmp/nengo-loihi-$TRAVIS_JOB_NUMBER/coverage.xml coverage.xml
+    exe scp "loihihost:/tmp/nengo-loihi-$TRAVIS_JOB_NUMBER/coverage.xml" coverage.xml
     eval "bash <(curl -s https://codecov.io/bash)"
 elif [[ "$COMMAND" == "after_script" ]]; then
-    ssh loihihost "conda-env remove -y -n travis-ci-$TRAVIS_JOB_NUMBER"
+    exe ssh loihihost "conda-env remove -y -n travis-ci-$TRAVIS_JOB_NUMBER"
+elif [[ -z "$COMMAND" ]]; then
+    echo "$NAME requires a command like 'install' or 'script'"
 else
     echo "$NAME does not define $COMMAND"
 fi
+
+set +e  # reset options in case this is sourced

--- a/.ci/static.sh
+++ b/.ci/static.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
-set -v  # print each line as it executes
 shopt -s globstar
+if [[ ! -e .ci/common.sh || ! -e nengo_loihi ]]; then
+    echo "Run this script from the root directory of this repository"
+    exit 1
+fi
+source .ci/common.sh
 
 # This script runs the static style checks
 
@@ -10,9 +14,9 @@ STATUS=0  # used to exit with non-zero status if any check fails
 
 if [[ "$COMMAND" == "install" ]]; then
     # pip installs a more recent entrypoints version than conda
-    pip install entrypoints
-    conda install --quiet jupyter
-    pip install codespell flake8 pylint gitlint
+    exe pip install entrypoints
+    exe conda install --quiet jupyter
+    exe pip install codespell flake8 pylint gitlint
 elif [[ "$COMMAND" == "script" ]]; then
     # Convert notebooks to Python scripts
     jupyter-nbconvert \
@@ -21,18 +25,21 @@ elif [[ "$COMMAND" == "script" ]]; then
         --TemplateExporter.exclude_input_prompt=True \
         -- **/*.ipynb
     sed -i -e 's/# $/#/g' -e '/get_ipython()/d' -- docs/**/*.py
-    flake8 nengo_loihi || STATUS=1
-    flake8 --ignore=E226,E703,W291,W391,W503 docs || STATUS=1
-    pylint docs nengo_loihi || STATUS=1
-    codespell -q 3 --skip="./build,./docs/_build,*-checkpoint.ipynb" || STATUS=1
+    exe flake8 nengo_loihi || STATUS=1
+    exe flake8 --ignore=E226,E703,W291,W391,W503 docs || STATUS=1
+    exe pylint docs nengo_loihi || STATUS=1
+    exe codespell -q 3 --skip="./build,./docs/_build,*-checkpoint.ipynb" || STATUS=1
     # undo single-branch cloning
     git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
     git fetch origin master
     N_COMMITS=$(git rev-list --count HEAD ^origin/master)
     for ((i=0; i<N_COMMITS; i++)) do
-        git log -n 1 --skip $i --pretty=%B | grep -v '^Co-authored-by:' | gitlint -vvv || STATUS=1
+        git log -n 1 --skip $i --pretty=%B | grep -v '^Co-authored-by:' | exe gitlint -vvv || STATUS=1
     done
+elif [[ -z "$COMMAND" ]]; then
+    echo "$NAME requires a command like 'install' or 'script'"
 else
     echo "$NAME does not define $COMMAND"
 fi
+
 exit $STATUS

--- a/.ci/static.sh
+++ b/.ci/static.sh
@@ -29,6 +29,7 @@ elif [[ "$COMMAND" == "script" ]]; then
     exe flake8 --ignore=E226,E703,W291,W391,W503 docs || STATUS=1
     exe pylint docs nengo_loihi || STATUS=1
     exe codespell -q 3 --skip="./build,./docs/_build,*-checkpoint.ipynb" || STATUS=1
+    exe shellcheck -e SC2087 .ci/*.sh || STATUS=1
     # undo single-branch cloning
     git config --replace-all remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
     git fetch origin master

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,6 +54,7 @@ nbsphinx_timeout = -1
 # -- sphinx
 nitpicky = True
 exclude_patterns = ['_build']
+linkcheck_timeout = 30
 source_suffix = '.rst'
 source_encoding = 'utf-8'
 master_doc = 'index'


### PR DESCRIPTION
This is mainly relevant if these scripts are sourced, which happens for `conda.sh` on TravisCI. Once a script is sourced, the rest of the bash session will print all lines, which litters the TravsisCI log with internal commands that we can ignore like `travis_nanoseconds`.

This PR also gives a more informative error message if no command is passed to the script.