### PR TITLE
Accommodate new nengo.NeuronTypes.currents and .rates

### DIFF
--- a/docs/setup/host-board.rst
+++ b/docs/setup/host-board.rst
@@ -147,7 +147,7 @@ Compiling Ubuntu
 ----------------
 
 These steps are based on `this guide
-<https://web.archive.org/web/20180130073104/https://gnu-linux.org/building-ubuntu-rootfs-for-arm.html>`_.
+<https://gnu-linux.org/building-ubuntu-rootfs-for-arm.html>`_.
 These steps should be performed on the superhost.
 You will need root access.
 

--- a/nengo_loihi/neurons.py
+++ b/nengo_loihi/neurons.py
@@ -56,10 +56,26 @@ def loihi_spikingrectifiedlinear_rates(neuron_type, x, gain, bias, dt):
     return out
 
 
+def _broadcast_rates_inputs(x, gain, bias):
+    x = np.array(x, dtype=float, copy=False, ndmin=1)
+    gain = np.array(gain, dtype=float, copy=False, ndmin=1)
+    bias = np.array(bias, dtype=float, copy=False, ndmin=1)
+    if x.ndim == 1:
+        x = x[:, np.newaxis] * np.ones(gain.shape[-1])
+    return x, gain, bias
+
+
 def loihi_rates(neuron_type, x, gain, bias, dt):
+    x, gain, bias = _broadcast_rates_inputs(x, gain, bias)
     for cls in type(neuron_type).__mro__:
         if cls in loihi_rate_functions:
             return loihi_rate_functions[cls](neuron_type, x, gain, bias, dt)
+    return neuron_type.rates(x, gain, bias)
+
+
+def nengo_rates(neuron_type, x, gain, bias):
+    """Call NeuronType.rates with Nengo 3.0 broadcasting rules"""
+    x, gain, bias = _broadcast_rates_inputs(x, gain, bias)
     return neuron_type.rates(x, gain, bias)
 
 

--- a/nengo_loihi/tests/test_connection.py
+++ b/nengo_loihi/tests/test_connection.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from nengo_loihi.config import add_params
+from nengo_loihi.neurons import nengo_rates
 
 
 @pytest.mark.parametrize('weight_solver', [False, True])
@@ -62,7 +63,7 @@ def test_node_to_neurons(dt, precompute, allclose, Simulator, plt):
     bias = [0] * len(y)
 
     neuron_type = nengo.LIF()
-    z = neuron_type.rates(y, gain, bias)
+    z = nengo_rates(neuron_type, y[np.newaxis, :], gain, bias).squeeze(axis=0)
 
     with nengo.Network() as model:
         u = nengo.Node(x, label='u')
@@ -83,6 +84,7 @@ def test_node_to_neurons(dt, precompute, allclose, Simulator, plt):
     plt.bar(np.arange(len(z)) + bar_width, rates, bar_width, label='rates')
     plt.legend(loc='best')
 
+    assert rates.shape == z.shape
     assert allclose(rates, z, atol=3, rtol=0.1)
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,6 @@ addopts = -p nengo.tests.options --simulator nengo_loihi.Simulator --ref-simulat
 filterwarnings =
     ignore:Seed will be ignored when running on Loihi
 log_format = %(levelname).1s %(module)-18s %(message)s
-log_level = DEBUG
 norecursedirs = .* *.egg build dist docs *.analytics *.logs *.plots
 nengo_test_unsupported =
     # no ensembles on chip


### PR DESCRIPTION
The changes here break a number of nengo-loihi tests: https://github.com/nengo/nengo/pull/1437. Here we will fix them.