### PR TITLE
Fix bug with scalar probe weights

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,9 @@ Release history
   is correct, even if the underlying values are integers).
   (`#169 <https://github.com/nengo/nengo-loihi/pull/124>`_,
   `#141 <https://github.com/nengo/nengo-loihi/issues/141>`_)
+- Neuron (spike) probes can now be filtered with ``synapse`` objects.
+  (`#182 <https://github.com/nengo/nengo-loihi/issues/182>`__,
+  `#183 <https://github.com/nengo/nengo-loihi/pull/180>`__)
 
 0.4.0 (December 6, 2018)
 ========================

--- a/nengo_loihi/builder/probe.py
+++ b/nengo_loihi/builder/probe.py
@@ -95,7 +95,7 @@ def signal_probe(model, key, probe):
                 weights = 1.0 / model.dt
 
             if hasattr(probe.target.ensemble.neuron_type, 'amplitude'):
-                weights = weights * probe.target.ensemble.neuron_type.amplitude
+                weights *= probe.target.ensemble.neuron_type.amplitude
 
     # Signal probes directly probe a target signal
     target = model.objs[probe.obj]['out']

--- a/nengo_loihi/tests/test_probe.py
+++ b/nengo_loihi/tests/test_probe.py
@@ -101,3 +101,17 @@ def test_neuron_probes(precompute, probe_target, Simulator, seed, plt,
 
         sneg = (t > 0.7 * simtime) & (t < 0.9 * simtime)
         assert np.all(y[sneg] < 0)
+
+
+def test_neuron_probe_with_synapse(Simulator, seed, plt, allclose):
+    synapse = nengo.Lowpass(0.01)
+    with nengo.Network(seed=seed) as net:
+        ens = nengo.Ensemble(10, 1)
+        p_nosynapse = nengo.Probe(ens.neurons, synapse=None)
+        p_synapse = nengo.Probe(ens.neurons, synapse=synapse)
+
+    with Simulator(net) as sim:
+        sim.run(0.1)
+
+    assert allclose(sim.data[p_synapse],
+                    synapse.filt(sim.data[p_nosynapse]))


### PR DESCRIPTION
Scalar probe weights occur when probing spikes, which was not being handled correctly in the `EmulatorInterface`. This is used in the CIFAR-10 notebook.