### PR TITLE
Fix travis CI

### DIFF
--- a/.ci/hardware.sh.template
+++ b/.ci/hardware.sh.template
@@ -20,7 +20,8 @@
         pip install nengo-dl jupyter
         pip install -e .[tests]
         pip install $NENGO_VERSION --upgrade
-        pip install ~/travis-ci/nxsdk-0.8.0.tar.gz
+        cp /nfs/ncl/releases/$NXSDK_VERSION/nxsdk-$NXSDK_VERSION.tar.gz .
+        pip install nxsdk-$NXSDK_VERSION.tar.gz
         SLURM=1 pytest --target loihi --no-hang -v --durations 50 --color=yes -n 1 --cov=nengo_loihi --cov-report=xml --cov-report=term-missing || HW_STATUS=1
         exit \$HW_STATUS
 EOF

--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -16,6 +16,7 @@ travis_yml:
     - script: hardware
       env:
         NENGO_VERSION: git+https://github.com/nengo/nengo.git#egg=nengo
+        NXSDK_VERSION: 0.8.1
     - script: docs
       env:
         NENGO_VERSION: git+https://github.com/nengo/nengo.git#egg=nengo

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ jobs:
   -
     env:
       NENGO_VERSION="git+https://github.com/nengo/nengo.git#egg=nengo"
+      NXSDK_VERSION="0.8.1"
       SCRIPT="hardware"
   -
     env:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,8 @@ Release history
   (`#202 <https://github.com/nengo/nengo-loihi/pull/202>`__,
   `#208 <https://github.com/nengo/nengo-loihi/issues/208>`__,
   `#209 <https://github.com/nengo/nengo-loihi/issues/209>`__)
+- Nengo Loihi now requires at least NxSDK version 0.8.0.
+  (`#218 <https://github.com/nengo/nengo-loihi/pull/218>`__)
 
 **Fixed**
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -31,8 +31,7 @@ for running Nengo Loihi,
 as well as for running models
 using the NxSDK directly.
 
-Note, you *must* use Python 3.5.2 and NumPy 1.14.3
-when working with NxSDK.
+Note, you *must* use Python 3.5.2 when working with NxSDK.
 The easiest way to satisfy those constraints is to use `Miniconda
 <https://conda.io/projects/conda/en/latest/user-guide/install/index.html>`_
 to set up an isolated environment
@@ -94,11 +93,10 @@ for running Loihi models.
              you log onto the superhost.
 
 4. Install NumPy and Cython with conda.
-   Note, you *must* use NumPy 1.14.3 when working with NxSDK.
 
    .. code-block:: bash
 
-      conda install numpy=1.14.3 cython
+      conda install numpy cython
 
    The NumPy provided by conda is usually faster
    than those installed by other means.
@@ -108,25 +106,25 @@ for running Loihi models.
    .. note:: The location of NxSDK may have changed.
              Refer to Intel's documentation to be sure.
              The most recent release and NxSDK location
-             are current as of September 2018.
+             are current as of May 2019.
 
    If you are logged into INRC:
 
    .. code-block:: bash
 
-      cp /nfs/ncl/releases/0.7/nxsdk-0.7.tar.gz .
+      cp /nfs/ncl/releases/0.8.1/nxsdk-0.8.1.tar.gz .
 
    If you are setting up a non-INRC superhost:
 
    .. code-block:: bash
 
-      scp <inrc-host>:/nfs/ncl/releases/0.7/nxsdk-0.7.tar.gz .
+      scp <inrc-host>:/nfs/ncl/releases/0.8.1/nxsdk-0.8.1.tar.gz .
 
 6. Install NxSDK.
 
    .. code-block:: bash
 
-      pip install nxsdk-0.7.tar.gz
+      pip install nxsdk-0.8.1.tar.gz
 
 7. Install Nengo Loihi.
 

--- a/nengo_loihi/builder/tests/test_connection.py
+++ b/nengo_loihi/builder/tests/test_connection.py
@@ -54,7 +54,8 @@ def test_manual_decoders(
         post_probe = nengo.Probe(post, synapse=None)
 
     if not use_solver and learn:
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(NotImplementedError,
+                           match="presynaptic object must be an Ensemble"):
             with Simulator(model) as sim:
                 pass
     else:

--- a/nengo_loihi/emulator/tests/test_interface.py
+++ b/nengo_loihi/emulator/tests/test_interface.py
@@ -29,7 +29,7 @@ def test_strict_mode(strict, monkeypatch):
     assert emu.strict == strict
 
     if strict:
-        check = pytest.raises(SimulationError)
+        check = pytest.raises(SimulationError, match="Error in emulator")
     else:
         check = pytest.warns(UserWarning)
 

--- a/nengo_loihi/hardware/interface.py
+++ b/nengo_loihi/hardware/interface.py
@@ -18,7 +18,6 @@ from nengo_loihi.hardware.builder import build_board
 from nengo_loihi.hardware.nxsdk_shim import (
     assert_nxsdk,
     nxsdk,
-    nxsdk_version,
     N2SpikeProbe,
 )
 from nengo_loihi.hardware.validate import validate_board
@@ -87,8 +86,8 @@ class HardwareInterface:
 
         # if installed, check version
         version = LooseVersion(getattr(nxsdk, "__version__", "0.0.0"))
-        minimum = LooseVersion("0.7.0")
-        max_tested = LooseVersion("0.8.0")
+        minimum = LooseVersion("0.8.0")
+        max_tested = LooseVersion("0.8.1")
         if version < minimum:
             raise ImportError("nengo-loihi requires nxsdk>=%s, found %s"
                               % (minimum, version))
@@ -383,8 +382,6 @@ class HardwareInterface:
             max_error_len=max_error_len,
             cores=cores,
             probes=probes,
-            time_step=('time' if nxsdk_version < LooseVersion('0.8.0')
-                       else 'time_step'),
         )
         with open(c_path, 'w') as f:
             f.write(code)

--- a/nengo_loihi/hardware/interface.py
+++ b/nengo_loihi/hardware/interface.py
@@ -68,13 +68,6 @@ class HardwareInterface:
         # the nengo_io_h2c channel on one timestep.
         self.snip_max_spikes_per_step = snip_max_spikes_per_step
 
-        nxsdk_dir = os.path.realpath(
-            os.path.join(os.path.dirname(nxsdk.__file__), "..")
-        )
-        self.cwd = os.getcwd()
-        logger.debug("cd to %s", nxsdk_dir)
-        os.chdir(nxsdk_dir)
-
         # probeDict is a class attribute, so might contain things left over
         # from previous simulators
         N2SpikeProbe.probeDict.clear()
@@ -293,12 +286,6 @@ class HardwareInterface:
     def close(self):
         if self.n2board is not None:
             self.n2board.disconnect()
-
-        # TODO: can we chdir back earlier?
-        if self.cwd is not None:
-            logger.debug("cd to %s", self.cwd)
-            os.chdir(self.cwd)
-            self.cwd = None
 
         self.closed = True
 

--- a/nengo_loihi/hardware/nxsdk_shim.py
+++ b/nengo_loihi/hardware/nxsdk_shim.py
@@ -24,13 +24,7 @@ except ImportError:
         raise exception
 
 
-if HAS_NXSDK and nxsdk_version < LooseVersion("0.8.0"):  # pragma: no cover
-    import nxsdk.arch.n2a.compiler.microcodegen.interface as microcodegen_uci
-    from nxsdk.arch.n2a.compiler.tracecfggen.tracecfggen import TraceCfgGen
-    from nxsdk.arch.n2a.graph.graph import N2Board
-    from nxsdk.arch.n2a.graph.inputgen import BasicSpikeGenerator
-    from nxsdk.arch.n2a.graph.probes import N2SpikeProbe
-elif HAS_NXSDK:
+if HAS_NXSDK:
     import nxsdk.compiler.microcodegen.interface as microcodegen_uci
     from nxsdk.compiler.tracecfggen.tracecfggen import TraceCfgGen
     from nxsdk.graph.nxboard import N2Board

--- a/nengo_loihi/hardware/snips/nengo_io.c.template
+++ b/nengo_loihi/hardware/snips/nengo_io.c.template
@@ -36,8 +36,8 @@ void nengo_io(runState *s) {
         return;
     }
 
-    if (s->{{ time_step }} % 100 == 0) {
-        printf("time %d\n", s->{{ time_step }});
+    if (s->time_step % 100 == 0) {
+        printf("time %d\n", s->time_step);
     }
 
     readChannel(in_channel, count, 1);
@@ -59,9 +59,9 @@ void nengo_io(runState *s) {
                    core_id.id, axon_id, axon_type, atom);
         }
         if (axon_type == 0) {
-            nx_send_discrete_spike(s->{{ time_step }}, core_id, axon_id);
+            nx_send_discrete_spike(s->time_step, core_id, axon_id);
         } else if (axon_type == 32) {
-            nx_send_pop32_spike(s->{{ time_step }}, core_id, axon_id, atom, 0, 0, 0);
+            nx_send_pop32_spike(s->time_step, core_id, axon_id, atom, 0, 0, 0);
         } else {
             printf("Got invalid axon_type: %d\n", axon_type);
             return;
@@ -82,7 +82,7 @@ void nengo_io(runState *s) {
         error_index += ERROR_INFO_SIZE + error_info[1];
     }
 
-    output[0] = s->{{ time_step }};
+    output[0] = s->time_step;
 {% for n_out, core, cx, key in probes %}
 {% if key == 'u' %}
     output[{{ n_out }}] = core{{ core }}->cx_state[{{ cx }}].U;

--- a/nengo_loihi/hardware/tests/test_allocators.py
+++ b/nengo_loihi/hardware/tests/test_allocators.py
@@ -51,7 +51,7 @@ def test_block_size(Simulator):
 
     with nengo.Network() as net:
         nengo.Ensemble(1025, 1)
-    with pytest.raises(BuildError):
+    with pytest.raises(BuildError, match="Number of compartments"):
         with Simulator(net):
             pass
 
@@ -60,7 +60,7 @@ def test_one_to_one_allocator_big_block_error():
     model = Model()
     model.add_block(LoihiBlock(1050))
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="Segment does not fit"):
         OneToOne()(model)
 
 

--- a/nengo_loihi/hardware/tests/test_interface.py
+++ b/nengo_loihi/hardware/tests/test_interface.py
@@ -26,7 +26,7 @@ def test_error_on_old_version(monkeypatch):
 
 def test_no_warn_on_current_version(monkeypatch):
     mock = MockNxsdk()
-    mock.__version__ = "0.7.0"
+    mock.__version__ = "0.8.0"
 
     monkeypatch.setattr(hardware_interface, 'nxsdk', mock)
     monkeypatch.setattr(hardware_interface, 'assert_nxsdk', lambda: True)

--- a/nengo_loihi/hardware/tests/test_interface.py
+++ b/nengo_loihi/hardware/tests/test_interface.py
@@ -20,7 +20,7 @@ def test_error_on_old_version(monkeypatch):
     mock.__version__ = "0.5.5"
 
     monkeypatch.setattr(hardware_interface, 'nxsdk', mock)
-    with pytest.raises(ImportError):
+    with pytest.raises(ImportError, match="nxsdk"):
         hardware_interface.HardwareInterface.check_nxsdk_version()
 
 

--- a/nengo_loihi/tests/test_conv.py
+++ b/nengo_loihi/tests/test_conv.py
@@ -664,7 +664,7 @@ def test_conv_gain(Simulator):
         nengo.Connection(a.neurons, b.neurons,
                          transform=nengo_transforms.Convolution(1, (4, 4, 1)))
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="must have the same gain"):
         with Simulator(net):
             pass
 

--- a/nengo_loihi/tests/test_learning.py
+++ b/nengo_loihi/tests/test_learning.py
@@ -292,7 +292,7 @@ def test_pes_pre_synapse_type_error(Simulator):
         conn = nengo.Connection(pre, post, learning_rule_type=rule_type)
         nengo.Connection(post, conn.learning_rule)
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="pre-synapses for learning"):
         with Simulator(model):
             pass
 
@@ -321,5 +321,6 @@ def test_drop_trace_spikes(Simulator, seed):
         nengo.Connection(b, conn.learning_rule)
 
     with Simulator(net, target="sim") as sim:
-        with pytest.raises(SimulationError):
+        with pytest.raises(SimulationError,
+                           match="Synaptic trace spikes lost"):
             sim.run(1.0)

--- a/nengo_loihi/tests/test_version.py
+++ b/nengo_loihi/tests/test_version.py
@@ -8,7 +8,8 @@ from nengo_loihi.version import check_nengo_version
 def test_nengo_version(Simulator, monkeypatch):
     # test nengo version below minimum
     monkeypatch.setattr(nengo.version, 'version_info', (2, 0, 0))
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError,
+                       match="nengo-loihi does not support Nengo version"):
         check_nengo_version()
 
     # test nengo version newer than latest


### PR DESCRIPTION
The first commit makes our `pytest.raises` checks more strict. This is something I was using to debug, and isn't strictly needed by this PR, but IMO is a good thing to do.

The second commit localizes the `os.chdir` to be within a `try-finally` block. This avoids a really weird issue we were seeing as a part of #217 (e.g., [see this job](https://travis-ci.com/nengo/nengo-loihi/jobs/195940847) and look for `nengo_loihi/hardware/tests/test_allocators.py::test_block_size`).

Essentially... if an error happens when the model is being built, then the current working directory (cwd) is permanently changed. More specifically, an error occurs within `HardwareInterface.__init__`, and so `__exit__` is never invoked. As a result, the directory is never changed back. This only occurs for `--target loihi`, and causes `coverage.xml` to be written to the wrong directory. Part of what made this issue weird is that `coverage.xml` is only written to the wrong directory if `-n` is omitted, but not for `-n 1`. This may be a subtle aspect of how pytest spins up its workers.

The second commit also adds a check to pytest's setup/teardown to make sure the directory is not changing. This test would fail on `test_block_size` with `--target loihi` if it were not for the fix.

Note this does *not* solve #217 (i.e., it does not make `nengo-loihi` process safe). The issue explained in the commit message of e9cd851b01b20b774d58c82a2ba775b531cf2bab is still present. Solving this is outside the scope of PR.