### PR TITLE
Splitter refactoring

### DIFF
--- a/.ci/hardware.sh.template
+++ b/.ci/hardware.sh.template
@@ -21,7 +21,7 @@
         pip install -e .[tests]
         pip install $NENGO_VERSION --upgrade
         pip install ~/travis-ci/nxsdk-0.8.0.tar.gz
-        SLURM=1 pytest --target loihi --no-hang -v --durations 50 --color=yes -n 2 --cov=nengo_loihi --cov-report=xml --cov-report=term-missing || HW_STATUS=1
+        SLURM=1 pytest --target loihi --no-hang -v --durations 50 --color=yes -n 1 --cov=nengo_loihi --cov-report=xml --cov-report=term-missing || HW_STATUS=1
         exit \$HW_STATUS
 EOF
 {% endblock %}

--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -47,7 +47,7 @@ ci_scripts:
     pip_install:
       - flake8
     post_commands:
-      - flake8 nengo
+      - flake8 nengo_loihi
       - flake8 --ignore=E226,E703,W391,W503 docs
   - template: deploy
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,9 @@ Release history
 
 - Switched to nengo-bones templating system for TravisCI config/scripts.
   (`#204 <https://github.com/nengo/nengo-loihi/pull/204>`__)
+- It is no longer possible to pass ``network=None`` to ``Simulator``.
+  Previously this was possible, but unlikely to work as expected.
+  (`#202 <https://github.com/nengo/nengo-loihi/pull/202>`__)
 
 0.6.0 (February 22, 2019)
 =========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,7 +50,9 @@ Release history
   (`#202 <https://github.com/nengo/nengo-loihi/pull/202>`__,
   `#205 <https://github.com/nengo/nengo-loihi/issues/205>`__,
   `#206 <https://github.com/nengo/nengo-loihi/issues/206>`__)
-
+- We no longer disable the Nengo decoder cache for all models.
+  (`#202 <https://github.com/nengo/nengo-loihi/pull/202>`__,
+  `#207 <https://github.com/nengo/nengo-loihi/issues/207>`__)
 
 0.6.0 (February 22, 2019)
 =========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,12 @@ Release history
   in the splitting process.
   (`#202 <https://github.com/nengo/nengo-loihi/pull/202>`__,
   `#211 <https://github.com/nengo/nengo-loihi/issues/211>`__)
+- It is now possible to make connections and probes with object slices
+  (e.g., ``nengo.Probe(my_ensemble[0])``).
+  (`#202 <https://github.com/nengo/nengo-loihi/pull/202>`__,
+  `#205 <https://github.com/nengo/nengo-loihi/issues/205>`__,
+  `#206 <https://github.com/nengo/nengo-loihi/issues/206>`__)
+
 
 0.6.0 (February 22, 2019)
 =========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,14 @@ Release history
   Previously this was possible, but unlikely to work as expected.
   (`#202 <https://github.com/nengo/nengo-loihi/pull/202>`__)
 
+**Fixed**
+
+- The splitting and passthrough removal procedures were significantly
+  refactored, which fixed an issue in which networks could be modified
+  in the splitting process.
+  (`#202 <https://github.com/nengo/nengo-loihi/pull/202>`__,
+  `#211 <https://github.com/nengo/nengo-loihi/issues/211>`__)
+
 0.6.0 (February 22, 2019)
 =========================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,11 @@ Release history
 - It is no longer possible to pass ``network=None`` to ``Simulator``.
   Previously this was possible, but unlikely to work as expected.
   (`#202 <https://github.com/nengo/nengo-loihi/pull/202>`__)
+- Better error messages are raised when attempting to simulate networks
+  in which certain objects participating in a learning rule are on-chip.
+  (`#202 <https://github.com/nengo/nengo-loihi/pull/202>`__,
+  `#208 <https://github.com/nengo/nengo-loihi/issues/208>`__,
+  `#209 <https://github.com/nengo/nengo-loihi/issues/209>`__)
 
 **Fixed**
 

--- a/docs/examples/adaptive_motor_control.ipynb
+++ b/docs/examples/adaptive_motor_control.ipynb
@@ -122,7 +122,7 @@
     "        # Create node that calculates the OSC signal\n",
     "        model.osc_node = nengo.Node(\n",
     "            output=lambda t, x: ctrlr.generate(\n",
-    "                q=x[:2], dq=x[2:4], target_pos=np.hstack([x[4:6], 0])),\n",
+    "                q=x[:2], dq=x[2:4], target=np.hstack([x[4:6], np.zeros(4)])),\n",
     "            size_in=6, size_out=2)\n",
     "\n",
     "        # Create node that runs the arm simulation and gets feedback\n",

--- a/nengo_loihi/builder/builder.py
+++ b/nengo_loihi/builder/builder.py
@@ -1,7 +1,8 @@
 from collections import defaultdict, OrderedDict
 import logging
 
-from nengo import Network
+from nengo import Ensemble, Network, Node, Probe
+from nengo.builder import Model as NengoModel
 from nengo.builder.builder import Builder as NengoBuilder
 from nengo.builder.network import build_network
 from nengo.cache import NoDecoderCache
@@ -106,9 +107,22 @@ class Model:
         self.build_callback = None
         self.decoder_cache = NoDecoderCache()
 
+        # TODO: these models may not look/behave exactly the same as
+        # standard nengo models, because they don't have a toplevel network
+        # built into them or configs set
+        self.host_pre = NengoModel(
+            dt=float(dt), label="%s:host_pre, dt=%f" % (label, dt),
+        )
+        self.host = NengoModel(
+            dt=float(dt), label="%s:host, dt=%f" % (label, dt),
+        )
+
         # Objects created by the model for simulation on Loihi
         self.inputs = OrderedDict()
         self.blocks = OrderedDict()
+
+        # Will be filled in by the simulator __init__
+        self.split = None
 
         # Will be filled in by the network builder
         self.toplevel = None
@@ -145,8 +159,11 @@ class Model:
         # magnitude/weight resolution)
         self.pes_wgt_exp = 4
 
-        # Will be provided by Simulator
+        # Used to track interactions between host models
         self.chip2host_params = {}
+        self.chip2host_receivers = OrderedDict()
+        self.host2chip_senders = OrderedDict()
+        self.needs_sender = {}
 
     def __getstate__(self):
         raise NotImplementedError("Can't pickle nengo_loihi.builder.Model")
@@ -168,13 +185,38 @@ class Model:
         self.blocks[block] = len(self.blocks)
 
     def build(self, obj, *args, **kwargs):
-        built = self.builder.build(self, obj, *args, **kwargs)
+        # Don't build the objects marked as "to_remove" by PassthroughSplit
+        if obj in self.split.passthrough.to_remove:
+            return None
+
+        if not isinstance(obj, (Node, Ensemble, Probe)):
+            model = self
+        elif self.split.on_chip(obj):
+            model = self
+        else:
+            # Note: callbacks for the host_model will not be invoked
+            model = self.host_model(obj)
+
+            # done for compatibility with nengo<=2.8.0
+            # otherwise we could just copy over the initial
+            # seeding to all other models
+            model.seeds[obj] = self.seeds[obj]
+            model.seeded[obj] = self.seeded[obj]
+
+        built = model.builder.build(model, obj, *args, **kwargs)
         if self.build_callback is not None:
             self.build_callback(obj)
         return built
 
     def has_built(self, obj):
         return obj in self.params
+
+    def host_model(self, obj):
+        """Returns the Model corresponding to where obj should be built."""
+        if self.split.is_precomputable(obj):
+            return self.host_pre
+        else:
+            return self.host
 
 
 class Builder(NengoBuilder):

--- a/nengo_loihi/builder/builder.py
+++ b/nengo_loihi/builder/builder.py
@@ -111,10 +111,14 @@ class Model:
         # standard nengo models, because they don't have a toplevel network
         # built into them or configs set
         self.host_pre = NengoModel(
-            dt=float(dt), label="%s:host_pre, dt=%f" % (label, dt),
+            dt=float(dt),
+            label="%s:host_pre, dt=%f" % (label, dt),
+            decoder_cache=NoDecoderCache(),
         )
         self.host = NengoModel(
-            dt=float(dt), label="%s:host, dt=%f" % (label, dt),
+            dt=float(dt),
+            label="%s:host, dt=%f" % (label, dt),
+            decoder_cache=NoDecoderCache(),
         )
 
         # Objects created by the model for simulation on Loihi

--- a/nengo_loihi/builder/connection.py
+++ b/nengo_loihi/builder/connection.py
@@ -15,9 +15,10 @@ import numpy as np
 from nengo_loihi import conv
 from nengo_loihi.block import Axon, LoihiBlock, Probe, Synapse
 from nengo_loihi.builder.builder import Builder
+from nengo_loihi.builder.inputs import ChipReceiveNeurons
 from nengo_loihi.compat import (
     nengo_transforms, sample_transform, conn_solver)
-from nengo_loihi.inputs import ChipReceiveNeurons, LoihiInput
+from nengo_loihi.inputs import LoihiInput
 from nengo_loihi.neurons import loihi_rates
 
 

--- a/nengo_loihi/builder/inputs.py
+++ b/nengo_loihi/builder/inputs.py
@@ -1,0 +1,101 @@
+from collections import OrderedDict
+
+from nengo import Node
+from nengo.exceptions import SimulationError
+from nengo.params import Default
+import numpy as np
+
+
+class HostSendNode(Node):
+    """For sending host->chip messages"""
+
+    def __init__(self, dimensions, label=Default):
+        self.queue = []
+        super(HostSendNode, self).__init__(
+            self.update,
+            size_in=dimensions,
+            size_out=0,
+            label=label,
+        )
+
+    def update(self, t, x):
+        assert len(self.queue) == 0 or t > self.queue[-1][0]
+        self.queue.append((t, x))
+
+
+class HostReceiveNode(Node):
+    """For receiving chip->host messages"""
+
+    def __init__(self, dimensions, label=Default):
+        self.queue = [(0, np.zeros(dimensions))]
+        self.queue_index = 0
+        super(HostReceiveNode, self).__init__(
+            self.update,
+            size_in=0,
+            size_out=dimensions,
+            label=label,
+        )
+
+    def update(self, t):
+        while (len(self.queue) > self.queue_index + 1
+               and self.queue[self.queue_index][0] < t):
+            self.queue_index += 1
+        return self.queue[self.queue_index][1]
+
+    def receive(self, t, x):
+        self.queue.append((t, x))
+
+
+class ChipReceiveNode(Node):
+    """For receiving host->chip messages"""
+
+    def __init__(self, dimensions, size_out, label=Default):
+        self.raw_dimensions = dimensions
+        self.spikes = []
+        self.spike_input = None  # set by builder
+        super(ChipReceiveNode, self).__init__(
+            self.update, size_in=0, size_out=size_out, label=label)
+
+    def clear(self):
+        self.spikes.clear()
+
+    def receive(self, t, x):
+        assert len(self.spikes) == 0 or t > self.spikes[-1][0]
+        assert x.ndim == 1
+        self.spikes.append((t, x.nonzero()[0]))
+
+    def update(self, t):
+        raise SimulationError("ChipReceiveNodes should not be run")
+
+    def collect_spikes(self):
+        assert self.spike_input is not None
+        for t, x in self.spikes:
+            yield (self.spike_input, t, x)
+
+
+class ChipReceiveNeurons(ChipReceiveNode):
+    """Passes spikes directly (no on-off neuron encoding)"""
+    def __init__(self, dimensions, neuron_type=None, label=Default):
+        self.neuron_type = neuron_type
+        super(ChipReceiveNeurons, self).__init__(
+            dimensions, dimensions, label=label)
+
+
+class PESModulatoryTarget:
+    def __init__(self, target):
+        self.target = target
+        self.errors = OrderedDict()
+
+    def clear(self):
+        self.errors.clear()
+
+    def receive(self, t, x):
+        assert len(self.errors) == 0 or t >= next(reversed(self.errors))
+        if t in self.errors:
+            self.errors[t] += x
+        else:
+            self.errors[t] = np.array(x)
+
+    def collect_errors(self):
+        for t, x in self.errors.items():
+            yield (self.target, t, x)

--- a/nengo_loihi/builder/node.py
+++ b/nengo_loihi/builder/node.py
@@ -1,7 +1,8 @@
 from nengo import Node
 
 from nengo_loihi.builder.builder import Builder
-from nengo_loihi.inputs import ChipReceiveNode, SpikeInput
+from nengo_loihi.builder.inputs import ChipReceiveNode
+from nengo_loihi.inputs import SpikeInput
 
 
 @Builder.register(Node)

--- a/nengo_loihi/builder/probe.py
+++ b/nengo_loihi/builder/probe.py
@@ -1,5 +1,6 @@
 import nengo
 from nengo import Ensemble, Connection, Node
+from nengo.base import ObjView
 from nengo.connection import LearningRule
 from nengo.ensemble import Neurons
 from nengo.exceptions import BuildError
@@ -74,10 +75,15 @@ def conn_probe(model, nengo_probe):
     model.seeded[conn] = model.seeded[nengo_probe]
     model.seeds[conn] = model.seeds[nengo_probe]
 
+    if isinstance(nengo_probe.target, ObjView):
+        target_obj = nengo_probe.target.obj
+    else:
+        target_obj = nengo_probe.target
+
     d = conn.size_out
-    if isinstance(nengo_probe.target, Ensemble):
+    if isinstance(target_obj, Ensemble):
         # probed values are scaled by the target ensemble's radius
-        scale = nengo_probe.target.radius
+        scale = target_obj.radius
         w = np.diag(scale * np.ones(d))
         weights = np.vstack([w, -w])
     else:

--- a/nengo_loihi/builder/probe.py
+++ b/nengo_loihi/builder/probe.py
@@ -45,6 +45,10 @@ def conn_probe(model, nengo_probe):
             raise NotImplementedError()
 
         target = nengo.Node(size_in=output_dim, add_to_container=False)
+        # TODO: This is a hack so that the builder can properly delegate the
+        # connection build to the right method
+        model.split._seen_objects.add(target)
+        model.split._chip_objects.add(target)
 
         conn = Connection(
             nengo_probe.target,

--- a/nengo_loihi/builder/tests/test_connection.py
+++ b/nengo_loihi/builder/tests/test_connection.py
@@ -1,0 +1,67 @@
+from distutils.version import LooseVersion
+
+import nengo
+from nengo.exceptions import BuildError
+import numpy as np
+import pytest
+
+
+@pytest.mark.skipif(LooseVersion(nengo.__version__) <= LooseVersion('2.8.0'),
+                    reason="requires more recent Nengo version")
+def test_split_conv2d_transform_error(Simulator):
+    with nengo.Network() as net:
+        node_offchip = nengo.Node([1])
+        ens_onchip = nengo.Ensemble(10, 1)
+        conv2d = nengo.Convolution(
+            n_filters=1, input_shape=(1, 1, 1), kernel_size=(1, 1))
+        nengo.Connection(node_offchip, ens_onchip, transform=conv2d)
+
+    with pytest.raises(BuildError, match="Conv2D"):
+        with Simulator(net):
+            pass
+
+
+@pytest.mark.parametrize("pre_dims", [1, 3])
+@pytest.mark.parametrize("post_dims", [1, 3])
+@pytest.mark.parametrize("learn", [True, False])
+@pytest.mark.parametrize("use_solver", [True, False])
+def test_manual_decoders(
+        seed, Simulator, pre_dims, post_dims, learn, use_solver):
+
+    with nengo.Network(seed=seed) as model:
+        pre = nengo.Ensemble(50, dimensions=pre_dims,
+                             gain=np.ones(50),
+                             bias=np.ones(50) * 5)
+        post = nengo.Node(size_in=post_dims)
+
+        learning_rule_type = nengo.PES() if learn else None
+        weights = np.zeros((post_dims, 50))
+        if use_solver:
+            conn = nengo.Connection(pre, post,
+                                    function=lambda x: np.zeros(post_dims),
+                                    learning_rule_type=learning_rule_type,
+                                    solver=nengo.solvers.NoSolver(weights.T))
+        else:
+            conn = nengo.Connection(pre.neurons, post,
+                                    learning_rule_type=learning_rule_type,
+                                    transform=weights)
+
+        if learn:
+            error = nengo.Node(np.zeros(post_dims))
+            nengo.Connection(error, conn.learning_rule)
+
+        pre_probe = nengo.Probe(pre.neurons, synapse=None)
+        post_probe = nengo.Probe(post, synapse=None)
+
+    if not use_solver and learn:
+        with pytest.raises(NotImplementedError):
+            with Simulator(model) as sim:
+                pass
+    else:
+        with Simulator(model) as sim:
+            sim.run(0.1)
+
+        # Ensure pre population has a lot of activity
+        assert np.mean(sim.data[pre_probe]) > 100
+        # But that post has no activity due to the zero weights
+        assert np.all(sim.data[post_probe] == 0)

--- a/nengo_loihi/builder/tests/test_inputs.py
+++ b/nengo_loihi/builder/tests/test_inputs.py
@@ -1,8 +1,9 @@
 import nengo
 from nengo.exceptions import SimulationError
+import numpy as np
 import pytest
 
-from nengo_loihi.builder.inputs import ChipReceiveNode
+from nengo_loihi.builder.inputs import ChipReceiveNode, PESModulatoryTarget
 
 
 def test_chipreceivenode_run_error():
@@ -12,3 +13,35 @@ def test_chipreceivenode_run_error():
     with pytest.raises(SimulationError, match="should not be run"):
         with nengo.Simulator(net) as sim:
             sim.step()
+
+
+def test_pesmodulatorytarget_interface():
+    target = "target"
+    p = PESModulatoryTarget(target)
+
+    t0 = 4
+    e0 = [1.8, 2.4, 3.3]
+    t1 = t0 + 3
+    e1 = [7.2, 2.2, 4.1]
+    e01 = np.array(e0) + np.array(e1)
+
+    p.receive(t0, e0)
+    assert isinstance(p.errors[t0], np.ndarray)
+    assert np.allclose(p.errors[t0], e0)
+
+    p.receive(t0, e1)
+    assert np.allclose(p.errors[t0], e01)
+
+    with pytest.raises(AssertionError):
+        p.receive(t0 - 1, e0)  # time needs to be >= last time
+
+    p.receive(t1, e1)
+    assert np.allclose(p.errors[t1], e1)
+
+    errors = list(p.collect_errors())
+    assert len(errors) == 2
+    assert errors[0][:2] == (target, t0) and np.allclose(errors[0][2], e01)
+    assert errors[1][:2] == (target, t1) and np.allclose(errors[1][2], e1)
+
+    p.clear()
+    assert len(list(p.collect_errors())) == 0

--- a/nengo_loihi/builder/tests/test_inputs.py
+++ b/nengo_loihi/builder/tests/test_inputs.py
@@ -2,7 +2,7 @@ import nengo
 from nengo.exceptions import SimulationError
 import pytest
 
-from nengo_loihi.inputs import ChipReceiveNode
+from nengo_loihi.builder.inputs import ChipReceiveNode
 
 
 def test_chipreceivenode_run_error():

--- a/nengo_loihi/conv.py
+++ b/nengo_loihi/conv.py
@@ -1,16 +1,8 @@
-import copy
 import itertools
 
-import nengo
-from nengo.builder.connection import BuiltConnection
-from nengo.ensemble import Neurons
-from nengo.exceptions import ValidationError
 import numpy as np
 
-from nengo_loihi.block import Axon, LoihiBlock, Synapse
-from nengo_loihi.builder.inputs import ChipReceiveNeurons
 from nengo_loihi.compat import nengo_transforms
-from nengo_loihi.inputs import LoihiInput
 
 
 class ImageSlice:
@@ -104,93 +96,6 @@ def pixel_idxs(shape):
     idxs = np.arange(shape.size, dtype=int)
     return ((idxs // shape.n_channels) if shape.channels_last else
             (idxs % np.prod(shape.spatial_shape)))
-
-
-def build_conv2d_connection(model, conn):
-    if nengo_transforms is None:
-        # It should not be possible to reach this, because this function is
-        # only called for a Convolution transform, which can exist only if
-        # nengo_transforms exists.
-        raise NotImplementedError("Convolution requires newer Nengo")
-
-    if conn.transform.dimensions != 2:
-        raise NotImplementedError("nengo-loihi only supports 2D convolution")
-    if conn.transform.padding != "valid":
-        raise NotImplementedError(
-            "nengo-loihi only supports convolution with 'valid' padding")
-
-    # Create random number generator
-    rng = np.random.RandomState(model.seeds[conn])
-
-    pre_cx = model.objs[conn.pre_obj]['out']
-    post_cx = model.objs[conn.post_obj]['in']
-    assert isinstance(pre_cx, (LoihiInput, LoihiBlock))
-    assert isinstance(post_cx, LoihiBlock)
-
-    tau_s = 0.0
-    if isinstance(conn.synapse, nengo.synapses.Lowpass):
-        tau_s = conn.synapse.tau
-    elif conn.synapse is not None:
-        raise NotImplementedError("Cannot handle non-Lowpass synapses")
-
-    # --- pre
-    assert isinstance(conn.pre_obj, (Neurons, ChipReceiveNeurons))
-    assert conn.pre_slice == slice(None)
-
-    assert isinstance(conn.transform, nengo_transforms.Convolution)
-
-    weights = conn.transform.sample(rng=rng)
-    input_shape = conn.transform.input_shape
-
-    # Account for nengo spike height of 1/dt
-    weights = weights / model.dt
-
-    if isinstance(conn.pre_obj, ChipReceiveNeurons):
-        neuron_type = conn.pre_obj.neuron_type
-    elif isinstance(conn.pre_obj, Neurons):
-        neuron_type = conn.pre_obj.ensemble.neuron_type
-
-    if neuron_type is not None and hasattr(neuron_type, 'amplitude'):
-        weights = weights * neuron_type.amplitude
-
-    # --- post
-    assert isinstance(conn.post_obj, Neurons)
-    assert conn.post_slice == slice(None)
-
-    gain = model.params[conn.post_obj.ensemble].gain
-    if not np.all(gain == gain[0]):
-        # TODO: support this?
-        raise ValidationError(
-            "All neurons targeted by a Convolution connection must "
-            "have the same gain", "gain", obj=conn.post_obj.ensemble)
-    weights = weights * gain[0]
-
-    pop_type = 32  # TODO: pick this
-    new_transform = copy.copy(conn.transform)
-    type(new_transform).init.data[new_transform] = weights
-    weights, indices, axon_to_weight_map, cx_bases = conv2d_loihi_weights(
-        new_transform)
-
-    synapse = Synapse(np.prod(input_shape.spatial_shape),
-                      label="conv2d_weights")
-    synapse.set_population_weights(
-        weights, indices, axon_to_weight_map, cx_bases, pop_type=pop_type)
-    post_cx.add_synapse(synapse)
-    model.objs[conn]['weights'] = synapse
-
-    ax = Axon(np.prod(input_shape.spatial_shape), label="conv2d_weights")
-    ax.target = synapse
-    ax.cx_to_axon_map = pixel_idxs(input_shape)
-    ax.cx_atoms = channel_idxs(input_shape)
-    pre_cx.add_axon(ax)
-
-    post_cx.compartment.configure_filter(tau_s, dt=model.dt)
-
-    model.params[conn] = BuiltConnection(
-        eval_points=None,
-        solver_info=None,
-        transform=None,
-        weights=weights)
 
 
 def conv2d_loihi_weights(transform):

--- a/nengo_loihi/conv.py
+++ b/nengo_loihi/conv.py
@@ -8,8 +8,9 @@ from nengo.exceptions import ValidationError
 import numpy as np
 
 from nengo_loihi.block import Axon, LoihiBlock, Synapse
+from nengo_loihi.builder.inputs import ChipReceiveNeurons
 from nengo_loihi.compat import nengo_transforms
-from nengo_loihi.inputs import ChipReceiveNeurons, LoihiInput
+from nengo_loihi.inputs import LoihiInput
 
 
 class ImageSlice:

--- a/nengo_loihi/emulator/interface.py
+++ b/nengo_loihi/emulator/interface.py
@@ -4,7 +4,7 @@ from collections import defaultdict, OrderedDict
 import logging
 import warnings
 
-from nengo.exceptions import SimulationError
+from nengo.exceptions import SimulationError, ValidationError
 from nengo.utils.compat import is_array, is_number
 import numpy as np
 
@@ -294,7 +294,8 @@ class CompartmentState(IterableState):
             def overflow(x, bits, name=None):
                 pass  # do not do overflow in floating point
         else:
-            raise ValueError("dtype %r not supported" % self.dtype)
+            raise ValidationError("dtype %r not supported" % self.dtype,
+                                  attr='dtype', obj=block_info)
 
         self._overflow = overflow
 
@@ -367,7 +368,8 @@ class NoiseState(IterableState):
             def uniform(rng, n=self.n_compartments):
                 return rng.uniform(-1, 1, size=n).astype(np.float32)
         else:
-            raise ValueError("dtype %r not supported" % self.dtype)
+            raise ValidationError("dtype %r not supported" % self.dtype,
+                                  attr='dtype', obj=block_info)
 
         assert not np.any(np.isnan(self.enabled))
         assert not np.any(np.isnan(self.exp))
@@ -469,7 +471,8 @@ class SynapseState(IterableState):
                 for w, delta_w in zip(synapse.weights, delta_ws):
                     w += synapse.learning_rate * delta_w
         else:
-            raise ValueError("dtype %r not supported" % self.dtype)
+            raise ValidationError("dtype %r not supported" % self.dtype,
+                                  attr='dtype', obj=block_info)
 
         self._trace_round = trace_round
         self._weight_update = weight_update

--- a/nengo_loihi/hardware/builder.py
+++ b/nengo_loihi/hardware/builder.py
@@ -388,7 +388,7 @@ def build_synapse(n2core, core, block, synapse, cx_idxs):  # noqa C901
             n2core.synapseMap[axon_id].population32MapEntry.configure(
                 cxBase=cx_base)
         else:
-            raise ValueError("Synapse: unrecognized pop_type: %s" % (
+            raise BuildError("Synapse: unrecognized pop_type: %s" % (
                 synapse.pop_type,))
 
         if synapse.learning:
@@ -445,7 +445,7 @@ def collect_axons(n2core, core, block, axon, cx_ids):
                                  "with a multi-chip allocator" % (
                                      tchip_id_source, tchip_id))
         else:
-            raise ValueError("Axon: unrecognized pop_type: %s" % (
+            raise BuildError("Axon: unrecognized pop_type: %s" % (
                 synapse.pop_type,))
 
     return all_axons

--- a/nengo_loihi/hardware/nxsdk_shim.py
+++ b/nengo_loihi/hardware/nxsdk_shim.py
@@ -1,8 +1,6 @@
 from distutils.version import LooseVersion
 import os
-import shutil
 import sys
-import tempfile
 
 try:
     import nxsdk
@@ -15,27 +13,6 @@ try:
     def assert_nxsdk():
         pass
 
-    from nxsdk.graph import graph
-
-    class PatchedGraph(graph.Graph):
-        def __init__(self, *args, **kwargs):
-            super(PatchedGraph, self).__init__(*args, **kwargs)
-            self.nengo_tmp_dirs = []
-
-        def createProcess(self, name, cFilePath, *args, **kwargs):
-            # copy the c file to a temporary directory (so that multiple
-            # simulations can use the same snip files without running into
-            # problems)
-            tmp = tempfile.TemporaryDirectory()
-            self.nengo_tmp_dirs.append(tmp)
-
-            tmp_path = os.path.join(tmp.name, os.path.basename(cFilePath))
-            shutil.copyfile(cFilePath, tmp_path)
-
-            return super(PatchedGraph, self).createProcess(
-                name, tmp_path, *args, **kwargs)
-
-    graph.Graph = PatchedGraph
 except ImportError:
     HAS_NXSDK = False
     nxsdk_dir = None

--- a/nengo_loihi/inputs.py
+++ b/nengo_loihi/inputs.py
@@ -1,10 +1,4 @@
-from __future__ import division
-
-from nengo import Node
-from nengo.exceptions import SimulationError
-from nengo.params import Default
 from nengo.utils.compat import is_integer
-import numpy as np
 
 
 class LoihiInput:
@@ -34,78 +28,3 @@ class SpikeInput(LoihiInput):
 
     def spike_idxs(self, ti):
         return self.spikes.get(ti, [])
-
-
-class HostSendNode(Node):
-    """For sending host->chip messages"""
-
-    def __init__(self, dimensions, label=Default):
-        self.queue = []
-        super(HostSendNode, self).__init__(
-            self.update,
-            size_in=dimensions,
-            size_out=0,
-            label=label,
-        )
-
-    def update(self, t, x):
-        assert len(self.queue) == 0 or t > self.queue[-1][0]
-        self.queue.append((t, x))
-
-
-class HostReceiveNode(Node):
-    """For receiving chip->host messages"""
-
-    def __init__(self, dimensions, label=Default):
-        self.queue = [(0, np.zeros(dimensions))]
-        self.queue_index = 0
-        super(HostReceiveNode, self).__init__(
-            self.update,
-            size_in=0,
-            size_out=dimensions,
-            label=label,
-        )
-
-    def update(self, t):
-        while (len(self.queue) > self.queue_index + 1
-               and self.queue[self.queue_index][0] < t):
-            self.queue_index += 1
-        return self.queue[self.queue_index][1]
-
-    def receive(self, t, x):
-        self.queue.append((t, x))
-
-
-class ChipReceiveNode(Node):
-    """For receiving host->chip messages"""
-
-    def __init__(self, dimensions, size_out, label=Default):
-        self.raw_dimensions = dimensions
-        self.spikes = []
-        self.spike_input = None  # set by builder
-        super(ChipReceiveNode, self).__init__(
-            self.update, size_in=0, size_out=size_out, label=label)
-
-    def clear(self):
-        self.spikes.clear()
-
-    def receive(self, t, x):
-        assert len(self.spikes) == 0 or t > self.spikes[-1][0]
-        assert x.ndim == 1
-        self.spikes.append((t, x.nonzero()[0]))
-
-    def update(self, t):
-        raise SimulationError("ChipReceiveNodes should not be run")
-
-    def collect_spikes(self):
-        assert self.spike_input is not None
-        for t, x in self.spikes:
-            yield (self.spike_input, t, x)
-
-
-class ChipReceiveNeurons(ChipReceiveNode):
-    """Passes spikes directly (no on-off neuron encoding)"""
-    def __init__(self, dimensions, neuron_type=None, label=Default):
-        self.neuron_type = neuron_type
-        super(ChipReceiveNeurons, self).__init__(
-            dimensions, dimensions, label=label)

--- a/nengo_loihi/simulator.py
+++ b/nengo_loihi/simulator.py
@@ -4,7 +4,6 @@ import traceback
 import warnings
 
 import nengo
-from nengo.cache import get_default_decoder_cache
 from nengo.exceptions import (
     ReadonlyError,
     SimulatorClosed,
@@ -21,7 +20,7 @@ import nengo_loihi.config as config
 from nengo_loihi.discretize import discretize_model
 from nengo_loihi.emulator import EmulatorInterface
 from nengo_loihi.hardware import HardwareInterface, HAS_NXSDK
-from nengo_loihi.splitter import split
+from nengo_loihi.splitter import Split
 
 logger = logging.getLogger(__name__)
 
@@ -110,7 +109,7 @@ class Simulator:
         # initialize values used in __del__ and close() first
         self.closed = True
         self.precompute = precompute
-        self.networks = None
+        self.network = network
         self.sims = OrderedDict()
         self._run_steps = None
 
@@ -139,43 +138,44 @@ class Simulator:
         config.add_params(network)
 
         # ensure seeds are identical to nengo
+        # this has no effect for nengo<=2.8.0
         seed_network(network, seeds=self.model.seeds,
                      seeded=self.model.seeded)
 
-        # split the host into one, two or three networks
-        self.networks = split(
-            network,
-            precompute=precompute,
-            node_neurons=self.model.node_neurons,
-            node_tau=self.model.decode_tau,
-            remove_passthrough=remove_passthrough,
-        )
-        network = self.networks.chip
+        # determine how to split the host into one, two or three models
+        self.model.split = Split(network,
+                                 precompute=precompute,
+                                 remove_passthrough=remove_passthrough)
 
-        self.model.chip2host_params = self.networks.chip2host_params
+        # Build the network into the model
+        self.model.build(network)
 
-        self.chip = self.networks.chip
-        self.host = self.networks.host
-        self.host_pre = self.networks.host_pre
+        # Build the extra passthrough connections into the model
+        passthrough = self.model.split.passthrough
+        for conn in passthrough.to_add:
+            # Note: connections added by the passthrough splitter do not
+            # respect seeds
+            self.model.seeds[conn] = None
+            self.model.seeded[conn] = False
+            self.model.build(conn)
 
-        if len(self.host_pre.all_objects) > 0:
-            host_pre_model = self._get_host_model(
-                self.host_pre, dt=dt, seeds=self.model.seeds,
-                seeded=self.model.seeded)
-            self.sims["host_pre"] = nengo.Simulator(self.host_pre,
-                                                    dt=self.dt,
-                                                    model=host_pre_model,
-                                                    progress_bar=False,
-                                                    optimize=False)
-
-        if len(self.host.all_objects) > 0:
-            host_model = self._get_host_model(
-                self.host, dt=dt, seeds=self.model.seeds,
-                seeded=self.model.seeded)
-            self.sims["host"] = nengo.Simulator(
-                self.host,
+        if len(self.model.host_pre.params):
+            assert precompute
+            self.sims["host_pre"] = nengo.Simulator(
+                network=None,
                 dt=self.dt,
-                model=host_model,
+                model=self.model.host_pre,
+                progress_bar=False,
+                optimize=False)
+        elif precompute:
+            warnings.warn("No precomputable objects. Setting "
+                          "precompute=True has no effect.")
+
+        if len(self.model.host.params):
+            self.sims["host"] = nengo.Simulator(
+                network=None,
+                dt=self.dt,
+                model=self.model.host,
                 progress_bar=False,
                 optimize=False)
         elif not precompute:
@@ -185,9 +185,6 @@ class Simulator:
             # We could warn about this, but we want to avoid people having
             # to specify `precompute` unless they absolutely have to.
             self.precompute = True
-
-        # Build the network into the model
-        self.model.build(network)
 
         self._probe_outputs = self.model.params
         self.data = ProbeDict(self._probe_outputs)
@@ -225,16 +222,6 @@ class Simulator:
 
         self.closed = False
         self.reset(seed=seed)
-
-    @staticmethod
-    def _get_host_model(network, dt, seeds, seeded):
-        model = nengo.builder.Model(
-            dt=float(dt),
-            label="%s, dt=%f" % (network, dt),
-            decoder_cache=get_default_decoder_cache())
-        model.seeds.update(seeds)
-        model.seeded.update(seeded)
-        return model
 
     def __del__(self):
         """Raise a ResourceWarning if we are deallocated while open."""
@@ -291,7 +278,7 @@ class Simulator:
         self._probe_step_time()
 
         for probe in self.model.probes:
-            if probe in self.networks.chip2host_params:
+            if probe in self.model.chip2host_params:
                 continue
             assert probe.sample_every is None, (
                 "probe.sample_every not implemented")
@@ -374,7 +361,7 @@ class Simulator:
     def _collect_receiver_info(self):
         spikes = []
         errors = OrderedDict()
-        for sender, receiver in self.networks.host2chip_senders.items():
+        for sender, receiver in self.model.host2chip_senders.items():
             receiver.clear()
             for t, x in sender.queue:
                 receiver.receive(t, x)
@@ -407,7 +394,7 @@ class Simulator:
     def _chip2host(self, sim):
         probes_receivers = OrderedDict(  # map probes to receivers
             (self.model.objs[probe]['out'], receiver)
-            for probe, receiver in self.networks.chip2host_receivers.items())
+            for probe, receiver in self.model.chip2host_receivers.items())
         sim.chip2host(probes_receivers)
 
     def _make_run_steps(self):

--- a/nengo_loihi/simulator.py
+++ b/nengo_loihi/simulator.py
@@ -134,7 +134,6 @@ class Simulator:
             raise ValidationError("network parameter must not be None",
                                   attr="network")
 
-        nengo.rc.set("decoder_cache", "enabled", "False")
         config.add_params(network)
 
         # ensure seeds are identical to nengo

--- a/nengo_loihi/splitter.py
+++ b/nengo_loihi/splitter.py
@@ -39,10 +39,18 @@ class Split:
             if (conn.learning_rule_type is not None
                     and isinstance(post, Ensemble)
                     and post in self._chip_objects):
+                if network.config[post].on_chip:
+                    raise BuildError("Post ensemble (%r) of learned "
+                                     "connection (%r) must not be configured "
+                                     "as on_chip." % (post, conn))
                 self._chip_objects.remove(post)
             elif (isinstance(post, LearningRule)
                   and isinstance(pre, Ensemble)
                   and pre in self._chip_objects):
+                if network.config[pre].on_chip:
+                    raise BuildError("Pre ensemble (%r) of error "
+                                     "connection (%r) must not be configured "
+                                     "as on_chip." % (pre, conn))
                 self._chip_objects.remove(pre)
 
         # Step 4. Mark passthrough nodes for removal

--- a/nengo_loihi/splitter.py
+++ b/nengo_loihi/splitter.py
@@ -10,36 +10,17 @@ from nengo.ensemble import Neurons
 from nengo.exceptions import BuildError
 import numpy as np
 
-from nengo_loihi.compat import nengo_transforms, sample_transform
-from nengo_loihi.inputs import (
+from nengo_loihi.builder.inputs import (
     ChipReceiveNode,
     ChipReceiveNeurons,
     HostSendNode,
     HostReceiveNode,
+    PESModulatoryTarget,
 )
+from nengo_loihi.compat import nengo_transforms, sample_transform
 from nengo_loihi.passthrough import convert_passthroughs
 
 logger = logging.getLogger(__name__)
-
-
-class PESModulatoryTarget:
-    def __init__(self, target):
-        self.target = target
-        self.errors = OrderedDict()
-
-    def clear(self):
-        self.errors.clear()
-
-    def receive(self, t, x):
-        assert len(self.errors) == 0 or t >= next(reversed(self.errors))
-        if t in self.errors:
-            self.errors[t] += x
-        else:
-            self.errors[t] = np.array(x)
-
-    def collect_errors(self):
-        for t, x in self.errors.items():
-            yield (self.target, t, x)
 
 
 def base_obj(obj):

--- a/nengo_loihi/tests/test_examples.py
+++ b/nengo_loihi/tests/test_examples.py
@@ -5,7 +5,7 @@ import nengo
 from nengo.utils.stdlib import execfile
 try:
     from nengo.utils.ipython import iter_cells, load_notebook
-except ImportError as err:
+except ImportError:
     def iter_cells(nb, cell_type="code"):
         return (cell for cell in nb.cells if cell.cell_type == cell_type)
 

--- a/nengo_loihi/tests/test_learning.py
+++ b/nengo_loihi/tests/test_learning.py
@@ -91,14 +91,14 @@ def test_pes_comm_channel(dims, allclose, plt, seed, Simulator):
 
     x_loihi = loihi_sim.data[probes['pre']]
     assert allclose(x_loihi[pre_tmask], y_dpre[pre_tmask],
-                    atol=0.1, rtol=0.05)
+                    atol=0.15, rtol=0.05)
 
     assert allclose(y_loihi[post_tmask], y_dpost[post_tmask],
-                    atol=0.1, rtol=0.05)
+                    atol=0.15, rtol=0.05)
     assert allclose(y_loihi, y_nengo, atol=0.2, rtol=0.2)
 
     assert allclose(y_real[post_tmask], y_dpost[post_tmask],
-                    atol=0.1, rtol=0.05)
+                    atol=0.15, rtol=0.05)
     assert allclose(y_real, y_nengo, atol=0.2, rtol=0.2)
 
 

--- a/nengo_loihi/tests/test_passthrough.py
+++ b/nengo_loihi/tests/test_passthrough.py
@@ -4,9 +4,9 @@ import numpy as np
 import pytest
 
 import nengo_loihi
+from nengo_loihi.builder.inputs import ChipReceiveNode
 from nengo_loihi.compat import transform_array
 from nengo_loihi.decode_neurons import OnOffDecodeNeurons
-from nengo_loihi.inputs import ChipReceiveNode
 from nengo_loihi.splitter import split
 
 default_node_neurons = OnOffDecodeNeurons()

--- a/nengo_loihi/tests/test_passthrough.py
+++ b/nengo_loihi/tests/test_passthrough.py
@@ -3,11 +3,9 @@ from nengo.exceptions import BuildError
 import numpy as np
 import pytest
 
-import nengo_loihi
-from nengo_loihi.builder.inputs import ChipReceiveNode
 from nengo_loihi.compat import transform_array
 from nengo_loihi.decode_neurons import OnOffDecodeNeurons
-from nengo_loihi.splitter import split
+from nengo_loihi.passthrough import PassthroughSplit
 
 default_node_neurons = OnOffDecodeNeurons()
 
@@ -24,32 +22,20 @@ def test_passthrough_placement():
         g = nengo.Node(None, size_in=1)   # should be off-chip
         nengo.Connection(stim, a)
         nengo.Connection(a, b)
-        nengo.Connection(b, c)
-        nengo.Connection(c, d)
-        nengo.Connection(d, e)
-        nengo.Connection(e, f)
+        conn_bc = nengo.Connection(b, c)
+        conn_cd = nengo.Connection(c, d)
+        conn_de = nengo.Connection(d, e)
+        conn_ef = nengo.Connection(e, f)
         nengo.Connection(f, g)
         nengo.Probe(g)
 
-    nengo_loihi.add_params(model)
-    networks = split(model,
-                     precompute=False,
-                     node_neurons=default_node_neurons,
-                     node_tau=0.005,
-                     remove_passthrough=True)
-    chip = networks.chip
-    host = networks.host
+    split = PassthroughSplit(model, ignore={stim})
 
-    assert a in host.nodes
-    assert a not in chip.nodes
-    assert c not in host.nodes
-    assert c not in chip.nodes
-    assert d not in host.nodes
-    assert d not in chip.nodes
-    assert e not in host.nodes
-    assert e not in chip.nodes
-    assert g in host.nodes
-    assert g not in chip.nodes
+    assert split.to_remove == {c, d, e, conn_bc, conn_cd, conn_de, conn_ef}
+    assert len(split.to_add) == 1
+    conn = next(iter(split.to_add))
+    assert conn.pre is b
+    assert conn.post is f
 
 
 @pytest.mark.parametrize("d1", [1, 3])
@@ -64,19 +50,15 @@ def test_transform_merging(d1, d2, d3):
         t1 = np.random.uniform(-1, 1, (d2, d1))
         t2 = np.random.uniform(-1, 1, (d3, d2))
 
-        nengo.Connection(a, b, transform=t1)
-        nengo.Connection(b, c, transform=t2)
+        conn_ab = nengo.Connection(a, b, transform=t1)
+        conn_bc = nengo.Connection(b, c, transform=t2)
 
-    nengo_loihi.add_params(model)
-    networks = split(model,
-                     precompute=False,
-                     node_neurons=default_node_neurons,
-                     node_tau=0.005,
-                     remove_passthrough=True)
-    chip = networks.chip
+    split = PassthroughSplit(model)
 
-    assert len(chip.connections) == 1
-    conn = chip.connections[0]
+    assert split.to_remove == {b, conn_ab, conn_bc}
+
+    assert len(split.to_add) == 1
+    conn = next(iter(split.to_add))
     assert np.allclose(transform_array(conn.transform), np.dot(t2, t1))
 
 
@@ -88,22 +70,13 @@ def test_identity_array(n_ensembles, ens_dimensions):
         b = nengo.networks.EnsembleArray(10, n_ensembles, ens_dimensions)
         nengo.Connection(a.output, b.input)
 
-    nengo_loihi.add_params(model)
-    networks = split(model,
-                     precompute=False,
-                     node_neurons=default_node_neurons,
-                     node_tau=0.005,
-                     remove_passthrough=True)
+    split = PassthroughSplit(model)
 
-    # ignore the a.input -> a.ensemble connections
-    connections = [conn for conn in networks.chip.connections
-                   if not (isinstance(conn.pre_obj, ChipReceiveNode)
-                           and conn.post_obj in a.ensembles)]
+    assert len(split.to_add) == n_ensembles
 
-    assert len(connections) == n_ensembles
     pre = set()
     post = set()
-    for conn in connections:
+    for conn in split.to_add:
         assert conn.pre in a.all_ensembles or conn.pre_obj is a.input
         assert conn.post in b.all_ensembles
         assert np.allclose(transform_array(conn.transform),
@@ -123,21 +96,12 @@ def test_full_array(n_ensembles, ens_dimensions):
         D = n_ensembles * ens_dimensions
         nengo.Connection(a.output, b.input, transform=np.ones((D, D)))
 
-    nengo_loihi.add_params(model)
-    networks = split(model,
-                     precompute=False,
-                     node_neurons=default_node_neurons,
-                     node_tau=0.005,
-                     remove_passthrough=True)
+    split = PassthroughSplit(model)
 
-    # ignore the a.input -> a.ensemble connections
-    connections = [conn for conn in networks.chip.connections
-                   if not (isinstance(conn.pre_obj, ChipReceiveNode)
-                           and conn.post_obj in a.ensembles)]
+    assert len(split.to_add) == n_ensembles ** 2
 
-    assert len(connections) == n_ensembles ** 2
     pairs = set()
-    for conn in connections:
+    for conn in split.to_add:
         assert conn.pre in a.all_ensembles
         assert conn.post in b.all_ensembles
         assert np.allclose(transform_array(conn.transform),
@@ -158,26 +122,17 @@ def test_synapse_merging(Simulator, seed):
         nengo.Connection(b[1], c.input[0], synapse=None)
         nengo.Connection(b[1], c.input[1], synapse=0.2)
 
-    nengo_loihi.add_params(model)
-    networks = split(model,
-                     precompute=False,
-                     node_neurons=default_node_neurons,
-                     node_tau=0.005,
-                     remove_passthrough=True)
+    split = PassthroughSplit(model)
 
-    # ignore the a.input -> a.ensemble connections
-    connections = [conn for conn in networks.chip.connections
-                   if not (isinstance(conn.pre_obj, ChipReceiveNode)
-                           and conn.post_obj in a.ensembles)]
+    assert len(split.to_add) == 4
 
-    assert len(connections) == 4
     desired_filters = {
         ('0', '0'): None,
         ('0', '1'): 0.2,
         ('1', '0'): 0.1,
         ('1', '1'): 0.3,
     }
-    for conn in connections:
+    for conn in split.to_add:
         if desired_filters[(conn.pre.label, conn.post.label)] is None:
             assert conn.synapse is None
         else:
@@ -186,9 +141,13 @@ def test_synapse_merging(Simulator, seed):
                 conn.synapse.tau,
                 desired_filters[(conn.pre.label, conn.post.label)])
 
-    # check that model builds/runs correctly
-    with Simulator(model, remove_passthrough=True) as sim:
-        sim.step()
+    # check that model builds/runs, and issues the warning
+    with pytest.warns(UserWarning) as record:
+        with Simulator(model, remove_passthrough=True) as sim:
+            sim.step()
+
+    assert any("Combining two Lowpass synapses" in r.message.args[0]
+               for r in record)
 
 
 def test_no_input(Simulator, seed, allclose):
@@ -268,7 +227,7 @@ def test_cluster_errors(Simulator, seed, plt):
 
         return net, probes
 
-    # Since `convert_passthroughs` catches its own cluster errors, we won't see
+    # Since `PassthroughSplit` catches its own cluster errors, we won't see
     # the error here. We ensure identical behaviour (so nodes are not removed).
 
     # Test learning rule node input

--- a/nengo_loihi/tests/test_simulator.py
+++ b/nengo_loihi/tests/test_simulator.py
@@ -28,9 +28,14 @@ def test_model_validate_notempty(Simulator):
         a = nengo.Ensemble(10, 1)
         model.config[a].on_chip = False
 
+    assert nengo.rc.get("decoder_cache", "enabled")
+
     with pytest.raises(BuildError, match="No neurons marked"):
         with Simulator(model):
             pass
+
+    # Ensure cache config not changed
+    assert nengo.rc.get("decoder_cache", "enabled")
 
 
 @pytest.mark.parametrize("precompute", [True, False])

--- a/nengo_loihi/tests/test_simulator.py
+++ b/nengo_loihi/tests/test_simulator.py
@@ -1,7 +1,8 @@
 import inspect
 
 import nengo
-from nengo.exceptions import ReadonlyError, ValidationError, SimulationError
+from nengo.exceptions import (
+    BuildError, ReadonlyError, SimulationError, ValidationError)
 import numpy as np
 import pytest
 
@@ -15,6 +16,11 @@ from nengo_loihi.hardware.allocators import RoundRobin
 from nengo_loihi.inputs import SpikeInput
 
 
+def test_none_network(Simulator):
+    with pytest.raises(ValidationError, match="network parameter"):
+        Simulator(None)
+
+
 def test_model_validate_notempty(Simulator):
     with nengo.Network() as model:
         nengo_loihi.add_params(model)
@@ -22,7 +28,7 @@ def test_model_validate_notempty(Simulator):
         a = nengo.Ensemble(10, 1)
         model.config[a].on_chip = False
 
-    with pytest.raises(nengo.exceptions.BuildError):
+    with pytest.raises(BuildError, match="No neurons marked"):
         with Simulator(model):
             pass
 

--- a/nengo_loihi/tests/test_splitter.py
+++ b/nengo_loihi/tests/test_splitter.py
@@ -1,99 +1,40 @@
-from distutils.version import LooseVersion
-
 import pytest
 import nengo
 from nengo.exceptions import BuildError
 import numpy as np
 
-from nengo_loihi.builder.inputs import (
-    ChipReceiveNeurons,
-    ChipReceiveNode,
-    HostReceiveNode,
-    HostSendNode,
-)
-from nengo_loihi.decode_neurons import OnOffDecodeNeurons
 from nengo_loihi.config import add_params
-from nengo_loihi.splitter import (
-    PESModulatoryTarget,
-    place_ensembles,
-    place_internetwork_connections,
-    place_nodes,
-    place_probes,
-    SplitNetworks,
-    split,
-    split_chip_to_host,
-    split_host_neurons_to_chip,
-    split_host_to_chip,
-    split_host_to_learning_rules,
-    split_pre_from_host,
-)
-
-default_node_neurons = OnOffDecodeNeurons()
-
-
-@pytest.mark.parametrize("pre_dims", [1, 3])
-@pytest.mark.parametrize("post_dims", [1, 3])
-@pytest.mark.parametrize("learn", [True, False])
-@pytest.mark.parametrize("use_solver", [True, False])
-def test_manual_decoders(
-        seed, Simulator, pre_dims, post_dims, learn, use_solver):
-
-    with nengo.Network(seed=seed) as model:
-        pre = nengo.Ensemble(50, dimensions=pre_dims,
-                             gain=np.ones(50),
-                             bias=np.ones(50) * 5)
-        post = nengo.Node(size_in=post_dims)
-
-        learning_rule_type = nengo.PES() if learn else None
-        weights = np.zeros((post_dims, 50))
-        if use_solver:
-            conn = nengo.Connection(pre, post,
-                                    function=lambda x: np.zeros(post_dims),
-                                    learning_rule_type=learning_rule_type,
-                                    solver=nengo.solvers.NoSolver(weights.T))
-        else:
-            conn = nengo.Connection(pre.neurons, post,
-                                    learning_rule_type=learning_rule_type,
-                                    transform=weights)
-
-        if learn:
-            error = nengo.Node(np.zeros(post_dims))
-            nengo.Connection(error, conn.learning_rule)
-
-        pre_probe = nengo.Probe(pre.neurons, synapse=None)
-        post_probe = nengo.Probe(post, synapse=None)
-
-    if not use_solver and learn:
-        with pytest.raises(NotImplementedError):
-            with Simulator(model) as sim:
-                pass
-    else:
-        with Simulator(model) as sim:
-            sim.run(0.1)
-
-        # Ensure pre population has a lot of activity
-        assert np.mean(sim.data[pre_probe]) > 100
-        # But that post has no activity due to the zero weights
-        assert np.all(sim.data[post_probe] == 0)
+from nengo_loihi.splitter import Split
 
 
 def test_place_nodes():
+    # all nodes go on the host
+    # ChipReceiveNodes and HostSendNodes are created later by the builder
+
     with nengo.Network() as net:
+        add_params(net)
         offchip1 = nengo.Node(0)
         with nengo.Network():
             offchip2 = nengo.Node(np.sin)
-        offchip3 = HostSendNode(dimensions=1)
-        onchip = ChipReceiveNode(dimensions=1, size_out=1)
+            ensemble = nengo.Ensemble(100, 1)
+            offchip3 = nengo.Node(size_in=1)
+            nengo.Connection(ensemble, offchip3)
 
-    networks = SplitNetworks(net, node_neurons=default_node_neurons)
-    place_nodes(networks)
-    assert networks.moves[offchip1] == "host"
-    assert networks.moves[offchip2] == "host"
-    assert networks.moves[offchip3] == "host"
-    assert networks.moves[onchip] == "chip"
+    with nengo.Network():
+        nowhere = nengo.Node(0)
+
+    split = Split(net)
+    assert not split.on_chip(offchip1)
+    assert not split.on_chip(offchip2)
+    assert not split.on_chip(offchip3)
+
+    with pytest.raises(BuildError, match="not a part of the network"):
+        split.on_chip(nowhere)
 
 
 def test_place_ensembles():
+    # builder will move the learning stuff onto the host
+
     with nengo.Network() as net:
         add_params(net)
         offchip = nengo.Ensemble(10, 1, label="offchip")
@@ -108,352 +49,159 @@ def test_place_ensembles():
         conn = nengo.Connection(pre, post, learning_rule_type=nengo.PES())
         nengo.Connection(error, conn.learning_rule)
 
-    networks = SplitNetworks(net, node_neurons=default_node_neurons)
-    place_ensembles(networks)
-    assert networks.moves[offchip] == "host"
-    assert networks.moves[direct] == "host"
-    assert networks.moves[onchip] == "chip"
-    assert networks.moves[pre] == "chip"
-    assert networks.moves[post] == "host"
-    assert networks.moves[error] == "host"
+    split = Split(net)
+    assert not split.on_chip(offchip)
+    assert not split.on_chip(direct)
+    assert split.on_chip(onchip)
+    assert split.on_chip(pre)
+    assert not split.on_chip(post)
+    assert not split.on_chip(error)
+
+    for obj in net.all_ensembles + net.all_nodes:
+        assert not split.is_precomputable(obj)
+
+    with pytest.raises(BuildError, match="Locations are only established"):
+        split.on_chip(conn)
 
 
-def test_place_inter_network_connection():
+def test_place_internetwork_connections():
     with nengo.Network() as net:
+        add_params(net)
         offchip = nengo.Ensemble(10, 1)
+        net.config[offchip].on_chip = False
         onchip = nengo.Ensemble(10, 1)
+
         onon = nengo.Connection(onchip, onchip)
         onoff = nengo.Connection(onchip, offchip)
         offon = nengo.Connection(offchip, onchip)
         offoff = nengo.Connection(offchip, offchip)
 
-    networks = SplitNetworks(net, node_neurons=default_node_neurons)
-    networks.move(onchip, "chip")
-    networks.move(offchip, "host")
+    split = Split(net)
 
-    place_internetwork_connections(networks, networks.original.all_connections)
-    assert onoff not in networks
-    assert offon not in networks
-    assert networks.location(onon) == "chip"
-    assert networks.location(offoff) == "host"
+    assert split.on_chip(onon.pre)
+    assert split.on_chip(onon.post)
 
+    assert split.on_chip(onoff.pre)
+    assert not split.on_chip(onoff.post)
 
-def test_split_host_neurons_to_chip():
-    with nengo.Network() as net:
-        offchip = nengo.Ensemble(10, 1)
-        onchip = nengo.Ensemble(10, 1)
-        neurons2neurons = nengo.Connection(
-            offchip.neurons, onchip.neurons, transform=np.ones((10, 10)))
-        neurons2ensemble = nengo.Connection(
-            offchip.neurons, onchip, transform=np.ones((1, 10)))
+    assert not split.on_chip(offon.pre)
+    assert split.on_chip(offon.post)
 
-    networks = SplitNetworks(net, node_neurons=default_node_neurons)
-    networks.move(offchip, "host")
-    networks.move(onchip, "chip")
-
-    def assert_split_correctly(split_conn):
-        assert len(networks.adds) == 4
-        added_types = sorted([(type(obj).__name__, location)
-                              for obj, location in networks.adds.items()])
-        assert added_types == [
-            ("ChipReceiveNeurons", "chip"),
-            ("Connection", "chip"),
-            ("Connection", "host"),
-            ("HostSendNode", "host"),
-        ]
-        assert split_conn in networks.removes
-
-        send = next(obj for obj in networks.adds
-                    if isinstance(obj, HostSendNode))
-        receive = next(obj for obj in networks.adds
-                       if isinstance(obj, ChipReceiveNeurons))
-        assert networks.host2chip_senders[send] is receive
-
-    split_host_neurons_to_chip(networks, neurons2neurons)
-    assert_split_correctly(neurons2neurons)
-    networks.adds.clear()  # Makes testing subsequent adds easier
-    split_host_neurons_to_chip(networks, neurons2ensemble)
-    assert_split_correctly(neurons2ensemble)
-
-
-def test_split_host_to_chip():
-    with nengo.Network() as net:
-        ens_offchip = nengo.Ensemble(10, 1)
-        node_offchip = nengo.Node(np.sin)
-        ens_onchip = nengo.Ensemble(10, 1)
-        connections = [
-            nengo.Connection(ens_offchip, ens_onchip),
-            nengo.Connection(node_offchip, ens_onchip),
-            nengo.Connection(
-                ens_offchip, ens_onchip.neurons, transform=np.ones((10, 1))),
-            nengo.Connection(
-                node_offchip, ens_onchip.neurons, transform=np.ones((10, 1))),
-        ]
-
-    networks = SplitNetworks(net, node_neurons=default_node_neurons)
-    networks.move(ens_offchip, "host")
-    networks.move(node_offchip, "host")
-    networks.move(ens_onchip, "chip")
-
-    for conn in connections:
-        split_host_to_chip(networks, conn)
-        for added in networks.adds:
-            if isinstance(added, nengo.Ensemble):
-                ens = added
-            elif isinstance(added, ChipReceiveNode):
-                receive = added
-            elif isinstance(added, HostSendNode):
-                send = added
-            # Otherwise must be connection
-            elif added.pre is conn.pre:
-                pre2ens = added
-            elif added.post is conn.post:
-                receive2post = added
-            else:
-                ensneurons2send = added
-
-        assert networks.location(ens) == "host"
-        assert isinstance(ens.neuron_type, nengo.SpikingRectifiedLinear)
-        assert pre2ens.post is ens
-
-        assert networks.location(receive) == "chip"
-        assert networks.location(receive2post) == "chip"
-        assert receive2post.pre is receive
-
-        assert networks.location(send) == "host"
-        assert networks.location(ensneurons2send) == "host"
-        assert ensneurons2send.pre == ens.neurons
-        assert ensneurons2send.post is send
-
-        assert conn in networks.removes
-        networks.adds.clear()  # makes next loop iteration easier
-
-
-def test_split_no_node_neuron_error():
-    with nengo.Network() as net:
-        add_params(net)
-        node_offchip = nengo.Node(np.sin)
-        ens_onchip = nengo.Ensemble(10, 1)
-        nengo.Connection(node_offchip, ens_onchip)
-
-    with pytest.raises(BuildError, match="DecodeNeurons"):
-        split(net, precompute=False, node_neurons=None, node_tau=None)
-
-
-def test_split_chip_to_host():
-    with nengo.Network() as net:
-        ens_onchip = nengo.Ensemble(10, 1)
-        ens_offchip = nengo.Ensemble(10, 1)
-        node_offchip = nengo.Node(size_in=1)
-        connections = [
-            nengo.Connection(ens_onchip, ens_offchip),
-            nengo.Connection(
-                ens_onchip, ens_offchip, learning_rule_type=nengo.PES()),
-            nengo.Connection(ens_onchip, node_offchip),
-            nengo.Connection(
-                ens_onchip.neurons, ens_offchip, transform=np.ones((1, 10))),
-            nengo.Connection(
-                ens_onchip.neurons, node_offchip, transform=np.ones((1, 10))),
-        ]
-        connections.append(
-            nengo.Connection(ens_onchip, connections[1].learning_rule)
-        )
-
-    networks = SplitNetworks(net, node_neurons=default_node_neurons)
-    networks.move(ens_onchip, "chip")
-    networks.move(ens_offchip, "host")
-    networks.move(node_offchip, "host")
-
-    for conn in connections:
-        split_chip_to_host(networks, conn)
-        for added in networks.adds:
-            if isinstance(added, HostReceiveNode):
-                receive = added
-            elif isinstance(added, nengo.Probe):
-                probe = added
-            else:
-                assert added.post is conn.post
-                receive2post = added
-
-        assert networks.location(receive) == "host"
-        assert networks.location(receive2post) == "host"
-        assert receive2post.pre is receive
-
-        assert networks.location(probe) == "chip"
-        assert probe.target is conn.pre or probe.target is conn.pre.ensemble
-        assert probe.synapse is None
-        assert probe in networks.chip2host_params
-        assert probe in networks.chip2host_receivers
-        assert networks.chip2host_receivers[probe] is receive
-        if conn.learning_rule_type is not None:
-            assert conn.learning_rule in networks.needs_sender
-            assert isinstance(networks.needs_sender[conn.learning_rule],
-                              PESModulatoryTarget)
-
-        assert conn in networks.removes
-        networks.adds.clear()  # makes next loop iteration easier
+    assert not split.on_chip(offoff.pre)
+    assert not split.on_chip(offoff.post)
 
 
 def test_split_host_to_learning_rule():
     with nengo.Network() as net:
+        add_params(net)
         pre = nengo.Ensemble(10, 1, label="pre")
         post = nengo.Ensemble(10, 1, label="post")
         err_onchip = nengo.Ensemble(10, 1, label="err_onchip")
         err_offchip = nengo.Ensemble(10, 1, label="err_offchip")
+        net.config[err_offchip].on_chip = False
         ens_conn = nengo.Connection(pre, post, learning_rule_type=nengo.PES())
         neurons_conn = nengo.Connection(pre.neurons, post.neurons,
                                         learning_rule_type=nengo.PES())
-        on2on_ens = nengo.Connection(err_onchip, ens_conn.learning_rule)
-        on2on_neurons = nengo.Connection(
+        nengo.Connection(err_onchip, ens_conn.learning_rule)
+        nengo.Connection(
             err_onchip, neurons_conn.learning_rule)
-        off2on_ens = nengo.Connection(err_offchip, ens_conn.learning_rule)
-        off2on_neurons = nengo.Connection(
+        nengo.Connection(err_offchip, ens_conn.learning_rule)
+        nengo.Connection(
             err_offchip, neurons_conn.learning_rule)
 
-    networks = SplitNetworks(net, node_neurons=default_node_neurons)
-    networks.move(pre, "chip")
-    networks.move(post, "chip")
-    networks.move(err_onchip, "chip")
-    networks.move(err_offchip, "host")
-    networks.move(ens_conn, "chip")
-    networks.move(neurons_conn, "chip")
-    networks.needs_sender[ens_conn.learning_rule] = "ens_pes_target"
-    networks.needs_sender[neurons_conn.learning_rule] = "neurons_pes_target"
+    split = Split(net)
 
-    split_host_to_learning_rules(networks, networks.original.all_connections)
-    assert on2on_ens not in networks
-    assert on2on_neurons not in networks
-    assert sorted([type(obj).__name__ for obj in networks.adds]) == [
-        "Connection", "Connection", "HostSendNode", "HostSendNode",
-    ]
-    assert off2on_ens in networks.removes
-    assert "ens_pes_target" in list(networks.host2chip_senders.values())
-    assert off2on_neurons in networks.removes
-    assert "neurons_pes_target" in list(networks.host2chip_senders.values())
+    assert split.on_chip(pre)
+    assert not split.on_chip(post)
+
+    assert not split.on_chip(err_onchip)
+    assert not split.on_chip(err_offchip)
+
+
+def test_precompute_host_to_learning_rule_unsupported():
+    with nengo.Network() as net:
+        add_params(net)
+
+        pre = nengo.Ensemble(10, 1, label="pre")
+        post = nengo.Ensemble(10, 1, label="post")
+        nengo.Connection(pre, post, learning_rule_type=nengo.PES())
+
+    with pytest.raises(BuildError, match="learning rules"):
+        Split(net, precompute=True)
 
 
 def test_place_probes():
     with nengo.Network() as net:
+        add_params(net)
         offchip1 = nengo.Node(0)
         with nengo.Network():
             onchip1 = nengo.Ensemble(10, 1)
             offchip2 = nengo.Ensemble(10, 1)
+            net.config[offchip2].on_chip = False
         onchip2 = nengo.Ensemble(10, 1)
-        onchip3 = nengo.Connection(onchip1, onchip2)
-        offchip3 = nengo.Connection(offchip1, offchip2)
+        nengo.Connection(onchip1, onchip2)
+        nengo.Connection(offchip1, offchip2)
         offchip_probes = [
             nengo.Probe(offchip1),
             nengo.Probe(offchip2),
-            nengo.Probe(offchip3),
         ]
         onchip_probes = [
             nengo.Probe(onchip1),
             nengo.Probe(onchip2),
-            nengo.Probe(onchip3),
         ]
 
-    networks = SplitNetworks(net, node_neurons=default_node_neurons)
-    for obj in [offchip1, offchip2, offchip3]:
-        networks.move(obj, "host")
-    for obj in [onchip1, onchip2, onchip3]:
-        networks.move(obj, "chip")
-    place_probes(networks)
-    assert all(networks.location(p) == "host" for p in offchip_probes)
-    assert all(networks.location(p) == "chip" for p in onchip_probes)
+    split = Split(net)
+    assert split.on_chip(onchip1)
+    assert split.on_chip(onchip2)
+    assert not split.on_chip(offchip1)
+    assert not split.on_chip(offchip2)
+    assert not any(split.on_chip(p) for p in offchip_probes)
+    assert all(split.on_chip(p) for p in onchip_probes)
 
 
 def test_split_pre_from_host():
     with nengo.Network() as net:
+        add_params(net)
         pre_1 = nengo.Node(0, label="pre_1")
         pre_2 = nengo.Ensemble(10, 1, label="pre_2")
         pre_3 = nengo.Node(size_in=1, label="pre_3")
         pre_4 = nengo.Ensemble(1, 1, label="pre_4")
-        send = HostSendNode(dimensions=1)
+        pre_5 = nengo.Probe(pre_4)
+
         onchip = nengo.Ensemble(1, 1, label="onchip")
         post1 = nengo.Ensemble(10, 1, label="post1")
         post2 = nengo.Node(size_in=1, label="post2")
-        pre_connections = [
-            nengo.Connection(pre_1, pre_2),
-            nengo.Connection(pre_2, pre_3),
-            nengo.Connection(pre_3, pre_4),
-            nengo.Connection(pre_4.neurons, send),
-        ]
-        post_connections = [
-            nengo.Connection(onchip, post1),
-            nengo.Connection(post1, post2),
-        ]
+        post3 = nengo.Probe(post2, label="post3")
 
-    networks = SplitNetworks(net, node_neurons=default_node_neurons)
-    for obj in [pre_1, pre_3, send, post1, post2]:
-        networks.move(obj, "host")
-    for obj in [pre_2, pre_4]:
-        networks.add(obj, "host")
-    for conn in pre_connections + post_connections:
-        networks.move(conn, "host")
-    networks.move(onchip, "chip")
+        nengo.Connection(pre_1, pre_2)
+        nengo.Connection(pre_2, pre_3)
+        nengo.Connection(pre_3, pre_4)
+        nengo.Connection(pre_4.neurons, onchip)
+        nengo.Connection(onchip, post1)
+        nengo.Connection(post1, post2)
 
-    split_pre_from_host(networks)
-    for obj in [pre_1, pre_2, pre_3, pre_4, send] + pre_connections:
-        assert networks.location(obj) == "host_pre", obj
-    for obj in [post1, post2] + post_connections:
-        assert networks.location(obj) == "host", obj
-    assert networks.location(onchip) == "chip"
+        net.config[pre_2].on_chip = False
+        net.config[pre_4].on_chip = False
+        net.config[post1].on_chip = False
 
+    split = Split(net, precompute=True)
 
-def test_consistent_order():
-    with nengo.Network() as model:
-        add_params(model)
+    host_precomputable = {pre_1, pre_2, pre_3, pre_4, pre_5}
+    for obj in host_precomputable:
+        assert not split.on_chip(obj)
+        assert split.is_precomputable(obj)
 
-        u0 = nengo.Node(0, label="u0")
-        for i in range(5):
-            e = nengo.Ensemble(i+1, 1, label="e%d" % i)
-            f = nengo.Ensemble(i+1, 1, label="f%d" % i)
-            nengo.Connection(u0, e, label="c0%d" % i)
-            nengo.Connection(e, f, label="cf%d" % i)
-            nengo.Probe(e)
-            nengo.Probe(f.neurons)
+    host_nonprecomputable = {post1, post2, post3}
+    for obj in host_nonprecomputable:
+        assert not split.on_chip(obj)
+        assert not split.is_precomputable(obj)
 
-    # Test splitting a number of times, making sure the order of things matches
-    # the original network each time
-    split_params = dict(
-        precompute=False,
-        node_neurons=OnOffDecodeNeurons(dt=0.001),
-        node_tau=0.005,
-        remove_passthrough=False,
-    )
+    assert split.on_chip(onchip)
+    assert not split.is_precomputable(onchip)
 
-    networks0 = split(model, **split_params)
-    for _ in range(5):
-        networks = split(model, **split_params)
-
-        # --- order matches original network
-        assert len(model.all_ensembles) == len(networks.chip.all_ensembles)
-        for ea, eb in zip(model.all_ensembles, networks.chip.all_ensembles):
-            assert ea.n_neurons == eb.n_neurons and ea.label == eb.label
-
-        # --- order matches previous split
-        for attr in ('connections', 'ensembles', 'nodes', 'probes'):
-            for net in ('host_pre', 'host', 'chip'):
-                aa = getattr(getattr(networks0, net), 'all_' + attr)
-                bb = getattr(getattr(networks, net), 'all_' + attr)
-                for a, b in zip(aa, bb):
-                    assert a.label == b.label
-
-
-@pytest.mark.skipif(LooseVersion(nengo.__version__) <= LooseVersion('2.8.0'),
-                    reason="requires more recent Nengo version")
-def test_split_conv2d_transform_error():
-    with nengo.Network() as net:
-        add_params(net)
-        node_offchip = nengo.Node([1])
-        ens_onchip = nengo.Ensemble(10, 1)
-        conv2d = nengo.Convolution(
-            n_filters=1, input_shape=(1, 1, 1), kernel_size=(1, 1))
-        nengo.Connection(node_offchip, ens_onchip, transform=conv2d)
-
-    with pytest.raises(BuildError, match="Conv2D"):
-        split(net, precompute=False, node_neurons=default_node_neurons,
-              node_tau=0.005)
+    with pytest.raises(BuildError, match="not a part of the network"):
+        split.is_precomputable(
+            nengo.Node(0, add_to_container=False))
 
 
 def test_split_precompute_loop_error():
@@ -464,62 +212,80 @@ def test_split_precompute_loop_error():
         nengo.Connection(node_offchip, ens_onchip)
         nengo.Connection(ens_onchip, node_offchip)
 
-    with pytest.raises(BuildError, match="precompute"):
-        split(net, precompute=True, node_neurons=default_node_neurons,
-              node_tau=0.005)
+    with pytest.raises(BuildError, match="Cannot precompute"):
+        Split(net, precompute=True)
 
 
-def test_splitnetwork_bad_add_type():
-    net = nengo.Network()
-    networks = SplitNetworks(net)
-    networks.add(1, "chip")
-    with pytest.raises(AssertionError):
-        networks.finalize()
+@pytest.mark.parametrize("remove_passthrough", [True, False])
+def test_split_remove_passthrough(remove_passthrough):
+    with nengo.Network() as net:
+        add_params(net)
+
+        keep1 = nengo.Node(0, label="keep1")
+        keep2 = nengo.Node(lambda t, x: x, size_in=1, label="keep2")
+        keep3 = nengo.Node(size_in=1, label="keep3")
+
+        chip1 = nengo.Ensemble(10, 1, label="chip1")
+        discard1 = nengo.Node(size_in=1, label="discard1")
+        chip2 = nengo.Ensemble(10, 1, label="chip2")
+        discard2 = nengo.Node(size_in=1, label="discard2")
+        chip3 = nengo.Ensemble(10, 1, label="chip3")
+
+        keep4 = nengo.Node(size_in=1, label="keep4")
+        probe = nengo.Probe(keep4)
+
+        nengo.Connection(keep1, keep2)
+        nengo.Connection(keep2, keep3)
+        nengo.Connection(keep3, chip1)
+        conn1 = nengo.Connection(chip1, discard1)
+        conn2 = nengo.Connection(discard1, chip2)
+        conn3 = nengo.Connection(chip2, discard2)
+        conn4 = nengo.Connection(discard2, chip3)
+        nengo.Connection(chip3, keep4)
+
+    split = Split(net, remove_passthrough=remove_passthrough)
+    assert not split.on_chip(probe)
+
+    if remove_passthrough:
+        assert split.passthrough.to_remove == {
+            conn1, conn2, conn3, conn4, discard1, discard2,
+        }
+
+        conns = list(split.passthrough.to_add)
+        assert len(conns) == 2
+
+        prepost = {(conn.pre, conn.post) for conn in conns}
+        assert prepost == {(chip1, chip2), (chip2, chip3)}
+
+    else:
+        assert split.passthrough.to_remove == set()
+        assert split.passthrough.to_add == set()
 
 
-def test_splitnetwork_remove_add():
-    net = nengo.Network()
-    networks = SplitNetworks(net)
-    e = nengo.Ensemble(1, 1, add_to_container=False)
-    networks.add(e, "chip")
-    networks.remove(e)
-    assert e not in networks.adds
+def test_precompute_remove_passthrough():
+    with nengo.Network() as net:
+        add_params(net)
 
+        host = nengo.Node(0, label="host")
+        onchip1 = nengo.Ensemble(1, 1, label="onchip1")
+        passthrough1 = nengo.Node(size_in=1, label="passthrough1")
+        onchip2 = nengo.Ensemble(1, 1, label="onchip2")
+        passthrough2 = nengo.Node(size_in=1, label="passthrough2")
+        onchip3 = nengo.Ensemble(1, 1, label="onchip3")
 
-def test_pesmodulatorytarget_interface():
-    target = "target"
-    p = PESModulatoryTarget(target)
+        nengo.Connection(host, onchip1)
+        nengo.Connection(onchip1, passthrough1)
+        nengo.Connection(passthrough1, onchip2)
+        nengo.Connection(onchip2, passthrough2)
+        nengo.Connection(passthrough2, onchip3)
 
-    t0 = 4
-    e0 = [1.8, 2.4, 3.3]
-    t1 = t0 + 3
-    e1 = [7.2, 2.2, 4.1]
-    e01 = np.array(e0) + np.array(e1)
+    split = Split(net, precompute=True, remove_passthrough=True)
 
-    p.receive(t0, e0)
-    assert isinstance(p.errors[t0], np.ndarray)
-    assert np.allclose(p.errors[t0], e0)
+    assert split.is_precomputable(host)
+    assert not split.on_chip(host)
 
-    p.receive(t0, e1)
-    assert np.allclose(p.errors[t0], e01)
+    for obj in (onchip1, passthrough1, onchip2, passthrough2, onchip3):
+        assert not split.is_precomputable(obj)
 
-    with pytest.raises(AssertionError):
-        p.receive(t0 - 1, e0)  # time needs to be >= last time
-
-    p.receive(t1, e1)
-    assert np.allclose(p.errors[t1], e1)
-
-    errors = list(p.collect_errors())
-    assert len(errors) == 2
-    assert errors[0][:2] == (target, t0) and np.allclose(errors[0][2], e01)
-    assert errors[1][:2] == (target, t1) and np.allclose(errors[1][2], e1)
-
-    p.clear()
-    assert len(list(p.collect_errors())) == 0
-
-
-def test_bad_obj_type():
-    split = SplitNetworks(nengo.Network())
-    split.adds = {"woops": "host"}
-    with pytest.raises(AssertionError, match="cannot handle type"):
-        split.finalize()
+    for obj in (onchip1, onchip2, onchip3):
+        assert split.on_chip(obj)

--- a/nengo_loihi/tests/test_splitter.py
+++ b/nengo_loihi/tests/test_splitter.py
@@ -216,6 +216,34 @@ def test_split_precompute_loop_error():
         Split(net, precompute=True)
 
 
+def test_chip_learning_errors():
+    with nengo.Network() as net:
+        add_params(net)
+
+        a = nengo.Ensemble(100, 1)
+        b = nengo.Ensemble(100, 1)
+        net.config[b].on_chip = True
+
+        nengo.Connection(a, b, learning_rule_type=nengo.PES())
+
+    with pytest.raises(BuildError, match="Post ensemble"):
+        Split(net)
+
+    with nengo.Network() as net:
+        add_params(net)
+
+        a = nengo.Ensemble(100, 1)
+        b = nengo.Ensemble(100, 1)
+        error = nengo.Ensemble(100, 1)
+        net.config[error].on_chip = True
+
+        conn = nengo.Connection(a, b, learning_rule_type=nengo.PES())
+        nengo.Connection(error, conn.learning_rule)
+
+    with pytest.raises(BuildError, match="Pre ensemble"):
+        Split(net)
+
+
 @pytest.mark.parametrize("remove_passthrough", [True, False])
 def test_split_remove_passthrough(remove_passthrough):
     with nengo.Network() as net:

--- a/nengo_loihi/tests/test_splitter.py
+++ b/nengo_loihi/tests/test_splitter.py
@@ -262,6 +262,26 @@ def test_split_remove_passthrough(remove_passthrough):
         assert split.passthrough.to_add == set()
 
 
+def test_sliced_passthrough_bug():
+    with nengo.Network() as model:
+        add_params(model)
+
+        a = nengo.Ensemble(1, 1, label="a")
+        passthrough = nengo.Node(size_in=1, label="passthrough")
+
+        nengo.Connection(a, passthrough)
+        p = nengo.Probe(passthrough[0])
+
+    split = Split(model, remove_passthrough=True)
+
+    assert len(split.passthrough.to_add) == 0
+    assert len(split.passthrough.to_remove) == 0
+
+    assert split.on_chip(a)
+    assert not split.on_chip(passthrough)
+    assert not split.on_chip(p)
+
+
 def test_precompute_remove_passthrough():
     with nengo.Network() as net:
         add_params(net)

--- a/nengo_loihi/tests/test_splitter.py
+++ b/nengo_loihi/tests/test_splitter.py
@@ -5,14 +5,14 @@ import nengo
 from nengo.exceptions import BuildError
 import numpy as np
 
-from nengo_loihi.decode_neurons import OnOffDecodeNeurons
-from nengo_loihi.config import add_params
-from nengo_loihi.inputs import (
+from nengo_loihi.builder.inputs import (
     ChipReceiveNeurons,
     ChipReceiveNode,
     HostReceiveNode,
     HostSendNode,
 )
+from nengo_loihi.decode_neurons import OnOffDecodeNeurons
+from nengo_loihi.config import add_params
 from nengo_loihi.splitter import (
     PESModulatoryTarget,
     place_ensembles,


### PR DESCRIPTION
Closes #80. Refactors the splitter logic for adding / removing connections to occur within the builder. This consolidates the connection logic into one place (`builder/connection.py`) so that backend-relevant logic and objects are manipulated at the same level of abstraction.

Overarching ideas:
 - The splitter returns "directives" (i.e., sets of instructions) to guide the builder.
 - The builder fills in all three "sub-models" (`self`, `host`, and `host_pre`) in parallel, by delegating the objects to the appropriate builder methods.

Solves the following bugs:
 - https://github.com/nengo/nengo-loihi/issues/205 - Splitter handles sliced probes.
 - https://github.com/nengo/nengo-loihi/issues/206 - Passthrough removal handles sliced probes.
 - https://github.com/nengo/nengo-loihi/issues/207 - Decoder cache is not globally disabled.
 - https://github.com/nengo/nengo-loihi/issues/208 - Improved chip -> chip learning signal message.
 - https://github.com/nengo/nengo-loihi/issues/209 - Improved chip -> chip error signal message.
 - https://github.com/nengo/nengo-loihi/issues/211 - Splitter won't mutate original network.

Random improvements:
 - ~~`split_pre_from_host` is no longer `O(n^2)`~~ (This was a misunderstanding on my part, fueled by the fact the variable named "queue" was actually a stack -- it is now actually a queue)
 - `__contains__` is no longer `O(n)`

Bugs that have been identified that are outside the scope of this PR:
 - https://github.com/nengo/nengo-loihi/issues/210 - Passthrough connections aren’t seeded, and the order is non-deterministic.
 - https://github.com/nengo/nengo-loihi/issues/212 - Passthrough removal is too aggressive.
 - https://github.com/nengo/nengo-loihi/issues/213 - Passthrough removal is broken.
 - https://github.com/nengo/nengo-loihi/issues/214 - `precompute=True` could be smarter.

Existing issues that should now be more readily achievable:
 - #163 - Passing instance config parameters to builder
 - #154 - `sim.data` does not contain chip <-> host connections
 - #145 - Efficient passthrough nodes
 - #118 - Indicate which parts of a model are running on/off chip
 - #4 - Expose `params` and handle splitter-created objects

Other future work:
 - Ability to pass in `network=None`.
 - Change `assert self.model.dt == dt` to an error and then unit test (https://github.com/nengo/nengo/issues/1517).