### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,8 +19,8 @@ Release history
    - Removed
    - Fixed
 
-0.6.0 (unreleased)
-==================
+0.6.0 (February 22, 2019)
+=========================
 
 **Changed**
 
@@ -28,12 +28,6 @@ Release history
   the classes previously in ``conv.py`` have been moved to Nengo as part of
   this transition. The MNIST convnet example demonstrates the new syntax.
   (`#142 <https://github.com/nengo/nengo-loihi/pull/142>`__)
-- Removed the ``NIF`` and ``NIFRate`` neuron types. These types were only used
-  for encoding node values in spikes to send to the chip, which can be done
-  just as well with ``nengo.SpikingRectifiedLinear`` neurons.
-  (`#185 <https://github.com/nengo/nengo-loihi/pull/185>`__)
-- Removed the unused/untested ``Synapse.set_diagonal_weights``.
-  (`#185 <https://github.com/nengo/nengo-loihi/pull/185>`__)
 - Emulator now fails for any cx_base < 0, except -1 which indicates
   an unused axon.
   (`#185 <https://github.com/nengo/nengo-loihi/pull/185>`__)
@@ -45,6 +39,15 @@ Release history
   of neuron on the chip, improving the accuracy of these model.
   (`#140 <https://github.com/nengo/nengo-loihi/pull/140>`__)
 
+**Removed**
+
+- Removed the ``NIF`` and ``NIFRate`` neuron types. These types were only used
+  for encoding node values in spikes to send to the chip, which can be done
+  just as well with ``nengo.SpikingRectifiedLinear`` neurons.
+  (`#185 <https://github.com/nengo/nengo-loihi/pull/185>`__)
+- Removed the unused/untested ``Synapse.set_diagonal_weights``.
+  (`#185 <https://github.com/nengo/nengo-loihi/pull/185>`__)
+
 **Fixed**
 
 - Objects in nengo-loihi will have the same random seeds as in
@@ -54,7 +57,6 @@ Release history
 - Seeded networks that have learning are now deterministic on both
   emulator and hardware.
   (`#140 <https://github.com/nengo/nengo-loihi/pull/140>`__)
-
 
 0.5.0 (February 12, 2019)
 =========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,11 @@ Release history
    - Removed
    - Fixed
 
+0.7.0 (unreleased)
+==================
+
+
+
 0.6.0 (February 22, 2019)
 =========================
 

--- a/nengo_loihi/tests/test_connection.py
+++ b/nengo_loihi/tests/test_connection.py
@@ -489,12 +489,14 @@ def test_ens_decoded_on_host(precompute, allclose, Simulator, seed, plt):
 def test_n2n_on_host(precompute, allclose, Simulator, seed_ens, seed, plt):
     """Ensure that neuron to neuron connections work on and off chip."""
 
+    if not seed_ens and nengo.version.version_info <= (2, 8, 0):
+        plt.saveas = None
+        pytest.xfail("Seeds change when moving ensembles off/on chip")
+
     n_neurons = 50
     # When the ensemble is seeded, the output plots will make more sense,
     # but the test should work whether they're seeded or not.
     ens_seed = (seed + 1) if seed_ens else None
-    if not seed_ens:
-        pytest.xfail("Seeds change when moving ensembles off/on chip")
     simtime = 1.0
 
     with nengo.Network(seed=seed) as model:

--- a/nengo_loihi/tests/test_conv.py
+++ b/nengo_loihi/tests/test_conv.py
@@ -186,6 +186,7 @@ def test_pop_tiny(pop_type, channels_last, nc, request, plt, seed, allclose):
 @pytest.mark.parametrize("channels_last", (True, False))
 def test_conv2d_weights(channels_last, request, plt, seed, rng, allclose):
     if channels_last:
+        plt.saveas = None
         pytest.xfail("Blocked by CxBase cannot be > 256 bug")
 
     pop_type = 32
@@ -329,6 +330,7 @@ def test_conv2d_weights(channels_last, request, plt, seed, rng, allclose):
 def test_conv_connection(channels, channels_last, Simulator, seed, rng, plt,
                          allclose):
     if channels_last:
+        plt.saveas = None
         pytest.xfail("Blocked by CxBase cannot be > 256 bug")
 
     # load data

--- a/nengo_loihi/version.py
+++ b/nengo_loihi/version.py
@@ -8,7 +8,7 @@ a release version. Release versions are git tagged with the version.
 
 name = "nengo_loihi"
 version_info = (0, 6, 0)  # (major, minor, patch)
-dev = 0
+dev = None
 
 version = "{v}{dev}".format(v='.'.join(str(v) for v in version_info),
                             dev=('.dev%d' % dev) if dev is not None else '')

--- a/nengo_loihi/version.py
+++ b/nengo_loihi/version.py
@@ -7,8 +7,8 @@ a release version. Release versions are git tagged with the version.
 """
 
 name = "nengo_loihi"
-version_info = (0, 6, 0)  # (major, minor, patch)
-dev = None
+version_info = (0, 7, 0)  # (major, minor, patch)
+dev = 0
 
 version = "{v}{dev}".format(v='.'.join(str(v) for v in version_info),
                             dev=('.dev%d' % dev) if dev is not None else '')


### PR DESCRIPTION
We had some empty plots again, so I fixed those in 1bf0cc6 and also noticed a test that we can probably re-enable now with the changes we've made. They pass on emulator, but wasn't sure about hardware, so I figured I'd make a PR and let TravisCI do that testing for me.

I included the two release commits here so that if this PR passes tests I can merge this in and then go back to the 0.6.0 release commit, push things to PyPI and tag it and all that once it's in master.