### PR TITLE
Support NxSDK 0.8.5

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -444,7 +444,7 @@ travis_yml:
     - script: hardware
       env:
         NENGO_VERSION: git+https://github.com/nengo/nengo.git#egg=nengo
-        NXSDK_VERSION: 0.8.1
+        NXSDK_VERSION: 0.8.5
     - script: docs
       env:
         NENGO_VERSION: git+https://github.com/nengo/nengo.git#egg=nengo

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
   -
     env:
       NENGO_VERSION="git+https://github.com/nengo/nengo.git#egg=nengo"
-      NXSDK_VERSION="0.8.1"
+      NXSDK_VERSION="0.8.5"
       SCRIPT="hardware"
   -
     env:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,10 @@ Release history
 0.8.0 (unreleased)
 ==================
 
+**Changed**
 
+- Nengo Loihi now requires NxSDK version 0.8.5.
+  (`#225 <https://github.com/nengo/nengo-loihi/pull/225>`__)
 
 0.7.0 (June 21, 2019)
 =====================

--- a/nengo_loihi/hardware/interface.py
+++ b/nengo_loihi/hardware/interface.py
@@ -88,8 +88,8 @@ class HardwareInterface:
 
         # if installed, check version
         version = LooseVersion(getattr(nxsdk, "__version__", "0.0.0"))
-        minimum = LooseVersion("0.8.0")
-        max_tested = LooseVersion("0.8.1")
+        minimum = LooseVersion("0.8.5")
+        max_tested = LooseVersion("0.8.5")
         if version < minimum:
             raise ImportError("nengo-loihi requires nxsdk>=%s, found %s"
                               % (minimum, version))
@@ -268,7 +268,7 @@ class HardwareInterface:
 
     def is_connected(self):
         return self.nxsdk_board is not None and d_func(
-            self.nxsdk_board, b'bnhEcml2ZXI=', b'aGFzU3RhcnRlZA==')
+            self.nxsdk_board, b'ZXhlY3V0b3I=', b'aGFzU3RhcnRlZA==')
 
     def connect(self, attempts=10):
         if self.nxsdk_board is None:
@@ -280,7 +280,7 @@ class HardwareInterface:
         logger.info("Connecting to Loihi, max attempts: %d", attempts)
         for i in range(attempts):
             try:
-                d_func(self.nxsdk_board, b'c3RhcnREcml2ZXI=')
+                d_func(self.nxsdk_board, b'c3RhcnQ=')
                 if self.is_connected():
                     break
             except Exception as e:

--- a/nengo_loihi/hardware/nxsdk_shim.py
+++ b/nengo_loihi/hardware/nxsdk_shim.py
@@ -4,7 +4,6 @@ import shutil
 import sys
 import tempfile
 
-
 from nengo_loihi.nxsdk_obfuscation import d_get, d_import, d_set
 
 try:
@@ -19,7 +18,6 @@ try:
         pass
 
     snip_maker = d_import(b'bnhzZGsuZ3JhcGguZ3JhcGg=')
-    driver = d_import(b'bnhzZGsuZHJpdmVyLmh3ZHJpdmVyLmRyaXZlcg==')
 
     class SnipMaker(d_get(snip_maker, b"R3JhcGg=")):
         """Patch of the snip process manager that is multiprocess safe."""
@@ -63,20 +61,6 @@ try:
 
     d_set(snip_maker, b"R3JhcGg=", val=SnipMaker)
 
-    class PatchedDriver(d_get(driver, b"TjJEcml2ZXI=")):
-        """Patched version of the driver that is multiprocess safe."""
-
-        def startDriver(self, *args, **kwargs):
-            super().startDriver(*args, **kwargs)
-
-            # NxSDK tries to make a temporary directory for compiledir, but
-            # this does it in a more secure way.
-            # Note: we use mkdtemp rather than TemporaryDirectory because
-            # NxSDK is already taking care of cleaning up the directory.
-            self.compileDir = tempfile.mkdtemp()
-
-    d_set(driver, b"TjJEcml2ZXI=", val=PatchedDriver)
-
 except ImportError:
     HAS_NXSDK = False
     nxsdk_dir = None
@@ -99,7 +83,7 @@ if HAS_NXSDK:
         b'bnhzZGsuZ3JhcGgubnhib2FyZA==',
         b'TjJCb2FyZA==')
     SpikeGen = d_import(
-        b'bnhzZGsuZ3JhcGgubnhpbnB1dGdlbg==',
+        b'bnhzZGsuZ3JhcGgubnhpbnB1dGdlbi5ueGlucHV0Z2Vu',
         b'QmFzaWNTcGlrZUdlbmVyYXRvcg==')
     SpikeProbe = d_import(
         b'bnhzZGsuZ3JhcGgubnhwcm9iZXM=',

--- a/nengo_loihi/hardware/tests/test_interface.py
+++ b/nengo_loihi/hardware/tests/test_interface.py
@@ -27,7 +27,7 @@ def test_error_on_old_version(monkeypatch):
 
 def test_no_warn_on_current_version(monkeypatch):
     mock = MockNxsdk()
-    mock.__version__ = "0.8.0"
+    mock.__version__ = "0.8.5"
 
     monkeypatch.setattr(hardware_interface, 'nxsdk', mock)
     monkeypatch.setattr(hardware_interface, 'assert_nxsdk', lambda: True)
@@ -108,12 +108,12 @@ def test_interface_connection_errors(Simulator):
             sim.step()
 
     # test failed connection error
-    def start_driver(*args, **kwargs):
+    def start(*args, **kwargs):
         raise Exception("Mock failure to connect")
 
     with Simulator(net) as sim:
         interface = sim.sims['loihi']
-        d_set(interface.nxsdk_board, b'c3RhcnREcml2ZXI=', val=start_driver)
+        d_set(interface.nxsdk_board, b'c3RhcnQ=', val=start)
 
         with pytest.raises(SimulationError, match="[Cc]ould not connect"):
             interface.connect(attempts=1)


### PR DESCRIPTION
Support the newest NxSDK in a non-backwards-compatible way. The new NxSDK adds a number of features that we plan on taking advantage of, and supporting both new and old seems like an extra burden.

NOTE: Do not merge this until AFTER the next release, so that we have a released nengo_loihi (0.7.0) that works with NxSDK 0.8.0/1.