### PR TITLE
Only collect coverage for nengo_loihi

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,3 +27,6 @@ exclude_lines =
 # Patterns for files to exclude from reporting
 omit =
     */tests/*
+
+[coverage:run]
+source = nengo_loihi


### PR DESCRIPTION
This came up when testing some stuff from #185 locally. Not sure if we do this in our TravisCI build through a command line argument, but regardless this is useful when running coverage tests locally (otherwise the coverage report has way too much to read).