### PR TITLE
Update unsupported tests

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -196,6 +196,8 @@ setup_cfg:
         no ensembles onchip
       test_simulator.py:test_probe_cache:
         no ensembles onchip
+      test_simulator.py:test_sim_seed_set_by_network_seed:
+        no ensembles onchip
       test_simulator.py:test_invalid_run_time:
         no ensembles onchip
       test_simulator.py:test_sample_every*:
@@ -224,8 +226,6 @@ setup_cfg:
       # accuracy
       test_actionselection.py:test_basic:
         inaccurate
-      test_assoc_mem.py:test_am_basic:
-        integrator instability
       test_assoc_mem.py:test_am_threshold:
         integrator instability
       test_assoc_mem.py:test_am_wta:
@@ -251,8 +251,6 @@ setup_cfg:
       test_connection.py:test_function_and_transform:
         inaccurate
       test_connection.py:test_weights*:
-        inaccurate
-      test_connection.py:test_vector*:
         inaccurate
       test_connection.py:test_slicing*:
         inaccurate
@@ -290,8 +288,6 @@ setup_cfg:
         transform shape not implemented
       test_connection.py:test_list_indexing*:
         indexing bug?
-      test_connection.py:test_prepost_errors:
-        learning bug?
       test_ensemble.py:test_gain_bias_warning:
         warning not raised
       test_ensemble.py:*invalid_intercepts*:
@@ -306,8 +302,8 @@ setup_cfg:
         dict of learning rules not handled
       test_learning_rules.py:test_reset*:
         learning bug?
-      test_neurons.py:test_lif_min_voltage*:
-        lif.min_voltage ignored
+      test_neurons.py:test_lif_min_voltage[-1]:
+        min voltage bug?
       test_neurons.py:test_lif_zero_tau_ref:
         lif.tau_ref ignored
       test_probe.py:test_input_probe:
@@ -316,7 +312,7 @@ setup_cfg:
         ObjView not handled properly
       test_probe.py:test_update_timing:
         probe bug?
-      test_solvers.py:test_nosolver*:
+      test_solvers.py:test_nosolver[*:
         NoSolver bug
 
       # reset bugs
@@ -364,9 +360,11 @@ setup_cfg:
         probe.sample_every not implemented
 
       # needs better place and route
-      test_ensemble.py:test_eval_points_heuristic*:
+      test_ensemble.py:test_eval_points_heuristic[1290-4]:
         max number of compartments exceeded
-      test_neurons.py:test_lif*:
+      test_ensemble.py:test_eval_points_heuristic[2108-1]:
+        max number of compartments exceeded
+      test_neurons.py:test_lif[*:
         idxBits out of range
       test_basalganglia.py:test_basal_ganglia:
         output_axons exceeded max

--- a/setup.cfg
+++ b/setup.cfg
@@ -145,6 +145,8 @@ nengo_test_unsupported =
         "no ensembles onchip"
     test_simulator.py:test_probe_cache
         "no ensembles onchip"
+    test_simulator.py:test_sim_seed_set_by_network_seed
+        "no ensembles onchip"
     test_simulator.py:test_invalid_run_time
         "no ensembles onchip"
     test_simulator.py:test_sample_every*
@@ -171,8 +173,6 @@ nengo_test_unsupported =
         "no ensembles onchip"
     test_actionselection.py:test_basic
         "inaccurate"
-    test_assoc_mem.py:test_am_basic
-        "integrator instability"
     test_assoc_mem.py:test_am_threshold
         "integrator instability"
     test_assoc_mem.py:test_am_wta
@@ -198,8 +198,6 @@ nengo_test_unsupported =
     test_connection.py:test_function_and_transform
         "inaccurate"
     test_connection.py:test_weights*
-        "inaccurate"
-    test_connection.py:test_vector*
         "inaccurate"
     test_connection.py:test_slicing*
         "inaccurate"
@@ -233,8 +231,6 @@ nengo_test_unsupported =
         "transform shape not implemented"
     test_connection.py:test_list_indexing*
         "indexing bug?"
-    test_connection.py:test_prepost_errors
-        "learning bug?"
     test_ensemble.py:test_gain_bias_warning
         "warning not raised"
     test_ensemble.py:*invalid_intercepts*
@@ -249,8 +245,8 @@ nengo_test_unsupported =
         "dict of learning rules not handled"
     test_learning_rules.py:test_reset*
         "learning bug?"
-    test_neurons.py:test_lif_min_voltage*
-        "lif.min_voltage ignored"
+    test_neurons.py:test_lif_min_voltage[-1]
+        "min voltage bug?"
     test_neurons.py:test_lif_zero_tau_ref
         "lif.tau_ref ignored"
     test_probe.py:test_input_probe
@@ -259,7 +255,7 @@ nengo_test_unsupported =
         "ObjView not handled properly"
     test_probe.py:test_update_timing
         "probe bug?"
-    test_solvers.py:test_nosolver*
+    test_solvers.py:test_nosolver[*
         "NoSolver bug"
     test_neurons.py:test_reset*
         "sim.reset not working correctly"
@@ -293,9 +289,11 @@ nengo_test_unsupported =
         "probe.sample_every not implemented"
     test_probe.py:test_multiple_probes
         "probe.sample_every not implemented"
-    test_ensemble.py:test_eval_points_heuristic*
+    test_ensemble.py:test_eval_points_heuristic[1290-4]
         "max number of compartments exceeded"
-    test_neurons.py:test_lif*
+    test_ensemble.py:test_eval_points_heuristic[2108-1]
+        "max number of compartments exceeded"
+    test_neurons.py:test_lif[*
         "idxBits out of range"
     test_basalganglia.py:test_basal_ganglia
         "output_axons exceeded max"


### PR DESCRIPTION
https://github.com/nengo/nengo/pull/1398 fixed some of the nengo core tests that were accidentally using `nengo.Simulator` instead of the `Simulator` fixture.  This revealed another test that fails in nengo-loihi (no ensembles on chip), which is added to the unsupported list.

Then while I was updating that I also did a quick check for any tests that we were xpassing, and removed a few from the unsupported list as a result.