### PR TITLE
Improve speed of test suite

### DIFF
--- a/.ci/conda.sh
+++ b/.ci/conda.sh
@@ -12,14 +12,20 @@ COMMAND=$1
 MINICONDA="http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh"
 
 if [[ "$COMMAND" == "install" ]]; then
-    exe wget "$MINICONDA" --quiet -O miniconda.sh
-    exe bash miniconda.sh -b -p "$HOME/miniconda"
     export PATH="$HOME/miniconda/bin:$PATH"
+    if ! [[ -d $HOME/miniconda/envs/test ]]; then
+        exe rm -rf "$HOME/miniconda"
+        exe wget "$MINICONDA" --quiet -O miniconda.sh
+        exe bash miniconda.sh -b -p "$HOME/miniconda"
+        exe conda create --quiet -y -n test python="$PYTHON" pip
+    fi
     exe conda config --set always_yes yes --set changeps1 no
     exe conda update -q conda
     exe conda info -a
-    exe conda create -q -n test python="$PYTHON" pip
     exe source activate test
+    exe pip install pip
+elif [[ "$COMMAND" == "before_cache" ]]; then
+    conda clean --all
 elif [[ -z "$COMMAND" ]]; then
     echo "$NAME requires a command like 'install' or 'script'"
 else

--- a/.ci/emulator.sh
+++ b/.ci/emulator.sh
@@ -16,9 +16,8 @@ if [[ "$COMMAND" == "install" ]]; then
     exe pip install -e ".[tests]"
     exe pip install "$NENGO_VERSION"
 elif [[ "$COMMAND" == "script" ]]; then
-    exe coverage run -m pytest nengo_loihi -v --duration 20 --plots --color=yes -n 2
-    exe coverage run -a -m pytest --pyargs nengo -v --duration 20 --color=yes -n 2
-    exe coverage report -m
+    exe pytest nengo_loihi -v --duration 20 --plots --color=yes -n 2 --cov=nengo_loihi
+    exe pytest --pyargs nengo -v --duration 20 --color=yes -n 2 --cov=nengo_loihi --cov-append
 elif [[ "$COMMAND" == "after_script" ]]; then
     eval "bash <(curl -s https://codecov.io/bash)"
 elif [[ -z "$COMMAND" ]]; then

--- a/.ci/emulator.sh
+++ b/.ci/emulator.sh
@@ -16,8 +16,8 @@ if [[ "$COMMAND" == "install" ]]; then
     exe pip install -e ".[tests]"
     exe pip install "$NENGO_VERSION"
 elif [[ "$COMMAND" == "script" ]]; then
-    exe coverage run -m pytest nengo_loihi -v --duration 20 --plots --color=yes
-    exe coverage run -a -m pytest --pyargs nengo -v --duration 20 --color=yes
+    exe coverage run -m pytest nengo_loihi -v --duration 20 --plots --color=yes -n 2
+    exe coverage run -a -m pytest --pyargs nengo -v --duration 20 --color=yes -n 2
     exe coverage report -m
 elif [[ "$COMMAND" == "after_script" ]]; then
     eval "bash <(curl -s https://codecov.io/bash)"

--- a/.ci/hardware.sh
+++ b/.ci/hardware.sh
@@ -29,7 +29,7 @@ elif [[ "$COMMAND" == "script" ]]; then
         pip install -e .[tests]
         pip install $NENGO_VERSION
         pip install ~/travis-ci/nxsdk-0.8.0.tar.gz
-        SLURM=1 coverage run -m pytest --target loihi --no-hang -v --durations 50 --color=yes || HW_STATUS=1
+        SLURM=1 coverage run -m pytest --target loihi --no-hang -v --durations 50 --color=yes -n 2 || HW_STATUS=1
         coverage report -m
         coverage xml
         exit \$HW_STATUS

--- a/.ci/hardware.sh
+++ b/.ci/hardware.sh
@@ -29,9 +29,7 @@ elif [[ "$COMMAND" == "script" ]]; then
         pip install -e .[tests]
         pip install $NENGO_VERSION
         pip install ~/travis-ci/nxsdk-0.8.0.tar.gz
-        SLURM=1 coverage run -m pytest --target loihi --no-hang -v --durations 50 --color=yes -n 2 || HW_STATUS=1
-        coverage report -m
-        coverage xml
+        SLURM=1 pytest --target loihi --no-hang -v --durations 50 --color=yes -n 2 --cov=nengo_loihi --cov-report=xml || HW_STATUS=1
         exit \$HW_STATUS
 EOF
 elif [[ "$COMMAND" == "after_script" ]]; then

--- a/.ci/static.sh
+++ b/.ci/static.sh
@@ -15,7 +15,8 @@ if [[ "$COMMAND" == "install" ]]; then
     # pip installs a more recent entrypoints version than conda
     exe pip install entrypoints
     exe conda install --quiet jupyter
-    exe pip install codespell flake8 pylint gitlint
+    # astroid==2.2 causes an error when running pylint
+    exe pip install codespell flake8 pylint gitlint "astroid<2.2.0"
 elif [[ "$COMMAND" == "script" ]]; then
     # Convert notebooks to Python scripts
     jupyter-nbconvert \

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,17 @@ sudo: false
 notifications:
   email:
     - tbekolay@gmail.com
+cache:
+  directories:
+  - $HOME/miniconda
+  timeout: 600
 
 env:
   global:
     - PYTHON="3.5.2"
     - NENGO_VERSION="nengo"
+    - PIP_UPGRADE="true"
+    - PIP_UPGRADE_STRATEGY="eager"
 
 matrix:
   include:
@@ -17,6 +23,7 @@ matrix:
     - stage: advanced
       env: MODE="emulator"
            NENGO_VERSION="git+https://github.com/nengo/nengo.git"
+      cache: false
     - env: MODE="hardware"
            NENGO_VERSION="git+https://github.com/nengo/nengo.git"
     - env: MODE="docs"
@@ -30,6 +37,9 @@ install:
 
 script:
   - .ci/$MODE.sh script
+
+before_cache:
+  - .ci/conda.sh before_cache
 
 after_success:
   - .ci/$MODE.sh after_success

--- a/conftest.py
+++ b/conftest.py
@@ -118,7 +118,7 @@ def seed(request):
 def allclose(request):
     def safe_rms(x):
         x = np.asarray(x)
-        return npext.rms(x) if x.size > 0 else np.nan
+        return npext.rms(x).item() if x.size > 0 else np.nan
 
     def _allclose(a, b, rtol=1e-5, atol=1e-8, xtol=0,
                   equal_nan=False, print_fail=5):

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,3 +26,5 @@ exclude_lines =
 # Patterns for files to exclude from reporting
 omit =
     */tests/*
+
+show_missing = true

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
             "coverage>=4.3",
             "nengo-extras",
             "pytest>=3.4,<4",
+            "pytest-xdist>=1.26.0",
             "matplotlib>=2.0",
             "scipy",
         ],

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
             "coverage>=4.3",
             "nengo-extras",
             "pytest>=3.4,<4",
+            "pytest-cov>=2.6.0",
             "pytest-xdist>=1.26.0",
             "matplotlib>=2.0",
             "scipy",


### PR DESCRIPTION
Two improvements to test time.  First, use pytest-xdist to run tests in parallel.  This has the most significant impact on the hardware tests, as we can run jobs on different boards simultaneously.  Second, uses TravisCI's caching functionality to reduce the amount of time we spend setting up the environment for each job.  This will be slower for a cache miss, but should hopefully improve things overall (depends on how often the environment changes); we should keep an eye on it to make sure that we aren't getting too many cache misses.