### PR TITLE
Add test for input synapses

### DIFF
--- a/nengo_loihi/builder/connection.py
+++ b/nengo_loihi/builder/connection.py
@@ -9,7 +9,6 @@ from nengo.builder.connection import (
     BuiltConnection,
     get_eval_points,
     get_targets,
-    multiply,
 )
 from nengo.connection import LearningRule
 from nengo.ensemble import Neurons
@@ -27,7 +26,7 @@ from nengo_loihi.builder.inputs import (
     HostReceiveNode,
     PESModulatoryTarget,
 )
-from nengo_loihi.compat import conn_solver, nengo_transforms, sample_transform
+from nengo_loihi.compat import conn_solver, multiply, nengo_transforms, sample_transform
 from nengo_loihi.conv import channel_idxs, conv2d_loihi_weights, pixel_idxs
 from nengo_loihi.inputs import LoihiInput
 from nengo_loihi.neurons import loihi_rates

--- a/nengo_loihi/compat.py
+++ b/nengo_loihi/compat.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 
 if LooseVersion(nengo.__version__) > LooseVersion("2.8.0"):  # noqa: C901
     from nengo.builder.network import seed_network
+    from nengo.builder.transforms import multiply
     import nengo.transforms as nengo_transforms
 
     def conn_solver(solver, activities, targets, rng):
@@ -34,6 +35,8 @@ if LooseVersion(nengo.__version__) > LooseVersion("2.8.0"):  # noqa: C901
 
 
 else:
+    from nengo.builder.connection import multiply
+
     nengo_transforms = None
     from nengo.dists import get_samples as _get_samples
 

--- a/nengo_loihi/tests/test_conv.py
+++ b/nengo_loihi/tests/test_conv.py
@@ -705,9 +705,8 @@ def test_conv_split(Simulator, rng, plt, allclose):
     assert allclose(loihi_out, nengo_out, atol=0.15 * out_max, rtol=0.15)
 
 
-@pytest.mark.skipif(nengo_transforms is None, reason="Requires new nengo.transforms")
 def test_conv_preslice(Simulator, plt):
-    from nengo._vendor.npconv2d.conv2d import conv2d
+    conv2d = pytest.importorskip("nengo._vendor.npconv2d.conv2d")
 
     kernel = np.array([[-1, 2, -1], [-1, 2, -1], [-1, 2, -1]], dtype=float)
     kernel /= kernel.max()
@@ -731,7 +730,7 @@ def test_conv_preslice(Simulator, plt):
     neuron_type = nengo.SpikingRectifiedLinear()
 
     y_ref = LoihiSpikingRectifiedLinear().rates(image.ravel(), input_gain, 0)
-    y_ref = conv2d(
+    y_ref = conv2d.conv2d(
         y_ref.reshape((1, 5, 5, 1)), kernel.reshape((3, 3, 1, 1)), pad="VALID"
     )
     y_ref = LoihiSpikingRectifiedLinear().rates(y_ref.ravel(), 1.0, 0.0).reshape((3, 3))
@@ -779,10 +778,9 @@ def test_conv_preslice(Simulator, plt):
     assert np.allclose(y, y_ref, atol=0.02, rtol=0.1)
 
 
-@pytest.mark.skipif(nengo_transforms is None, reason="Requires new nengo.transforms")
 def test_conv_onchip(Simulator, plt):
     """Tests a fully on-chip conv connection. """
-    from nengo._vendor.npconv2d.conv2d import conv2d
+    conv2d = pytest.importorskip("nengo._vendor.npconv2d.conv2d")
 
     kernel = np.array([[-1, 2, -1], [-1, 2, -1], [-1, 2, -1]], dtype=float)
     kernel /= kernel.max()
@@ -805,7 +803,7 @@ def test_conv_onchip(Simulator, plt):
     neuron_type = nengo.SpikingRectifiedLinear()
 
     y_ref = LoihiSpikingRectifiedLinear().rates(image.ravel(), input_scale, 0)
-    y_ref = conv2d(
+    y_ref = conv2d.conv2d(
         y_ref.reshape((1, 5, 5, 1)), kernel.reshape((3, 3, 1, 1)), pad="VALID"
     )
     y_ref = LoihiSpikingRectifiedLinear().rates(y_ref.ravel(), 1.0, 0.0).reshape((3, 3))
@@ -850,10 +848,9 @@ def test_conv_onchip(Simulator, plt):
     assert np.allclose(y, y_ref, atol=0.02, rtol=0.1)
 
 
-@pytest.mark.skipif(nengo_transforms is None, reason="Requires new nengo.transforms")
 def test_conv_overlap_input(Simulator, plt):
     """Tests a fully on-chip conv connection. """
-    from nengo._vendor.npconv2d.conv2d import conv2d
+    conv2d = pytest.importorskip("nengo._vendor.npconv2d.conv2d")
 
     kernel = np.array([[-1, 2, -1], [-1, 2, -1], [-1, 2, -1]], dtype=float)
     kernel /= kernel.max()
@@ -876,7 +873,7 @@ def test_conv_overlap_input(Simulator, plt):
     neuron_type = nengo.SpikingRectifiedLinear()
 
     y_ref = LoihiSpikingRectifiedLinear().rates(image.ravel(), input_scale, 0)
-    y_ref = conv2d(
+    y_ref = conv2d.conv2d(
         y_ref.reshape((1, 5, 5, 1)), kernel.reshape((3, 3, 1, 1)), pad="VALID"
     )
     y_ref = LoihiSpikingRectifiedLinear().rates(y_ref.ravel(), 1.0, 0.0).reshape((3, 3))

--- a/nengo_loihi/tests/test_examples.py
+++ b/nengo_loihi/tests/test_examples.py
@@ -13,9 +13,9 @@ except ImportError:
 
     def load_notebook(nb_path):
         import io  # pylint: disable=import-outside-toplevel
-        from nengo.utils.ipython import (
+        from nengo.utils.ipython import (  # pylint: disable=import-outside-toplevel
             nbformat,
-        )  # pylint: disable=import-outside-toplevel
+        )
 
         with io.open(nb_path, "r", encoding="utf-8") as f:
             nb = nbformat.read(f, as_version=4)

--- a/nengo_loihi/tests/test_nxsdk_obfuscation.py
+++ b/nengo_loihi/tests/test_nxsdk_obfuscation.py
@@ -36,7 +36,9 @@ def test_d_import():
     imported0 = d_import(
         obfuscate("nengo_loihi.emulator.interface"), attr=obfuscate("EmulatorInterface")
     )
-    from nengo_loihi.emulator.interface import EmulatorInterface as imported1
+    from nengo_loihi.emulator.interface import (  # pylint: disable=import-outside-toplevel
+        EmulatorInterface as imported1,
+    )
 
     assert imported0 is imported1
 


### PR DESCRIPTION
This adds the test described in #63, with some additional filtering (Nengo Loihi drifts a little bit over time) and with an assertion at the end.

It's based on #247, which should be merged first.

As this just adds a test, I don't believe it needs a changelog entry.