### PR TITLE
Fix bug with no inputs to a neuron

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,12 @@ Release history
 - Fixed an issue that prevented population spikes to be sent to the chip when
   ``precompute=True``. (`#261 <https://github.com/nengo/nengo-loihi/pull/261>`__)
 
+**Fixed**
+
+- Fixed a bug preventing making sparse connections to an ensemble.
+  (`#245 <https://github.com/nengo/nengo-loihi/issues/245>`__,
+  `#246 <https://github.com/nengo/nengo-loihi/pull/246>`__)
+
 0.10.0 (November 25, 2019)
 ==========================
 

--- a/nengo_loihi/block.py
+++ b/nengo_loihi/block.py
@@ -302,23 +302,23 @@ class Axon:
 
         Parameters
         ----------
-        axon_id : int
+        axon_idx : int
             The index of the axon within the targeted Synapse object.
         atom : int, optional (Default: 0)
             An index into the target Synapse weights. This allows spikes
             targeting a particular axon to use different weights.
         """
 
-        __slots__ = ["axon_id", "atom"]
+        __slots__ = ["axon_idx", "atom"]
 
-        def __init__(self, axon_id, atom=0):
-            self.axon_id = axon_id
+        def __init__(self, axon_idx, atom=0):
+            self.axon_idx = axon_idx
             self.atom = atom
 
         def __repr__(self):
-            return "%s(axon_id=%d, atom=%d)" % (
+            return "%s(axon_idx=%d, atom=%d)" % (
                 type(self).__name__,
-                self.axon_id,
+                self.axon_idx,
                 self.atom,
             )
 

--- a/nengo_loihi/block.py
+++ b/nengo_loihi/block.py
@@ -653,7 +653,7 @@ class Synapse:
 
         Does not include ``axon_compartment_base``.
         """
-        return max(i.max() if len(i) > 0 else -1 for i in self.indices)
+        return max(i.max() if i.size > 0 else -1 for i in self.indices)
 
     def _set_weights_indices(self, weights, indices=None):
         weights = [np.array(w, copy=False, dtype=np.float32, ndmin=2) for w in weights]

--- a/nengo_loihi/emulator/interface.py
+++ b/nengo_loihi/emulator/interface.py
@@ -506,12 +506,12 @@ class SynapseState(IterableState):
             qb = input[:, s_slice]
 
             for spike in self.spikes_in[synapse]:
-                base = synapse.axon_compartment_base(spike.axon_id)
+                base = synapse.axon_compartment_base(spike.axon_idx)
                 if base is None:
                     continue
 
                 weights, indices = synapse.axon_weights_indices(
-                    spike.axon_id, atom=spike.atom
+                    spike.axon_idx, atom=spike.atom
                 )
                 qb[0, base + indices] += weights
 
@@ -539,9 +539,9 @@ class SynapseState(IterableState):
             trace_spikes = self.trace_spikes.get(synapse, None)
             if trace_spikes is not None:
                 for spike in self.spikes_in[synapse]:
-                    if spike.axon_id in trace_spikes:
+                    if spike.axon_idx in trace_spikes:
                         self.error("Synaptic trace spikes lost")
-                    trace_spikes.add(spike.axon_id)
+                    trace_spikes.add(spike.axon_idx)
 
             trace = self.traces.get(synapse, None)
             if trace is not None and t % synapse.train_epoch == 0:

--- a/nengo_loihi/hardware/builder.py
+++ b/nengo_loihi/hardware/builder.py
@@ -404,9 +404,9 @@ def build_synapse(nxsdk_core, core, block, synapse, compartment_idxs):  # noqa C
     synapse_map = {}  # map weight_idx to (ptr, pop_size, len)
     total_synapse_ptr = int(core.synapse_entries[synapse][0])
     for axon_idx, axon_id in enumerate(axon_ids):
-        assert axon_id <= 2 ** axon_bits
+        assert axon_id is None or axon_id <= 2 ** axon_bits
 
-        weight_idx = int(synapse.axon_weight_idx(axon_idx))
+        weight_idx = synapse.axon_weight_idx(axon_idx)
         base = synapse.axon_compartment_base(axon_idx)
 
         if weight_idx not in synapse_map:
@@ -440,17 +440,12 @@ def build_synapse(nxsdk_core, core, block, synapse, compartment_idxs):  # noqa C
         synapse_ptr, n_atoms, n_compartments = synapse_map[weight_idx]
         assert n_atoms <= 2 ** atom_bits
 
-        if base is None:
-            # This is a dummy axon with no weights. We set `n_compartments = 0`,
-            # but with population axons it appears the axon can still have an effect.
-            # So we also make sure not to connect into it with incoming axons. However,
-            # we still build the axon here so that our indexing is not thrown off.
-            synapse_ptr = 0
-            n_compartments = 0
-            base = 0
-        else:
-            base = int(base)
+        if axon_id is None:
+            # This is a dummy axon with no base or no weights, so skip it
+            assert base is None or n_compartments == 0
+            continue
 
+        base = int(base)
         assert base <= d(b"MjU2", int), "Currently limited by hardware"
         d_set(
             d_get(nxsdk_core, b"c3luYXBzZU1hcA==")[axon_id],
@@ -531,7 +526,7 @@ def build_synapse(nxsdk_core, core, block, synapse, compartment_idxs):  # noqa C
 
 def build_axons(nxsdk_core, core, block, axon, compartment_ids, pop_id_map):
     synapse = axon.target
-    tchip_idx, tcore_idx, tsyn_idxs = core.board.find_synapse(synapse)
+    tchip_idx, tcore_idx, taxon_ids = core.board.find_synapse(synapse)
     nxsdk_board = d_get(nxsdk_core, b"cGFyZW50", b"cGFyZW50")
     tchip_id = d_get(d_get(nxsdk_board, b"bjJDaGlwcw==")[tchip_idx], b"aWQ=")
     tcore_id = d_get(
@@ -548,11 +543,12 @@ def build_axons(nxsdk_core, core, block, axon, compartment_ids, pop_id_map):
         if spike is None:
             continue  # this compartment does not route through these axons
 
-        taxon_idx = int(spike.axon_id)
-        taxon_id = int(tsyn_idxs[taxon_idx])
+        taxon_idx = spike.axon_idx
+        taxon_id = taxon_ids[taxon_idx]
         atom = int(spike.atom)
         n_atoms = synapse.axon_populations(taxon_idx)
-        if synapse.axon_compartment_base(taxon_idx) is None:
+
+        if taxon_id is None:
             continue  # this connects to a dummy axon, so do not build
 
         if synapse.pop_type == 0:  # discrete

--- a/nengo_loihi/hardware/nxsdk_objects.py
+++ b/nengo_loihi/hardware/nxsdk_objects.py
@@ -103,7 +103,11 @@ class Core:
         self.stdp_pre_cfgs = []
 
         self.synapse_cfg_idxs = {}  # one synfmt per Synapse, for now
+
+        # for each Synapse, provides a map from axon index to axon id
         self.synapse_axons = collections.OrderedDict()
+
+        # for each Synapse, provides the indices occupied in the synapse weight table
         self.synapse_entries = collections.OrderedDict()
 
         self.learning_coreid = None
@@ -169,15 +173,30 @@ class Core:
         synapse_cfg_idx = self.get_synapse_cfg_idx(synapse.synapse_cfg)
         self.synapse_cfg_idxs[synapse] = synapse_cfg_idx
 
-        a0 = 0
+        # determine starting ID for this synapse's axons
+        id0 = 0
         if len(self.synapse_axons) > 0:
             last = next(reversed(self.synapse_axons))
-            a0 = self.synapse_axons[last][-1] + 1
-        idxs_per_synapse = synapse.idxs_per_synapse()
-        idxs = [a0 + idxs_per_synapse * i for i in range(synapse.n_axons)]
-        self.synapse_axons[synapse] = idxs
-        self.board.index_synapse(synapse, self.chip, self, idxs)
+            id0 = self.synapse_axons[last][-1] + 1
 
+        # determine the ID for each synapse axon index
+        idxs_per_synapse = synapse.idxs_per_synapse()
+        i = id0
+        ids = []
+        for idx in range(synapse.n_axons):
+            base = synapse.axon_compartment_base(idx)
+            w, _ = synapse.axon_weights_indices(idx)
+            if base is None or w.size == 0:
+                # dummy axon, which we will not build
+                ids.append(None)
+            else:
+                ids.append(i)
+                i += idxs_per_synapse
+
+        self.synapse_axons[synapse] = ids
+        self.board.index_synapse(synapse, self.chip, self, ids)
+
+        # determine the indices in the synapse weight table that this synapse occupies
         s0 = 0
         if len(self.synapse_entries) > 0:
             last = next(reversed(self.synapse_entries))
@@ -294,7 +313,7 @@ class LoihiSpikeInput:
         for axon in spike_input.axons:
             synapse = axon.target
             atom_bits_extra = synapse.atom_bits_extra()
-            tchip_idx, tcore_idx, tsyn_ids = board.find_synapse(synapse)
+            tchip_idx, tcore_idx, taxon_ids = board.find_synapse(synapse)
             tchip = d_get(nxsdk_board, b"bjJDaGlwcw==")[tchip_idx]
             tcore = d_get(tchip, b"bjJDb3Jlcw==")[tcore_idx]
             spikes = axon.map_spikes(input_idxs)
@@ -305,8 +324,8 @@ class LoihiSpikeInput:
                     continue  # pragma: no cover
 
                 self.axon_map.setdefault(input_idx, [])
-                taxon_idx = int(spike.axon_id)
-                if synapse.axon_compartment_base(taxon_idx) is None:
+                taxon_id = taxon_ids[spike.axon_idx]
+                if taxon_id is None:
                     continue  # this goes to a dummy axon, so do not connect
 
                 self.axon_map[input_idx].append(
@@ -316,7 +335,7 @@ class LoihiSpikeInput:
                             axon.pop_type,
                             tchip.id,
                             tcore.id,
-                            int(tsyn_ids[taxon_idx]),
+                            taxon_id,
                             spike.atom,
                             atom_bits_extra,
                         ),

--- a/nengo_loihi/tests/test_block.py
+++ b/nengo_loihi/tests/test_block.py
@@ -43,8 +43,8 @@ def test_strings():
     axon = Axon(2, label="myAxon")
     assert str(axon) == "Axon(myAxon)"
 
-    spike = Axon.Spike(axon_id=7, atom=2)
-    assert str(spike) == "Spike(axon_id=7, atom=2)"
+    spike = Axon.Spike(axon_idx=7, atom=2)
+    assert str(spike) == "Spike(axon_idx=7, atom=2)"
 
 
 # TODO: Only targeting sim due to bug with negative cx_base on Loihi


### PR DESCRIPTION
Some arrays have shape `(1, 0)` which gives them a length of 1, but no size.