### PR TITLE
Raise warning instead of error for progress bars

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,9 @@ Release history
 - Internal classes and functions have been reorganized and refactored.
   See the pull request for more details.
   (`#159 <https://github.com/nengo/nengo-loihi/pull/159>`_)
+- Simulator now gives a warning if the user requests a progress bar, instead
+  of an error. This avoids potential problems in ``nengo_gui`` and elsewhere.
+  (`#187 <https://github.com/nengo/nengo-loihi/pull/187>`_)
 
 **Fixed**
 

--- a/nengo_loihi/simulator.py
+++ b/nengo_loihi/simulator.py
@@ -283,7 +283,7 @@ class Simulator(object):
     ):
         self.closed = True  # Start closed in case constructor raises exception
         if progress_bar:
-            raise NotImplementedError("progress bars not implemented")
+            warnings.warn("nengo-loihi does not support progress bars")
 
         if model is None:
             # Call the builder to make a model

--- a/nengo_loihi/tests/test_simulator.py
+++ b/nengo_loihi/tests/test_simulator.py
@@ -277,7 +277,7 @@ def test_progressbar_values(Simulator):
         pass
 
     # progress bar not yet implemented
-    with pytest.raises(NotImplementedError):
+    with pytest.warns(UserWarning, match="progress bar"):
         with Simulator(model, progress_bar=True):
             pass
 


### PR DESCRIPTION
The GUI automatically tries to run with `progress_bar=True`, so raising a warning instead of an error allows the GUI to run successfully.