### PR TITLE
NxSDK 0.9.0

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -462,7 +462,7 @@ travis_yml:
       env:
         NENGO_VERSION: git+https://github.com/nengo/nengo.git#egg=nengo[tests]
         NENGO_DL_VERSION: git+https://github.com/nengo/nengo-dl.git#egg=nengo-dl
-        NXSDK_VERSION: 0.8.5
+        NXSDK_VERSION: 0.8.7
     - script: docs
       env:
         NENGO_VERSION: git+https://github.com/nengo/nengo.git#egg=nengo[tests]

--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -462,7 +462,7 @@ travis_yml:
       env:
         NENGO_VERSION: git+https://github.com/nengo/nengo.git#egg=nengo[tests]
         NENGO_DL_VERSION: git+https://github.com/nengo/nengo-dl.git#egg=nengo-dl
-        NXSDK_VERSION: 0.8.7
+        NXSDK_VERSION: 0.9
     - script: docs
       env:
         NENGO_VERSION: git+https://github.com/nengo/nengo.git#egg=nengo[tests]

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
     env:
       NENGO_VERSION="git+https://github.com/nengo/nengo.git#egg=nengo[tests]"
       NENGO_DL_VERSION="git+https://github.com/nengo/nengo-dl.git#egg=nengo-dl"
-      NXSDK_VERSION="0.8.5"
+      NXSDK_VERSION="0.8.7"
       SCRIPT="hardware"
     python: 3.5.2
   -

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
     env:
       NENGO_VERSION="git+https://github.com/nengo/nengo.git#egg=nengo[tests]"
       NENGO_DL_VERSION="git+https://github.com/nengo/nengo-dl.git#egg=nengo-dl"
-      NXSDK_VERSION="0.8.7"
+      NXSDK_VERSION="0.9"
       SCRIPT="hardware"
     python: 3.5.2
   -

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@ Release history
 0.10.0 (unreleased)
 ===================
 
+*Compatible with NxSDK 0.8.7 - 0.9.0*
+
 **Changed**
 
 - Nengo Loihi now requires NxSDK version 0.8.7 and supports NxSDK version 0.9.0.
@@ -29,6 +31,8 @@ Release history
 
 0.9.0 (November 20, 2019)
 =========================
+
+*Compatible with NxSDK 0.8.5*
 
 **Added**
 
@@ -62,6 +66,8 @@ Release history
 0.8.0 (June 23, 2019)
 =====================
 
+*Compatible with NxSDK 0.8.5*
+
 **Changed**
 
 - Nengo Loihi now requires NxSDK version 0.8.5.
@@ -69,6 +75,8 @@ Release history
 
 0.7.0 (June 21, 2019)
 =====================
+
+*Compatible with NxSDK 0.8.0 - 0.8.1*
 
 **Added**
 
@@ -122,6 +130,8 @@ Release history
 0.6.0 (February 22, 2019)
 =========================
 
+*Compatible with NxSDK 0.7.0 - 0.8.0*
+
 **Changed**
 
 - New Nengo transforms are supported, including ``nengo.Convolution``. Many of
@@ -160,6 +170,8 @@ Release history
 
 0.5.0 (February 12, 2019)
 =========================
+
+*Compatible with NxSDK 0.7.0 - 0.8.0*
 
 **Added**
 
@@ -222,6 +234,8 @@ Release history
 0.4.0 (December 6, 2018)
 ========================
 
+*Compatible with NxSDK 0.7.0*
+
 **Added**
 
 - Added version tracking to documentation.
@@ -245,6 +259,8 @@ Release history
 
 0.3.0 (September 28, 2018)
 ==========================
+
+*Compatible with NxSDK 0.7.0*
 
 **Added**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ Release history
 
 **Changed**
 
-- Nengo Loihi now requires NxSDK version 0.8.7.
+- Nengo Loihi now requires NxSDK version 0.8.7 and supports NxSDK version 0.9.0.
   (`#255 <https://github.com/nengo/nengo-loihi/pull/255>`__)
 
 0.9.0 (November 20, 2019)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,10 @@ Release history
 0.10.0 (unreleased)
 ===================
 
+**Changed**
 
+- Nengo Loihi now requires NxSDK version 0.8.7.
+  (`#255 <https://github.com/nengo/nengo-loihi/pull/255>`__)
 
 0.9.0 (November 20, 2019)
 =========================

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -72,11 +72,15 @@ for running Loihi models.
       Follow the prompts to set up Miniconda as desired.
 
 2. Create a new ``conda`` environment.
-   Note, you *must* use Python 3.5.2 when working with NxSDK.
+
+   .. warning:: You *must* use Python 3.5.2 when working with NxSDK.
+                Python 3.5.2 is not available in the default
+                ``conda`` channels, so you must pass
+                ``--channel conda-forge`` to the command below.
 
    .. code-block:: bash
 
-      conda create --name loihi python=3.5.2
+      conda create --channel conda-forge --name loihi python=3.5.2
 
 3. Activate your new environment.
 
@@ -105,25 +109,25 @@ for running Loihi models.
    .. note:: The location of NxSDK may have changed.
              Refer to Intel's documentation to be sure.
              The most recent release and NxSDK location
-             are current as of May 2019.
+             are current as of November, 2019.
 
    If you are logged into INRC:
 
    .. code-block:: bash
 
-      cp /nfs/ncl/releases/0.8.1/nxsdk-0.8.1.tar.gz .
+      cp /nfs/ncl/releases/0.9.0/nxsdk-0.9.0.tar.gz .
 
    If you are setting up a non-INRC superhost:
 
    .. code-block:: bash
 
-      scp <inrc-host>:/nfs/ncl/releases/0.8.1/nxsdk-0.8.1.tar.gz .
+      scp <inrc-host>:/nfs/ncl/releases/0.9.0/nxsdk-0.9.0.tar.gz .
 
 6. Install NxSDK.
 
    .. code-block:: bash
 
-      pip install nxsdk-0.8.1.tar.gz
+      pip install nxsdk-0.9.0.tar.gz
 
 7. Install Nengo Loihi.
 

--- a/nengo_loihi/hardware/builder.py
+++ b/nengo_loihi/hardware/builder.py
@@ -50,9 +50,9 @@ def build_board(board, seed=None):
 
 
 def build_chip(nxsdk_chip, chip, seed=None):
-    assert len(chip.cores) == len(d_get(nxsdk_chip, b"bjJDb3Jlcw=="))
+    assert len(chip.cores) == len(d_get(nxsdk_chip, b"bjJDb3Jlc0FzTGlzdA=="))
     rng = np.random.RandomState(seed)
-    for core, nxsdk_core in zip(chip.cores, d_get(nxsdk_chip, b"bjJDb3Jlcw==")):
+    for core, nxsdk_core in zip(chip.cores, d_get(nxsdk_chip, b"bjJDb3Jlc0FzTGlzdA==")):
         logger.debug("Building core %s", core)
         seed = rng.randint(npext.maxint)
         build_core(nxsdk_core, core, seed=seed)
@@ -539,7 +539,7 @@ def build_axons(nxsdk_core, core, block, axon, compartment_ids, pop_id_map):
     nxsdk_board = d_get(nxsdk_core, b"cGFyZW50", b"cGFyZW50")
     tchip_id = d_get(d_get(nxsdk_board, b"bjJDaGlwcw==")[tchip_idx], b"aWQ=")
     tcore_id = d_get(
-        d_get(d_get(nxsdk_board, b"bjJDaGlwcw==")[tchip_idx], b"bjJDb3Jlcw==")[
+        d_get(d_get(nxsdk_board, b"bjJDaGlwcw==")[tchip_idx], b"bjJDb3Jlc0FzTGlzdA==")[
             tcore_idx
         ],
         b"aWQ=",

--- a/nengo_loihi/hardware/interface.py
+++ b/nengo_loihi/hardware/interface.py
@@ -17,7 +17,7 @@ from nengo_loihi.discretize import scale_pes_errors
 from nengo_loihi.hardware.allocators import OneToOne, RoundRobin
 from nengo_loihi.hardware.builder import build_board
 from nengo_loihi.nxsdk_obfuscation import d, d_func, d_get
-from nengo_loihi.hardware.nxsdk_shim import assert_nxsdk, nxsdk, SpikeProbe
+from nengo_loihi.hardware.nxsdk_shim import assert_nxsdk, nxsdk, SnipPhase, SpikeProbe
 from nengo_loihi.hardware.validate import validate_board
 from nengo_loihi.validate import validate_model
 
@@ -90,8 +90,8 @@ class HardwareInterface:
 
         # if installed, check version
         version = LooseVersion(getattr(nxsdk, "__version__", "0.0.0"))
-        minimum = LooseVersion("0.8.5")
-        max_tested = LooseVersion("0.8.5")
+        minimum = LooseVersion("0.8.7")
+        max_tested = LooseVersion("0.8.7")
         if version < minimum:
             raise ImportError(
                 "nengo-loihi requires nxsdk>=%s, found %s" % (minimum, version)
@@ -459,14 +459,14 @@ class HardwareInterface:
         logger.debug("Creating nengo_io snip process")
         nengo_io = d_func(
             self.nxsdk_board,
-            b"Y3JlYXRlUHJvY2Vzcw==",
+            b"Y3JlYXRlU25pcA==",
             kwargs={
                 b"bmFtZQ==": "nengo_io",
                 b"Y0ZpbGVQYXRo": c_path,
                 b"aW5jbHVkZURpcg==": snips_dir,
                 b"ZnVuY05hbWU=": "nengo_io",
                 b"Z3VhcmROYW1l": "guard_io",
-                b"cGhhc2U=": d(b"bWdtdA=="),
+                b"cGhhc2U=": d_get(SnipPhase, b"RU1CRURERURfTUdNVA=="),
             },
         )
         logger.debug("Creating nengo_learn snip process")
@@ -474,14 +474,14 @@ class HardwareInterface:
         shutil.copyfile(os.path.join(snips_dir, "nengo_learn.c"), c_path)
         d_func(
             self.nxsdk_board,
-            b"Y3JlYXRlUHJvY2Vzcw==",
+            b"Y3JlYXRlU25pcA==",
             kwargs={
                 b"bmFtZQ==": "nengo_learn",
                 b"Y0ZpbGVQYXRo": os.path.join(snips_dir, "nengo_learn.c"),
                 b"aW5jbHVkZURpcg==": snips_dir,
                 b"ZnVuY05hbWU=": "nengo_learn",
                 b"Z3VhcmROYW1l": "guard_learn",
-                b"cGhhc2U=": d(b"cHJlTGVhcm5NZ210"),
+                b"cGhhc2U=": d_get(SnipPhase, b"RU1CRURERURfUFJFTEVBUk5fTUdNVA=="),
             },
         )
 

--- a/nengo_loihi/hardware/nxsdk_shim.py
+++ b/nengo_loihi/hardware/nxsdk_shim.py
@@ -80,9 +80,11 @@ if HAS_NXSDK:
         b"bnhzZGsuZ3JhcGgubnhpbnB1dGdlbi5ueGlucHV0Z2Vu", b"QmFzaWNTcGlrZUdlbmVyYXRvcg=="
     )
     SpikeProbe = d_import(b"bnhzZGsuZ3JhcGgubnhwcm9iZXM=", b"TjJTcGlrZVByb2Jl")
+    SnipPhase = d_import(b"bnhzZGsuZ3JhcGgucHJvY2Vzc2VzLnBoYXNlX2VudW1z", b"UGhhc2U=")
 else:
     micro_gen = None
     TraceConfigGenerator = None
     NxsdkBoard = None
     SpikeGen = None
     SpikeProbe = None
+    SnipPhase = None

--- a/nengo_loihi/hardware/tests/test_interface.py
+++ b/nengo_loihi/hardware/tests/test_interface.py
@@ -27,7 +27,7 @@ def test_error_on_old_version(monkeypatch):
 
 def test_no_warn_on_current_version(monkeypatch):
     mock = MockNxsdk()
-    mock.__version__ = "0.8.7"
+    mock.__version__ = str(hardware_interface.HardwareInterface.max_nxsdk_version)
 
     monkeypatch.setattr(hardware_interface, "nxsdk", mock)
     monkeypatch.setattr(hardware_interface, "assert_nxsdk", lambda: True)

--- a/nengo_loihi/hardware/tests/test_interface.py
+++ b/nengo_loihi/hardware/tests/test_interface.py
@@ -27,7 +27,7 @@ def test_error_on_old_version(monkeypatch):
 
 def test_no_warn_on_current_version(monkeypatch):
     mock = MockNxsdk()
-    mock.__version__ = "0.8.5"
+    mock.__version__ = "0.8.7"
 
     monkeypatch.setattr(hardware_interface, "nxsdk", mock)
     monkeypatch.setattr(hardware_interface, "assert_nxsdk", lambda: True)


### PR DESCRIPTION
Support NxSDK 0.9.0. No changes are actually required, but we now do not warn for and test against 0.9.0.

I also updated `HardwareInterface` to store the min and max NxSDK versions on the class, so these can be checked. We now no longer have to remember to update the test in `hardware/tests/test_interface.py` each time we change the NxSDK version.

Depends on #234.