### PR TITLE
Multi-chip support, testing, and failure modes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,13 @@ Release history
 0.7.0 (unreleased)
 ==================
 
+**Added**
 
+- Added ``RoundRobin`` allocator, which allows networks to be run across
+  multiple chips (multi-chip) by assigning each ensemble to a different chip
+  in a round-robin format. This allocator can be selected using the
+  ``hardware_options`` argument when creating ``nengo_loihi.Simulator``.
+  (`#197 <https://github.com/nengo/nengo-loihi/pull/197>`__)
 
 0.6.0 (February 22, 2019)
 =========================

--- a/nengo_loihi/hardware/builder.py
+++ b/nengo_loihi/hardware/builder.py
@@ -3,6 +3,7 @@ from __future__ import division
 import logging
 
 import nengo.utils.numpy as npext
+from nengo.exceptions import BuildError
 from nengo.utils.stdlib import groupby
 import numpy as np
 
@@ -435,6 +436,14 @@ def collect_axons(n2core, core, block, axon, cx_ids):
             assert (n_blocks == 0
                     or (n_blocks == 1 and block is core.blocks[0]))
             assert len(block.probes) == 0
+            tchip_id_source = n2board.n2Chips[core.chip.index].id
+            if tchip_id != tchip_id_source:
+                raise BuildError("pop16 and pop32 weights are not "
+                                 "supported across multiple chips "
+                                 "(%d -> %d); this is likely raised due "
+                                 "to convolutional weights being used "
+                                 "with a multi-chip allocator" % (
+                                     tchip_id_source, tchip_id))
         else:
             raise ValueError("Axon: unrecognized pop_type: %s" % (
                 synapse.pop_type,))

--- a/nengo_loihi/hardware/builder.py
+++ b/nengo_loihi/hardware/builder.py
@@ -24,9 +24,9 @@ logger = logging.getLogger(__name__)
 
 
 def build_board(board, seed=None):
-    n_chips = board.n_chips()
-    n_cores_per_chip = board.n_cores_per_chip()
-    n_synapses_per_core = board.n_synapses_per_core()
+    n_chips = board.n_chips
+    n_cores_per_chip = board.n_cores_per_chip
+    n_synapses_per_core = board.n_synapses_per_core
     n2board = N2Board(
         board.board_id, n_chips, n_cores_per_chip, n_synapses_per_core)
 

--- a/nengo_loihi/hardware/interface.py
+++ b/nengo_loihi/hardware/interface.py
@@ -35,9 +35,13 @@ class HardwareInterface:
         Model specification that will be placed on the Loihi board.
     seed : int, optional (Default: None)
         A seed for stochastic operations.
+    snip_max_spikes_per_step : int
+        The maximum number of spikes that can be sent to the chip in one
+        timestep if ``.use_snips`` is True.
     """
 
-    def __init__(self, model, use_snips=True, seed=None):
+    def __init__(self, model, use_snips=True, seed=None,
+                 snip_max_spikes_per_step=50):
         self.closed = False
         self.use_snips = use_snips
         self.check_nxsdk_version()
@@ -52,7 +56,7 @@ class HardwareInterface:
 
         # Maximum number of spikes that can be sent through
         # the nengo_io_h2c channel on one timestep.
-        self.snip_max_spikes_per_step = 50
+        self.snip_max_spikes_per_step = snip_max_spikes_per_step
 
         nxsdk_dir = os.path.realpath(
             os.path.join(os.path.dirname(nxsdk.__file__), "..")

--- a/nengo_loihi/hardware/nxsdk_objects.py
+++ b/nengo_loihi/hardware/nxsdk_objects.py
@@ -70,6 +70,11 @@ class Chip:
         self.core_idxs = {}
 
     @property
+    def index(self):
+        """Index of this Chip in the parent Board"""
+        return self.board.chip_index(self)
+
+    @property
     def n_cores(self):
         return len(self.cores)
 

--- a/nengo_loihi/hardware/nxsdk_objects.py
+++ b/nengo_loihi/hardware/nxsdk_objects.py
@@ -23,6 +23,19 @@ class Board:
 
         self.probe_map = {}
 
+    @property
+    def n_chips(self):
+        return len(self.chips)
+
+    @property
+    def n_cores_per_chip(self):
+        return [chip.n_cores for chip in self.chips]
+
+    @property
+    def n_synapses_per_core(self):
+        return [[core.n_synapses for core in chip.cores]
+                for chip in self.chips]
+
     def _add_chip(self, chip):
         assert chip not in self.chips
         self.chip_idxs[chip] = len(self.chips)
@@ -48,16 +61,6 @@ class Board:
     def find_synapse(self, synapse):
         return self.synapse_index[synapse]
 
-    def n_chips(self):
-        return len(self.chips)
-
-    def n_cores_per_chip(self):
-        return [chip.n_cores() for chip in self.chips]
-
-    def n_synapses_per_core(self):
-        return [[core.n_synapses() for core in chip.cores]
-                for chip in self.chips]
-
 
 class Chip:
     def __init__(self, board):
@@ -65,6 +68,10 @@ class Chip:
 
         self.cores = []
         self.core_idxs = {}
+
+    @property
+    def n_cores(self):
+        return len(self.cores)
 
     def _add_core(self, core):
         assert core not in self.cores
@@ -78,9 +85,6 @@ class Chip:
 
     def core_index(self, core):
         return self.core_idxs[core]
-
-    def n_cores(self):
-        return len(self.cores)
 
 
 class Core:
@@ -107,6 +111,11 @@ class Core:
     @property
     def synapses(self):
         return list(self.synapse_axons)
+
+    @property
+    def n_synapses(self):
+        return sum(synapse.size() for block in self.blocks
+                   for synapse in block.synapses)
 
     def iterate_blocks(self):
         i0 = 0
@@ -151,10 +160,6 @@ class Core:
         self.stdpPreCfgs.append(stdp_pre_cfg)
         return len(self.stdpPreCfgs) - 1  # index
 
-    def n_synapses(self):
-        return sum(synapse.size() for block in self.blocks
-                   for synapse in block.synapses)
-
     def add_synapse(self, synapse):
         synapse_fmt_idx = self.get_synapse_fmt_idx(synapse.synapse_fmt)
         self.synapse_fmt_idxs[synapse] = synapse_fmt_idx
@@ -174,9 +179,6 @@ class Core:
             s0 = self.synapse_entries[last][1]
         s1 = s0 + synapse.size()
         self.synapse_entries[synapse] = (s0, s1)
-
-    def add_axon(self, axon):
-        pass
 
     def get_synapse_fmt(self, synapse):
         return self.synapseFmts[self.synapse_fmt_idxs[synapse]]

--- a/nengo_loihi/hardware/tests/test_allocators.py
+++ b/nengo_loihi/hardware/tests/test_allocators.py
@@ -1,5 +1,6 @@
 import nengo
 from nengo.exceptions import BuildError, ValidationError
+from nengo.utils.numpy import rms
 import numpy as np
 import pytest
 
@@ -195,3 +196,47 @@ def test_round_robin_allocator_over():
     assert len(chip2.cores[0].synapses) == 0
     assert len(chip2.cores[0].blocks) == 0
     assert len(chip2.cores[0].inputs) == 1
+
+
+@pytest.mark.skipif(pytest.config.getoption('--target') != 'loihi',
+                    reason="Hardware allocators are Loihi-only")
+def test_deterministic_network_allocation(Simulator, seed):
+    # test that we get the same simulations results across allocators.
+    # the determinism of the allocation itself is covered by other unit tests.
+    n_neurons = 64
+    n_ensembles = 8
+    tau = 0.1
+    sim_t = 1.0
+
+    with nengo.Network(seed=seed) as model:
+        prev = nengo.Node(output=1)
+
+        p = []
+        for i in range(n_ensembles):
+            ens = nengo.Ensemble(n_neurons, 1)
+            nengo.Connection(prev, ens, synapse=tau)
+            p.append(nengo.Probe(ens, synapse=tau))
+            prev = ens
+
+    with nengo.Simulator(model) as sim_ref:
+        sim_ref.run(sim_t)
+
+    allocation = [
+        (1, OneToOne()),
+        (1, RoundRobin(n_chips=1)),
+        (3, RoundRobin(n_chips=3)),
+        (8, RoundRobin(n_chips=8)),
+    ]
+
+    sim_prev = None
+    for n_chips_used, allocator in allocation:
+        with Simulator(model, precompute=True,
+                       hardware_options={'allocator': allocator}) as sim_loihi:
+            sim_loihi.run(sim_t)
+
+        assert n_chips_used == sim_loihi.sims["loihi"].board.n_chips
+        for p_i in p:
+            assert rms(sim_loihi.data[p_i] - sim_ref.data[p_i]) < 0.05
+            if sim_prev is not None:
+                assert np.allclose(sim_prev.data[p_i], sim_loihi.data[p_i])
+        sim_prev = sim_loihi

--- a/nengo_loihi/hardware/tests/test_allocators.py
+++ b/nengo_loihi/hardware/tests/test_allocators.py
@@ -3,13 +3,16 @@ from nengo.exceptions import BuildError, ValidationError
 import numpy as np
 import pytest
 
-from nengo_loihi.block import LoihiBlock, Synapse
+from nengo_loihi.block import LoihiBlock, Synapse, Axon
 from nengo_loihi.builder import Model
+from nengo_loihi.discretize import discretize_model
 from nengo_loihi.hardware.allocators import (
     core_stdp_pre_cfgs,
-    one_to_one_allocator,
+    OneToOne,
+    RoundRobin,
 )
 from nengo_loihi.hardware.nxsdk_objects import Board
+from nengo_loihi.inputs import LoihiInput
 
 
 def test_core_stdp_pre_cfgs():
@@ -57,4 +60,138 @@ def test_one_to_one_allocator_big_block_error():
     model.add_block(LoihiBlock(1050))
 
     with pytest.raises(ValidationError):
-        one_to_one_allocator(model)
+        OneToOne()(model)
+
+
+def _basic_model():
+    model = Model()
+
+    block0 = LoihiBlock(1)
+    block0.compartment.configure_lif()
+    model.add_block(block0)
+
+    block1 = LoihiBlock(1)
+    block1.compartment.configure_lif()
+    model.add_block(block1)
+
+    axon1 = Axon(1)
+    block0.add_axon(axon1)
+
+    synapse1 = Synapse(1)
+    synapse1.set_full_weights([1])
+    axon1.target = synapse1
+    block1.add_synapse(synapse1)
+
+    axon0 = Axon(1)
+    input = LoihiInput()
+    input.add_axon(axon0)
+    model.add_input(input)
+
+    synapse0 = Synapse(1)
+    synapse0.set_full_weights([1])
+    axon0.target = synapse0
+    block0.add_synapse(synapse0)
+
+    discretize_model(model)
+
+    return model
+
+
+@pytest.mark.parametrize("allocator", [OneToOne(), RoundRobin(n_chips=1)])
+def test_one_to_one_allocator(allocator):
+    # RoundRobin(n_chips=1) is equivalent to OneToOne()
+    model = _basic_model()
+    board = allocator(model)
+
+    assert board.n_chips == 1
+    assert board.n_cores_per_chip == [3]
+    assert board.n_synapses_per_core == [[1, 1, 0]]
+
+    chip = board.chips[0]
+    assert chip.board is board
+    assert chip.n_cores == 3
+
+    assert chip.cores[0].chip is chip
+    assert len(chip.cores[0].synapses) == 1
+    assert len(chip.cores[0].blocks) == 1
+    assert len(chip.cores[0].inputs) == 0
+
+    assert chip.cores[1].chip is chip
+    assert len(chip.cores[1].synapses) == 1
+    assert len(chip.cores[1].blocks) == 1
+    assert len(chip.cores[1].inputs) == 0
+
+    assert chip.cores[2].chip is chip
+    assert len(chip.cores[2].synapses) == 0
+    assert len(chip.cores[2].blocks) == 0
+    assert len(chip.cores[2].inputs) == 1
+
+
+def test_round_robin_allocator_under():
+    model = _basic_model()
+
+    board = RoundRobin(n_chips=2)(model)
+
+    assert board.n_chips == 2
+    assert board.n_cores_per_chip == [2, 1]
+    assert board.n_synapses_per_core == [[1, 0], [1]]
+
+    chip0 = board.chips[0]
+    assert chip0.board is board
+    assert chip0.n_cores == 2
+
+    assert chip0.cores[0].chip is chip0
+    assert len(chip0.cores[0].synapses) == 1
+    assert len(chip0.cores[0].blocks) == 1
+    assert len(chip0.cores[0].inputs) == 0
+
+    assert chip0.cores[1].chip is chip0
+    assert len(chip0.cores[1].synapses) == 0
+    assert len(chip0.cores[1].blocks) == 0
+    assert len(chip0.cores[1].inputs) == 1
+
+    chip1 = board.chips[1]
+    assert chip1.board is board
+    assert chip1.n_cores == 1
+
+    assert chip1.cores[0].chip is chip1
+    assert len(chip1.cores[0].synapses) == 1
+    assert len(chip1.cores[0].blocks) == 1
+    assert len(chip1.cores[0].inputs) == 0
+
+
+def test_round_robin_allocator_over():
+    model = _basic_model()
+
+    board = RoundRobin(n_chips=4)(model)
+
+    assert board.n_chips == 3
+    assert board.n_cores_per_chip == [1, 1, 1]
+    assert board.n_synapses_per_core == [[1], [1], [0]]
+
+    chip0 = board.chips[0]
+    assert chip0.board is board
+    assert chip0.n_cores == 1
+
+    assert chip0.cores[0].chip is chip0
+    assert len(chip0.cores[0].synapses) == 1
+    assert len(chip0.cores[0].blocks) == 1
+    assert len(chip0.cores[0].inputs) == 0
+
+    chip1 = board.chips[1]
+    assert chip1.board is board
+    assert chip1.n_cores == 1
+
+    assert chip1.cores[0].chip is chip1
+    assert len(chip1.cores[0].synapses) == 1
+    assert len(chip1.cores[0].blocks) == 1
+    assert len(chip1.cores[0].inputs) == 0
+
+    chip2 = board.chips[2]
+    assert chip2.board is board
+    assert chip2.n_cores == 1
+
+    assert chip2.cores[0].chip is chip2
+    assert len(chip2.cores[0].synapses) == 0
+    assert len(chip2.cores[0].blocks) == 0
+    assert len(chip2.cores[0].inputs) == 1

--- a/nengo_loihi/hardware/tests/test_interface.py
+++ b/nengo_loihi/hardware/tests/test_interface.py
@@ -6,7 +6,7 @@ from nengo_loihi.block import Axon, LoihiBlock, Synapse
 from nengo_loihi.builder import Model
 from nengo_loihi.discretize import discretize_model
 from nengo_loihi.hardware import interface as hardware_interface
-from nengo_loihi.hardware.allocators import one_to_one_allocator
+from nengo_loihi.hardware.allocators import OneToOne
 from nengo_loihi.hardware.builder import build_board
 
 
@@ -61,7 +61,7 @@ def test_builder_poptype_errors():
 
     discretize_model(model)
 
-    allocator = one_to_one_allocator  # one core per ensemble
+    allocator = OneToOne()  # one core per ensemble
     board = allocator(model)
 
     with pytest.raises(ValueError, match="[Ss]ynapse.*[Uu]nrec.*pop.*type"):
@@ -87,7 +87,6 @@ def test_builder_poptype_errors():
 
     discretize_model(model)
 
-    allocator = one_to_one_allocator  # one core per ensemble
     board = allocator(model)
 
     with pytest.raises(ValueError, match="[Aa]xon.*[Uu]nrec.*pop.*type"):

--- a/nengo_loihi/simulator.py
+++ b/nengo_loihi/simulator.py
@@ -71,6 +71,9 @@ class Simulator:
         Whether the simulator should target the emulator (``'sim'``) or
         Loihi hardware (``'loihi'``). If None, *target* will default to
         ``'loihi'`` if NxSDK is installed, and the emulator if it is not.
+    hardware_options : dict, optional (Default: {})
+        Dictionary of additional configuration for the hardware.
+        See `.hardware.HardwareInterface` for possible parameters.
 
     Attributes
     ----------
@@ -287,7 +290,8 @@ class Simulator:
             precompute=False,
             target=None,
             progress_bar=None,
-            remove_passthrough=True
+            remove_passthrough=True,
+            hardware_options=None,
     ):
         # initialize values used in __del__ and close() first
         self.closed = True
@@ -295,6 +299,8 @@ class Simulator:
         self.networks = None
         self.sims = OrderedDict()
         self._run_steps = None
+
+        hardware_options = {} if hardware_options is None else hardware_options
 
         if progress_bar:
             warnings.warn("nengo-loihi does not support progress bars")
@@ -392,7 +398,8 @@ class Simulator:
         elif target == 'loihi':
             assert HAS_NXSDK, "Must have NxSDK installed to use Loihi hardware"
             self.sims["loihi"] = HardwareInterface(
-                self.model, use_snips=not self.precompute, seed=seed)
+                self.model, use_snips=not self.precompute, seed=seed,
+                **hardware_options)
         else:
             raise ValidationError("Must be 'simreal', 'sim', or 'loihi'",
                                   attr="target")


### PR DESCRIPTION
Abstracted two different methods of allocating resources to models:
 - `OneToOne()` which is the same method as before (default)
 - `RoundRobin(n_chips)` which cycles through chips per block / input

Ran the entire unit test suite with a manually-overwritten default of `allocator=RoundRobin(n_chips=8)` (on our local host; not shown) and discovered that all failed tests currently fall into one of two categories:
 1. Convolutional weights (`pop[16|32]`) across chips
 2. Use of SNIPS (`precompute=False`)

Multi-chip support is otherwise working and the user can override / customize the behaviour, with the following notes:
 - `RoundRobin(n_chips)` gives _identical_ behaviour across any number of `n_chips` between `1` and `8` inclusive (unit-tested).
 - Each failure mode currently returns an error (unit-tested).

The current syntax for running a multi-chip simulation of the model is:
```python
from nengo_loihi.hardware.allocators import RoundRobin  # or OneToOne

with Simulator(model, precompute=True,
               hardware_options={'allocator': RoundRobin(n_chips=8)}):
    ...
```

Todo:
 - [x] Is this abstraction okay for now? I realize things may change and so this is just a basic starting point that can be adapted.
 - [x] Is this an acceptable level of exposure to the user, even if it might change in the future? Or do we have better ways of exposing advanced configuration? _(Resolution: will need to rethink global simulator configuration at the level of Nengo core)_
 - [x] Are there more appropriate exceptions to raise?