### PR TITLE
Re-enable parallel hardware tests

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -222,6 +222,10 @@ setup_cfg:
         no ensembles onchip
       test_transforms.py:test_convolution*:
         no ensembles onchip
+      test_synapses.py:test_combined_delay:
+        no ensembles onchip
+      test_synapses.py:test_direct:
+        no ensembles onchip
 
       # accuracy
       test_actionselection.py:test_basic:
@@ -412,6 +416,10 @@ setup_cfg:
       # sparse transforms not supported
       test_transforms.py:test_sparse[*:
         sparse transforms not supported
+
+      # dtype not supported
+      test_simulator.py:test_dtype[*:
+        dtype option not supported
 
 
 docs_conf_py:

--- a/.templates/hardware.sh.template
+++ b/.templates/hardware.sh.template
@@ -22,7 +22,7 @@
         pip install $NENGO_VERSION --upgrade
         cp /nfs/ncl/releases/$NXSDK_VERSION/nxsdk-$NXSDK_VERSION.tar.gz .
         pip install nxsdk-$NXSDK_VERSION.tar.gz
-        SLURM=1 pytest --target loihi --no-hang -v --durations 50 --color=yes -n 1 --cov=nengo_loihi --cov-report=xml --cov-report=term-missing || HW_STATUS=1
+        SLURM=1 pytest --target loihi --no-hang -v --durations 50 --color=yes -n 2 --cov=nengo_loihi --cov-report=xml --cov-report=term-missing || HW_STATUS=1
         exit \$HW_STATUS
 EOF
 {% endblock %}

--- a/nengo_loihi/hardware/interface.py
+++ b/nengo_loihi/hardware/interface.py
@@ -4,6 +4,8 @@ import collections
 from distutils.version import LooseVersion
 import logging
 import os
+import shutil
+import tempfile
 import time
 import warnings
 
@@ -372,7 +374,8 @@ class HardwareInterface:
                         n_outputs += 1
 
         # --- write c file using template
-        c_path = os.path.join(snips_dir, "nengo_io.c")
+        self.tmp_snip_dir = tempfile.TemporaryDirectory()
+        c_path = os.path.join(self.tmp_snip_dir.name, "nengo_io.c")
         logger.debug(
             "Creating %s with %d outputs, %d error, %d cores, %d probes",
             c_path, n_outputs, n_errors, len(cores), len(probes))
@@ -397,9 +400,11 @@ class HardwareInterface:
             phase="mgmt",
         )
         logger.debug("Creating nengo_learn snip process")
+        c_path = os.path.join(self.tmp_snip_dir.name, "nengo_learn.c")
+        shutil.copyfile(os.path.join(snips_dir, "nengo_learn.c"), c_path)
         self.n2board.createProcess(
             name="nengo_learn",
-            cFilePath=os.path.join(snips_dir, "nengo_learn.c"),
+            cFilePath=c_path,
             includeDir=snips_dir,
             funcName="nengo_learn",
             guardName="guard_learn",

--- a/setup.cfg
+++ b/setup.cfg
@@ -171,6 +171,10 @@ nengo_test_unsupported =
         "no ensembles onchip"
     test_transforms.py:test_convolution*
         "no ensembles onchip"
+    test_synapses.py:test_combined_delay
+        "no ensembles onchip"
+    test_synapses.py:test_direct
+        "no ensembles onchip"
     test_actionselection.py:test_basic
         "inaccurate"
     test_assoc_mem.py:test_am_threshold
@@ -329,6 +333,8 @@ nengo_test_unsupported =
         "1D convolution not supported"
     test_transforms.py:test_sparse[*
         "sparse transforms not supported"
+    test_simulator.py:test_dtype[*
+        "dtype option not supported"
 
 [pylint]
 # note: pylint doesn't look in setup.cfg by default, need to call it with


### PR DESCRIPTION
The only change from what we had before is that we now do the rendering of the snip template files in a temporary directory (to ensure we don't have multiple simulators trying to write to the same file).  Ran the CI build a bunch of times (see https://travis-ci.com/nengo/nengo-loihi/builds) and didn't see any problems.  Hard to say for sure with these race conditions, I'll keep running it some more, but seems good 🤷‍♂ .