### PR TITLE
Nengo version check

### DIFF
--- a/nengo_loihi/__init__.py
+++ b/nengo_loihi/__init__.py
@@ -1,6 +1,8 @@
 import logging
 
-from .version import version as __version__
+from .version import check_nengo_version, version as __version__
+check_nengo_version()
+del check_nengo_version
 
 from .simulator import Simulator
 from .config import add_params, set_defaults

--- a/nengo_loihi/tests/test_version.py
+++ b/nengo_loihi/tests/test_version.py
@@ -1,0 +1,47 @@
+import nengo.version
+import pytest
+
+from nengo_loihi import version
+from nengo_loihi.version import check_nengo_version
+
+
+def test_nengo_version(Simulator, monkeypatch):
+    # test nengo version below minimum
+    monkeypatch.setattr(nengo.version, 'version_info', (2, 0, 0))
+    with pytest.raises(ValueError):
+        check_nengo_version()
+
+    # test nengo version newer than latest
+    monkeypatch.setattr(nengo.version, 'version_info', (99, 0, 0))
+    with pytest.warns(UserWarning):
+        check_nengo_version()
+
+
+def test_nengo_version_check():
+    # note: we rely on travis-ci to test this against different nengo versions
+
+    if version.dev is not None or nengo.version.dev is None:
+        # nengo_loihi should be compatible with all non-development nengo
+        # versions, and a nengo_loihi dev version should be compatible with all
+        # (dev or non-dev) nengo versions
+        assert nengo.version.version_info <= version.latest_nengo_version_info
+        with pytest.warns(None) as w:
+            check_nengo_version()
+
+        assert len(w) == 0, (
+            "Should not warn about version: %s" % [str(x.message) for x in w])
+    else:  # version.dev is None and nengo.version.dev is not None
+        # a development version of nengo with a non-development nengo_loihi
+        # version should cause a warning (we don't want to mark a nengo_loihi
+        # release as compatible with a nengo dev version, since the nengo
+        # version may change and no longer be compatible with our nengo_loihi
+        # release).
+
+        # note: we assume that a nengo dev version means the latest dev version
+        assert nengo.version.version_info >= version.latest_nengo_version_info
+
+        # if no warning is issued here, it may mean you're forgetting to set
+        # the `latest_nengo_version` back to the last released nengo version
+        # when nengo_loihi is being released.
+        with pytest.warns(UserWarning, match="This version.*not been tested"):
+            check_nengo_version()

--- a/nengo_loihi/version.py
+++ b/nengo_loihi/version.py
@@ -5,10 +5,41 @@ and conform to PEP440 (see https://www.python.org/dev/peps/pep-0440/).
 '.devN' will be added to the version unless the code base represents
 a release version. Release versions are git tagged with the version.
 """
+import warnings
+
+
+def check_nengo_version():
+    import nengo
+
+    if nengo.version.version_info < minimum_nengo_version_info:
+        raise ValueError(
+            "nengo-loihi does not support Nengo version %s. "
+            "Upgrade with 'pip install --upgrade --no-deps nengo'."
+            % nengo.__version__)
+    elif nengo.version.version_info > latest_nengo_version_info:
+        warnings.warn("This version of `nengo_loihi` has not been tested "
+                      "with your `nengo` version (%s). The latest fully "
+                      "supported version is %s" % (
+                          nengo.__version__, latest_nengo_version))
+
+
+def info2string(info):
+    return '.'.join(str(v) for v in info)
+
 
 name = "nengo_loihi"
 version_info = (0, 7, 0)  # (major, minor, patch)
 dev = 0
 
-version = "{v}{dev}".format(v='.'.join(str(v) for v in version_info),
+version = "{v}{dev}".format(v=info2string(version_info),
                             dev=('.dev%d' % dev) if dev is not None else '')
+
+# --- Nengo version compatibility
+# oldest nengo version we are compatible with (test on release)
+minimum_nengo_version_info = (2, 7, 0)
+minimum_nengo_version = info2string(minimum_nengo_version_info)
+
+# newest nengo version we are compatible with (set to lastest released nengo
+# version when releasing this repository)
+latest_nengo_version_info = (3, 0, 0)
+latest_nengo_version = info2string(latest_nengo_version_info)


### PR DESCRIPTION
Check Nengo version for compatibility. 

- Error if Nengo version is too old
- Warn if Nengo version is newer than latest tested version

TODO:
- [x] I moved the error to `__init__.py`, since otherwise if you use an earlier nengo version you just get an `ImportError` because `SpikingRectifiedLinear` doesn't exist in Nengo. So we need to check and error early (before these imports). However, I'm not sure how to test this early error, since it happens in `__init__.py` so we can't use monkeypatch (at least not in any way I'm aware of).