### PR TITLE
Implement Sparse transforms

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -35,6 +35,7 @@ setup_py:
   install_req:
     - jinja2
     - nengo>=2.8.0
+    - scipy>=1.2.1
   docs_req:
     - abr_control
     - jupyter
@@ -53,7 +54,6 @@ setup_py:
     - pytest-cov>=2.6.0
     - pytest-xdist>=1.26.0,<1.28.0
     - matplotlib>=2.0
-    - scipy
     - tensorflow<1.14
   classifiers:
     - "Development Status :: 3 - Alpha"

--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -91,7 +91,6 @@ setup_cfg:
       - superfluous-parens
       - undefined-loop-variable
       - unnecessary-pass
-      - unused-import
       - unused-variable
       - wrong-import-position
     known_third_party:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,12 +27,16 @@ Release history
 - It is now possible to slice the ``pre`` neurons in a neuron->neuron
   connection.
   (`#226 <https://github.com/nengo/nengo-loihi/pull/226>`__)
+- Connections now support ``Sparse`` transforms.
+  (`#240 <https://github.com/nengo/nengo-loihi/pull/240>`__)
 
 **Changed**
 
 - Connections from neurons with scalar transforms are now sparse internally.
   This allows much larger neuron->neuron connections with scalar transforms.
   (`#226 <https://github.com/nengo/nengo-loihi/pull/226>`__)
+- The ``scipy`` package is now required to run Nengo Loihi.
+  (`#240 <https://github.com/nengo/nengo-loihi/pull/240>`__)
 
 0.8.0 (June 23, 2019)
 =====================

--- a/nengo_loihi/builder/sparse_matrix.py
+++ b/nengo_loihi/builder/sparse_matrix.py
@@ -1,0 +1,50 @@
+import numpy as np
+import scipy
+
+
+def expand_matrix(matrix, shape):
+    """Ensure matrix is 2-D of the given shape, make it sparse diagonal if not.
+
+    If the matrix is 0-D or 1-D, ensure it's square and make it a diagonal
+    sparse matrix. Otherwise, just check the shape.
+    """
+    if matrix.ndim < 2:
+        assert shape[0] == shape[1]
+        data = matrix * np.ones(shape[0]) if matrix.ndim == 0 else matrix
+        assert data.size == shape[0]
+        matrix = scipy.sparse.dia_matrix((data, 0), shape=(shape[0], shape[0]))
+    else:
+        assert matrix.ndim == 2
+
+    assert matrix.shape == shape
+    return matrix
+
+
+def scale_matrix(matrix, scale):
+    scale = np.asarray(scale)
+
+    if isinstance(matrix, scipy.sparse.spmatrix) and scale.size > 1:
+        assert scale.ndim < 2
+        assert scale.size == matrix.shape[1]
+        diag = scipy.sparse.dia_matrix((scale, 0), shape=(scale.size, scale.size))
+        return matrix.dot(diag)
+    else:
+        return matrix * scale
+
+
+def stack_matrices(matrices, order="v"):
+    assert order in ("h", "v")
+
+    if all(isinstance(m, scipy.sparse.spmatrix) for m in matrices):
+        return (
+            scipy.sparse.vstack(matrices)
+            if order == "v"
+            else scipy.sparse.hstack(matrices)
+        )
+    elif all(isinstance(m, np.ndarray) for m in matrices):
+        return np.vstack(matrices) if order == "v" else np.hstack(matrices)
+    else:
+        raise NotImplementedError(
+            "All matrices must be the same type, one of: "
+            "np.ndarray, scipy.sparse.spmatrix"
+        )

--- a/nengo_loihi/builder/tests/test_connection.py
+++ b/nengo_loihi/builder/tests/test_connection.py
@@ -5,8 +5,6 @@ from nengo.exceptions import BuildError
 import numpy as np
 import pytest
 
-from nengo_loihi.builder.connection import expand_weights
-
 
 @pytest.mark.skipif(
     LooseVersion(nengo.__version__) <= LooseVersion("2.8.0"),
@@ -77,23 +75,3 @@ def test_manual_decoders(seed, Simulator, pre_dims, post_dims, learn, use_solver
         assert np.mean(sim.data[pre_probe]) > 100
         # But that post has no activity due to the zero weights
         assert np.all(sim.data[post_probe] == 0)
-
-
-def test_expand_weights():
-    # 0-d input
-    assert np.allclose(expand_weights(np.array(2.0), 3, 3, min_dims=1), np.ones(3) * 2)
-    assert np.allclose(expand_weights(np.array(2.0), 3, 3, min_dims=2), np.eye(3) * 2)
-
-    # 1-d input
-    assert np.allclose(expand_weights(np.arange(3), 3, 3, min_dims=1), np.arange(3))
-    assert np.allclose(
-        expand_weights(np.arange(3), 3, 3, min_dims=2), np.diag(np.arange(3))
-    )
-
-    # 2-d input
-    assert np.allclose(
-        expand_weights(np.ones((2, 3)), 3, 2, min_dims=1), np.ones((2, 3))
-    )
-    assert np.allclose(
-        expand_weights(np.ones((2, 3)), 3, 2, min_dims=2), np.ones((2, 3))
-    )

--- a/nengo_loihi/builder/tests/test_sparse_matrix.py
+++ b/nengo_loihi/builder/tests/test_sparse_matrix.py
@@ -1,0 +1,91 @@
+import numpy as np
+import pytest
+import scipy
+
+from nengo_loihi.builder.sparse_matrix import (
+    expand_matrix,
+    scale_matrix,
+    stack_matrices,
+)
+
+
+matrix_types = [np.ndarray, scipy.sparse.spmatrix]
+
+
+def toarray(x):
+    return x.toarray() if isinstance(x, scipy.sparse.spmatrix) else x
+
+
+def make_matrix(matrix_type, shape):
+    n = max(shape)
+    assert n >= 3
+    dense = np.zeros((n, n))
+    i = np.arange(n)
+    dense[i[::-1], i] = -np.arange(1, n + 1)
+    dense[i, i] = np.arange(1, n + 1)
+    dense = dense[: shape[0], : shape[1]]
+
+    indices = dense.nonzero()
+    data = dense[indices]
+
+    if matrix_type == scipy.sparse.spmatrix:
+        matrix = scipy.sparse.csr_matrix((data, indices), shape=shape)
+    else:
+        matrix = dense
+
+    return dense, matrix
+
+
+@pytest.mark.parametrize("matrix_type", matrix_types)
+def test_expand_matrix(matrix_type, monkeypatch):
+    # 0-d input
+    y = expand_matrix(np.array(2.0), (3, 3))
+    assert isinstance(y, scipy.sparse.spmatrix)
+    assert np.allclose(toarray(y), np.eye(3) * 2)
+
+    # 1-d input
+    y = expand_matrix(np.arange(3), (3, 3))
+    assert isinstance(y, scipy.sparse.spmatrix)
+    assert np.allclose(toarray(y), np.diag(np.arange(3)))
+
+    # 2-d input
+    shape = (3, 4)
+    dense_x, sparse_x = make_matrix(matrix_type, shape)
+    y = expand_matrix(sparse_x, shape)
+    assert isinstance(y, matrix_type)
+    assert np.allclose(toarray(y), dense_x)
+
+
+@pytest.mark.parametrize("matrix_type", matrix_types)
+def test_scale_matrix(matrix_type):
+    shape = (5, 4)
+    dense_x, sparse_x = make_matrix(matrix_type, shape)
+
+    # scalar scale
+    scale = 2.5
+    y = scale_matrix(sparse_x, scale)
+    assert isinstance(y, matrix_type)
+    assert np.allclose(toarray(y), scale * dense_x)
+
+    # vector scale
+    scale = np.arange(4)
+    y = scale_matrix(sparse_x, scale)
+    assert isinstance(y, matrix_type)
+    assert np.allclose(toarray(y), dense_x * scale)
+
+
+@pytest.mark.parametrize("matrix_type", matrix_types)
+def test_stack_matrices(matrix_type):
+    # horizontal
+    xd1, xs1 = make_matrix(matrix_type, (5, 4))
+    xd2, xs2 = make_matrix(matrix_type, (5, 3))
+    y = stack_matrices([xs1, xs2], order="h")
+    assert isinstance(y, matrix_type)
+    assert np.allclose(toarray(y), np.hstack([xd1, xd2]))
+
+    # vertical
+    xd1, xs1 = make_matrix(matrix_type, (5, 4))
+    xd2, xs2 = make_matrix(matrix_type, (3, 4))
+    y = stack_matrices([xs1, xs2], order="v")
+    assert isinstance(y, matrix_type)
+    assert np.allclose(toarray(y), np.vstack([xd1, xd2]))

--- a/nengo_loihi/compat.py
+++ b/nengo_loihi/compat.py
@@ -3,6 +3,7 @@ import logging
 
 import nengo
 import numpy as np
+import scipy
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +19,14 @@ if LooseVersion(nengo.__version__) > LooseVersion("2.8.0"):  # noqa: C901
         return transform.init
 
     def sample_transform(conn, rng=np.random):
-        return conn.transform.sample(rng=rng)
+        transform = conn.transform.sample(rng=rng)
+
+        # convert SparseMatrix to scipy.sparse
+        if isinstance(transform, nengo_transforms.SparseMatrix):
+            transform = scipy.sparse.csr_matrix(
+                (transform.data, transform.indices.T), shape=transform.shape
+            )
+        return transform
 
     def make_process_step(process, shape_in, shape_out, dt, rng, dtype=None):
         state = process.make_state(shape_in, shape_out, dt, dtype=dtype)

--- a/nengo_loihi/discretize.py
+++ b/nengo_loihi/discretize.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import logging
 import warnings
 

--- a/nengo_loihi/emulator/interface.py
+++ b/nengo_loihi/emulator/interface.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from collections import defaultdict, OrderedDict
 import logging
 import warnings

--- a/nengo_loihi/emulator/tests/test_interface.py
+++ b/nengo_loihi/emulator/tests/test_interface.py
@@ -59,7 +59,7 @@ def test_uv_overflow(n_axons, plt, allclose, monkeypatch):
     block.compartment.configure_filter(0.1)
 
     synapse = Synapse(n_axons)
-    synapse.set_full_weights(np.ones((n_axons, 1)))
+    synapse.set_weights(np.ones((n_axons, 1)))
     block.add_synapse(synapse)
 
     axon = Axon(n_axons)

--- a/nengo_loihi/hardware/builder.py
+++ b/nengo_loihi/hardware/builder.py
@@ -1,10 +1,7 @@
-from __future__ import division
-
 import logging
 
 import nengo.utils.numpy as npext
 from nengo.exceptions import BuildError
-from nengo.utils.stdlib import groupby
 import numpy as np
 
 from nengo_loihi.discretize import bias_to_manexp

--- a/nengo_loihi/hardware/interface.py
+++ b/nengo_loihi/hardware/interface.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import collections
 from distutils.version import LooseVersion
 import logging

--- a/nengo_loihi/hardware/nxsdk_objects.py
+++ b/nengo_loihi/hardware/nxsdk_objects.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import collections
 
 import numpy as np

--- a/nengo_loihi/hardware/nxsdk_objects.py
+++ b/nengo_loihi/hardware/nxsdk_objects.py
@@ -74,11 +74,6 @@ class Chip:
         self.core_idxs = {}
 
     @property
-    def index(self):
-        """Index of this Chip in the parent Board"""
-        return self.board.chip_index(self)
-
-    @property
     def n_cores(self):
         return len(self.cores)
 

--- a/nengo_loihi/hardware/tests/test_allocators.py
+++ b/nengo_loihi/hardware/tests/test_allocators.py
@@ -17,7 +17,7 @@ def test_core_stdp_pre_cfgs():
 
     def new_syn(tracing_mag=None):
         syn = Synapse(n_axons=1)
-        syn.set_full_weights(np.array([[1]]))
+        syn.set_weights(np.array([[1]]))
         if tracing_mag is not None:
             syn.set_learning(tracing_mag=tracing_mag)
         core.add_synapse(syn)
@@ -75,7 +75,7 @@ def _basic_model():
     block0.add_axon(axon1)
 
     synapse1 = Synapse(1)
-    synapse1.set_full_weights([[1]])
+    synapse1.set_weights([[1]])
     axon1.target = synapse1
     block1.add_synapse(synapse1)
 
@@ -85,7 +85,7 @@ def _basic_model():
     model.add_input(input)
 
     synapse0 = Synapse(1)
-    synapse0.set_full_weights([[1]])
+    synapse0.set_weights([[1]])
     axon0.target = synapse0
     block0.add_synapse(synapse0)
 

--- a/nengo_loihi/hardware/tests/test_interface.py
+++ b/nengo_loihi/hardware/tests/test_interface.py
@@ -56,7 +56,7 @@ def test_builder_poptype_errors():
     model.add_block(block)
 
     synapse = Synapse(1)
-    synapse.set_full_weights([[1]])
+    synapse.set_weights([[1]])
     synapse.pop_type = 8
     block.add_synapse(synapse)
 
@@ -81,7 +81,7 @@ def test_builder_poptype_errors():
     block0.add_axon(axon)
 
     synapse = Synapse(1)
-    synapse.set_full_weights([[1]])
+    synapse.set_weights([[1]])
     synapse.pop_type = 8
     axon.target = synapse
     block1.add_synapse(synapse)

--- a/nengo_loihi/tests/test_conv.py
+++ b/nengo_loihi/tests/test_conv.py
@@ -3,7 +3,7 @@ import pickle
 
 import nengo
 from nengo.dists import Uniform
-from nengo.exceptions import BuildError, ValidationError
+from nengo.exceptions import ValidationError
 from nengo_extras.matplotlib import tile, imshow
 from nengo_extras.vision import Gabor
 import numpy as np

--- a/nengo_loihi/tests/test_validate.py
+++ b/nengo_loihi/tests/test_validate.py
@@ -32,7 +32,7 @@ def test_validate_block():
     # too many synapse bits
     block = LoihiBlock(600)
     synapse = Synapse(500)
-    synapse.set_full_weights(np.ones((500, 600)))
+    synapse.set_weights(np.ones((500, 600)))
     axon = Axon(500)
     axon.target = synapse
     block.add_synapse(synapse)

--- a/setup.cfg
+++ b/setup.cfg
@@ -398,7 +398,6 @@ disable =
     superfluous-parens,
     undefined-loop-variable,
     unnecessary-pass,
-    unused-import,
     unused-variable,
     wrong-import-position,
 known-third-party =

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def read(*filenames, **kwargs):
 root = os.path.dirname(os.path.realpath(__file__))
 version = runpy.run_path(os.path.join(root, "nengo_loihi", "version.py"))["version"]
 
-install_req = ["jinja2", "nengo>=2.8.0"]
+install_req = ["jinja2", "nengo>=2.8.0", "scipy>=1.2.1"]
 docs_req = [
     "abr_control",
     "jupyter",
@@ -50,7 +50,6 @@ tests_req = [
     "pytest-cov>=2.6.0",
     "pytest-xdist>=1.26.0,<1.28.0",
     "matplotlib>=2.0",
-    "scipy",
     "tensorflow<1.14",
 ]
 


### PR DESCRIPTION
Support `Sparse` transforms for on-chip connections.

Also uses sparse matrices when possible for node->neuron and neuron->neuron connections that have a scalar or diagonal transform.