### PR TITLE
All split networks use same seeds as Nengo

### DIFF
--- a/nengo_loihi/tests/test_simulator.py
+++ b/nengo_loihi/tests/test_simulator.py
@@ -310,3 +310,54 @@ def test_tau_s_warning(Simulator):
     assert any(rec.message.args[0] == (
         "tau_s is already set to 0.1, which is larger than 0.005. Using 0.1."
     ) for rec in record)
+
+
+@pytest.mark.parametrize('precompute', [False, True])
+def test_seeds(precompute, Simulator, seed):
+    with nengo.Network(seed=seed) as model:
+        nengo_loihi.add_params(model)
+
+        e0 = nengo.Ensemble(1, 1)
+        e1 = nengo.Ensemble(1, 1, seed=2)
+        e2 = nengo.Ensemble(1, 1)
+        model.config[e2].on_chip = False
+        nengo.Connection(e0, e1)
+        nengo.Connection(e0, e2)
+
+        with nengo.Network():
+            n = nengo.Node(0)
+            e = nengo.Ensemble(1, 1)
+            nengo.Node(1)
+            nengo.Connection(n, e)
+            nengo.Probe(e)
+
+        with nengo.Network(seed=8):
+            nengo.Ensemble(8, 1, seed=3)
+            nengo.Node(1)
+
+    ref = nengo.Simulator(model)
+    sim = Simulator(model, precompute=precompute)
+
+    for obj in model.all_objects:
+        on_chip = (not isinstance(obj, nengo.Node) and (
+            not isinstance(obj, nengo.Ensemble) or model.config[obj].on_chip))
+
+        seed = sim.model.seeds.get(obj, None)
+        assert seed is None or seed == ref.model.seeds[obj]
+        if on_chip:
+            assert seed is not None
+        if obj in sim.model.seeded:
+            assert sim.model.seeded[obj] == ref.model.seeded[obj]
+
+        seed0, seed1 = None, None
+        if precompute:
+            seed0 = sim.sims["host_pre"].model.seeds.get(obj, None)
+            assert seed0 is None or seed0 == ref.model.seeds[obj]
+            seed1 = sim.sims["host"].model.seeds.get(obj, None)
+            assert seed1 is None or seed1 == ref.model.seeds[obj]
+        else:
+            seed0 = sim.sims["host"].model.seeds.get(obj, None)
+            assert seed0 is None or seed0 == ref.model.seeds[obj]
+
+        if not on_chip:
+            assert seed0 is not None or seed1 is not None


### PR DESCRIPTION
This is true for the host, host_pre, and chip networks.

This uses the `seed-loihi` branch of Nengo.