### PR TITLE
Dummy axons work properly on chip

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,10 @@ Release history
 - Added a ``timers`` attribute to ``Simulator`` that tracks the wall time
   taken by various parts of the model, including build time and run time.
   (`#260 <https://github.com/nengo/nengo-loihi/pull/260>`__)
+- Added the ``pop_type`` configuration option to the ``Connection`` config.
+  See `nengo_loihi.add_params
+  <https://www.nengo.ai/nengo-loihi/api.html#nengo_loihi.add_params>`__
+  for details. (`#261 <https://github.com/nengo/nengo-loihi/pull/261>`__)
 
 **Changed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,8 @@ Release history
 - Fixed an issue in which ignored axons were still having an effect in
   convolutional networks where not all input pixels are used in the output.
   (`#261 <https://github.com/nengo/nengo-loihi/pull/261>`__)
+- Fixed an issue that prevented population spikes to be sent to the chip when
+  ``precompute=True``. (`#261 <https://github.com/nengo/nengo-loihi/pull/261>`__)
 
 0.10.0 (November 25, 2019)
 ==========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,9 @@ Release history
 
 - We no longer create a spike generator if we are communicating through Snips.
   (`#260 <https://github.com/nengo/nengo-loihi/pull/260>`__)
+- Fixed an issue in which ignored axons were still having an effect in
+  convolutional networks where not all input pixels are used in the output.
+  (`#261 <https://github.com/nengo/nengo-loihi/pull/261>`__)
 
 0.10.0 (November 25, 2019)
 ==========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,9 @@ Release history
   (`#261 <https://github.com/nengo/nengo-loihi/pull/261>`__)
 - Fixed an issue that prevented population spikes to be sent to the chip when
   ``precompute=True``. (`#261 <https://github.com/nengo/nengo-loihi/pull/261>`__)
+- Fixed a bug preventing making sparse connections to an ensemble.
+  (`#245 <https://github.com/nengo/nengo-loihi/issues/245>`__,
+  `#246 <https://github.com/nengo/nengo-loihi/pull/246>`__)
 
 0.10.0 (November 25, 2019)
 ==========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,9 @@ Release history
 - Added the ``add_to_container`` argument to ``DecodeNeurons.get_ensemble``,
   which makes it easier to add a decode neurons ensemble to a network.
   (`#260 <https://github.com/nengo/nengo-loihi/pull/260>`__)
+- ``Convolution`` transforms with ``channels_last=True`` now work with outputs
+  up to 1024 neurons.
+  (`#261 <https://github.com/nengo/nengo-loihi/pull/261>`__)
 
 **Fixed**
 

--- a/nengo_loihi/block.py
+++ b/nengo_loihi/block.py
@@ -302,23 +302,23 @@ class Axon:
 
         Parameters
         ----------
-        axon_id : int
+        axon_idx : int
             The index of the axon within the targeted Synapse object.
         atom : int, optional (Default: 0)
             An index into the target Synapse weights. This allows spikes
             targeting a particular axon to use different weights.
         """
 
-        __slots__ = ["axon_id", "atom"]
+        __slots__ = ["axon_idx", "atom"]
 
-        def __init__(self, axon_id, atom=0):
-            self.axon_id = axon_id
+        def __init__(self, axon_idx, atom=0):
+            self.axon_idx = axon_idx
             self.atom = atom
 
         def __repr__(self):
-            return "%s(axon_id=%d, atom=%d)" % (
+            return "%s(axon_idx=%d, atom=%d)" % (
                 type(self).__name__,
-                self.axon_id,
+                self.axon_idx,
                 self.atom,
             )
 

--- a/nengo_loihi/block.py
+++ b/nengo_loihi/block.py
@@ -653,7 +653,7 @@ class Synapse:
 
         Does not include ``axon_compartment_base``.
         """
-        return max(i.max() if len(i) > 0 else -1 for i in self.indices)
+        return max(i.max() if i.size > 0 else -1 for i in self.indices)
 
     def _set_weights_indices(self, weights, indices=None):
         weights = [np.array(w, copy=False, dtype=np.float32, ndmin=2) for w in weights]

--- a/nengo_loihi/builder/connection.py
+++ b/nengo_loihi/builder/connection.py
@@ -768,11 +768,11 @@ def build_conv2d_connection(model, conn):
     assert isinstance(conn.pre_obj, (Neurons, ChipReceiveNeurons))
     assert isinstance(conn.transform, nengo_transforms.Convolution)
 
-    weights = conn.transform.sample(rng=rng)
+    kernel = conn.transform.sample(rng=rng)
     input_shape = conn.transform.input_shape
 
     # Account for nengo spike height of 1/dt
-    weights = weights / model.dt
+    kernel = kernel / model.dt
 
     if isinstance(conn.pre_obj, ChipReceiveNeurons):
         neuron_type = conn.pre_obj.neuron_type
@@ -780,7 +780,7 @@ def build_conv2d_connection(model, conn):
         neuron_type = conn.pre_obj.ensemble.neuron_type
 
     if neuron_type is not None and hasattr(neuron_type, "amplitude"):
-        weights = weights * neuron_type.amplitude
+        kernel = kernel * neuron_type.amplitude
 
     # --- post
     assert isinstance(conn.post_obj, Neurons)
@@ -788,7 +788,7 @@ def build_conv2d_connection(model, conn):
 
     gain = model.params[conn.post_obj.ensemble].gain
     if not np.all(gain == gain[0]):
-        # Cannot fold gains into weights, result would not be convolutional.
+        # Cannot fold gains into kernel, result would not be convolutional.
         # Therefore, Loihi does not support this if we want to share weights.
         raise ValidationError(
             "All neurons targeted by a Convolution connection must "
@@ -796,11 +796,11 @@ def build_conv2d_connection(model, conn):
             "gain",
             obj=conn.post_obj.ensemble,
         )
-    weights = weights * gain[0]
+    kernel = kernel * gain[0]
 
     pop_type = model.config[conn].pop_type
     new_transform = copy.copy(conn.transform)
-    type(new_transform).init.data[new_transform] = weights
+    type(new_transform).init.data[new_transform] = kernel
     weights, indices, axon_to_weight_map, offsets = conv2d_loihi_weights(new_transform)
 
     synapse = Synapse(np.prod(input_shape.spatial_shape), label="conv2d_weights")
@@ -823,5 +823,5 @@ def build_conv2d_connection(model, conn):
     post_obj.compartment.configure_filter(tau_s, dt=model.dt)
 
     model.params[conn] = BuiltConnection(
-        eval_points=None, solver_info=None, transform=None, weights=weights
+        eval_points=None, solver_info=None, transform=None, weights=kernel
     )

--- a/nengo_loihi/config.py
+++ b/nengo_loihi/config.py
@@ -11,6 +11,10 @@ def add_params(network):
       * ``on_chip``: Whether the ensemble should be simulated
         on a Loihi chip. Marking specific ensembles for simulation
         off of a Loihi chip can help with debugging.
+    `nengo.Connection`
+      * ``pop_type``: The axon format when using population spikes, which are only
+        used for convolutional connections. Must be an int between 16 and 32.
+        By default, we use ``pop_type`` 32.
 
     Examples
     --------
@@ -28,6 +32,10 @@ def add_params(network):
     ens_cfg = config[nengo.Ensemble]
     if "on_chip" not in ens_cfg._extra_params:
         ens_cfg.set_param("on_chip", Parameter("on_chip", default=None, optional=True))
+
+    conn_cfg = config[nengo.Connection]
+    if "pop_type" not in conn_cfg._extra_params:
+        conn_cfg.set_param("pop_type", Parameter("pop_type", default=32, optional=True))
 
 
 def set_defaults():

--- a/nengo_loihi/emulator/interface.py
+++ b/nengo_loihi/emulator/interface.py
@@ -506,12 +506,12 @@ class SynapseState(IterableState):
             qb = input[:, s_slice]
 
             for spike in self.spikes_in[synapse]:
-                base = synapse.axon_compartment_base(spike.axon_id)
+                base = synapse.axon_compartment_base(spike.axon_idx)
                 if base is None:
                     continue
 
                 weights, indices = synapse.axon_weights_indices(
-                    spike.axon_id, atom=spike.atom
+                    spike.axon_idx, atom=spike.atom
                 )
                 qb[0, base + indices] += weights
 
@@ -539,9 +539,9 @@ class SynapseState(IterableState):
             trace_spikes = self.trace_spikes.get(synapse, None)
             if trace_spikes is not None:
                 for spike in self.spikes_in[synapse]:
-                    if spike.axon_id in trace_spikes:
+                    if spike.axon_idx in trace_spikes:
                         self.error("Synaptic trace spikes lost")
-                    trace_spikes.add(spike.axon_id)
+                    trace_spikes.add(spike.axon_idx)
 
             trace = self.traces.get(synapse, None)
             if trace is not None and t % synapse.train_epoch == 0:

--- a/nengo_loihi/hardware/builder.py
+++ b/nengo_loihi/hardware/builder.py
@@ -379,26 +379,15 @@ def build_input(nxsdk_core, core, spike_input, compartment_idxs):
     nxsdk_board.spike_inputs[spike_input] = loihi_input
 
     # add any pre-existing spikes to spikegen
+    nxsdk_spike_generator = nxsdk_board.global_spike_generator
     for t in spike_input.spike_times():
         assert (
-            nxsdk_board.global_spike_generator is not None
+            nxsdk_spike_generator is not None
         ), "Cannot add pre-existing spikes when using Snips (no spike generator)"
 
         spikes = spike_input.spike_idxs(t)
-        for spike in loihi_input.spikes_to_loihi(spikes):
-            assert (
-                spike["atom"] == 0
-            ), "Cannot send population spikes through spike generator"
-            d_func(
-                nxsdk_board.global_spike_generator,
-                b"YWRkU3Bpa2U=",
-                kwargs={
-                    b"dGltZQ==": t,
-                    b"Y2hpcElk": spike["chip_id"],
-                    b"Y29yZUlk": spike["core_id"],
-                    b"YXhvbklk": spike["axon_id"],
-                },
-            )
+        loihi_spikes = loihi_input.spikes_to_loihi(spikes)
+        loihi_input.add_spikes_to_generator(t, loihi_spikes, nxsdk_spike_generator)
 
 
 def build_synapse(nxsdk_core, core, block, synapse, compartment_idxs):  # noqa C901

--- a/nengo_loihi/hardware/nxsdk_objects.py
+++ b/nengo_loihi/hardware/nxsdk_objects.py
@@ -245,6 +245,8 @@ class LoihiSpikeInput:
     atom : np.int32
         The population index (atom), used if this axon sends population spikes
         (i.e. axon_type != 0).
+    atom_bits_extra : np.int32
+        The number of extra bits used for the atom (pop16 axons only).
     """
 
     spike_dtype = np.dtype(
@@ -255,8 +257,40 @@ class LoihiSpikeInput:
             ("core_id", np.int32),
             ("axon_id", np.int32),
             ("atom", np.int32),
+            ("atom_bits_extra", np.int32),
         ]
     )
+
+    @classmethod
+    def add_spikes_to_generator(cls, t, spikes, basic_spike_generator):
+        methods = {
+            0: getattr(basic_spike_generator, d(b"YWRkU3Bpa2U=")),
+            16: getattr(basic_spike_generator, d(b"YWRkUG9wMTZTcGlrZQ==")),
+            32: getattr(basic_spike_generator, d(b"YWRkUG9wMzJTcGlrZQ==")),
+        }
+        time = d(b"dGltZQ==")
+        chip_id = d(b"Y2hpcElk")
+        core_id = d(b"Y29yZUlk")
+        axon_id = d(b"YXhvbklk")
+        atom = d(b"c3JjQXRvbQ==")
+        atom_bits_extra = d(b"YXRvbUJpdHM=")
+
+        for spike in spikes:
+            axon_type = int(spike["axon_type"])
+            kwargs = {
+                time: t,
+                chip_id: spike["chip_id"],
+                core_id: spike["core_id"],
+                axon_id: spike["axon_id"],
+            }
+            if axon_type == 0:
+                assert spike["atom"] == 0, "Atom must be zero for discrete spikes"
+            else:
+                kwargs[atom] = spike["atom"]
+                if axon_type == 16:
+                    kwargs[atom_bits_extra] = spike["atom_bits_extra"]
+
+            methods[axon_type](**kwargs)
 
     def __init__(self):
         self.axon_map = {}  # maps spike_input idx to axon in self.axons
@@ -277,9 +311,8 @@ class LoihiSpikeInput:
         assert len(self.axon_map) == 0
         input_idxs = np.arange(spike_input.n_neurons)
         for axon in spike_input.axons:
-            axon_type = axon.pop_type
-            assert axon_type in (0, 32), "Only discrete and pop32 supported"
             synapse = axon.target
+            atom_bits_extra = synapse.atom_bits_extra()
             tchip_idx, tcore_idx, taxon_ids = board.find_synapse(synapse)
             tchip = d_get(nxsdk_board, b"bjJDaGlwcw==")[tchip_idx]
             tcore = d_get(tchip, b"bjJDb3Jlcw==")[tcore_idx]
@@ -297,7 +330,15 @@ class LoihiSpikeInput:
 
                 self.axon_map[input_idx].append(
                     np.array(
-                        (-1, axon_type, tchip.id, tcore.id, taxon_id, spike.atom),
+                        (
+                            -1,
+                            axon.pop_type,
+                            tchip.id,
+                            tcore.id,
+                            taxon_id,
+                            spike.atom,
+                            atom_bits_extra,
+                        ),
                         dtype=self.spike_dtype,
                     )
                 )

--- a/nengo_loihi/hardware/snips/nengo_io.c.template
+++ b/nengo_loihi/hardware/snips/nengo_io.c.template
@@ -33,16 +33,18 @@ void nengo_io(runState *s) {
 {% for core in cores %}
     {{ obfs.core_class }} *core{{ core }} = NEURON_PTR((CoreId){.id = {{ core }}});
 {% endfor %}
-    {{ obfs.id_class }} core_id;
+
     int in_channel = {{ obfs.get_channel }}("nengo_io_h2c");
     int out_channel = {{ obfs.get_channel }}("nengo_io_c2h");
 
-    {{ obfs.int_type }} axon_type;
-    {{ obfs.int_type }} axon_id;
-    {{ obfs.int_type }} atom;
     {{ obfs.int_type }} n_spikes; // input spike count
     {{ obfs.int_type }} i_spike;  // input spike position
     {{ obfs.int_type }} *spike;
+    {{ obfs.id_class }} core_id;
+    {{ obfs.int_type }} axon_type;
+    {{ obfs.int_type }} axon_id;
+    {{ obfs.int_type }} atom;
+    {{ obfs.int_type }} atom_bits;
 
     {{ obfs.int_type }} error_index;   // index into error stored in shared data
     {{ obfs.int_type }} i_error = 0;   // index of error block
@@ -115,10 +117,13 @@ void nengo_io(runState *s) {
         printf("send spike core=%d, axon=%d, type=%d atom=%d\n", core_id.id,
                axon_id, axon_type, atom);
 #endif
-        if (axon_type == {{ obfs.axon_type_0 }}) {
+        if (axon_type == 0) {
             {{ obfs.do_axon_type_0 }}(s->{{ obfs.step }}, core_id, axon_id);
-        } else if (axon_type == {{ obfs.axon_type_1 }}) {
-            {{ obfs.do_axon_type_1 }}(s->{{ obfs.step }}, core_id, axon_id, atom, 0, 0, 0);
+        } else if (axon_type == 32) {
+            {{ obfs.do_axon_type_32 }}(s->{{ obfs.step }}, core_id, axon_id, atom, 0, 0, 0);
+        } else if (axon_type >= 16) {
+            atom_bits = axon_type - 16;
+            {{ obfs.do_axon_type_16 }}(s->{{ obfs.step }}, core_id, axon_id, atom, atom_bits);
         } else {
             printf("Got invalid axon_type: %d\n", axon_type);
             return;

--- a/nengo_loihi/splitter.py
+++ b/nengo_loihi/splitter.py
@@ -4,7 +4,6 @@ from nengo import Direct, Ensemble, Node, Probe
 from nengo.exceptions import BuildError
 from nengo.connection import LearningRule
 
-from nengo_loihi.compat import nengo_transforms
 from nengo_loihi.config import add_params
 from nengo_loihi.passthrough import base_obj, PassthroughSplit
 
@@ -46,29 +45,13 @@ class PrecomputableSplit:
         # Also see issue #214.
         has_learning = any(conn.learning_rule is not None for conn in self._conns)
 
-        # host->chip convolutional connections are also not supported with
-        # precompute=True because the BasicSpikeGenerator cannot send population
-        # spikes correctly, meaning we have to use Snips.
-        has_convolution = False
-        if nengo_transforms is not None:
-            has_convolution = any(
-                isinstance(conn.transform, nengo_transforms.Convolution)
-                and not self.hostchip.on_chip(base_obj(conn.pre))
-                and self.hostchip.on_chip(base_obj(conn.post))
-                for conn in self._conns
-            )
-
-        if not has_learning and not has_convolution:
+        if not has_learning:
             self._find_precomputable_objs()
         else:
             self._precomputable = False
             if strict and has_learning:
                 raise BuildError(
                     "precompute=True not supported when using learning rules"
-                )
-            elif strict and has_convolution:
-                raise BuildError(
-                    "precompute=True not supported when using convolutional connections"
                 )
 
         if strict and not self._precomputable:

--- a/nengo_loihi/tests/test_block.py
+++ b/nengo_loihi/tests/test_block.py
@@ -43,8 +43,8 @@ def test_strings():
     axon = Axon(2, label="myAxon")
     assert str(axon) == "Axon(myAxon)"
 
-    spike = Axon.Spike(axon_id=7, atom=2)
-    assert str(spike) == "Spike(axon_id=7, atom=2)"
+    spike = Axon.Spike(axon_idx=7, atom=2)
+    assert str(spike) == "Spike(axon_idx=7, atom=2)"
 
 
 # TODO: Only targeting sim due to bug with negative cx_base on Loihi

--- a/nengo_loihi/tests/test_conv.py
+++ b/nengo_loihi/tests/test_conv.py
@@ -703,7 +703,8 @@ def test_conv_split(Simulator, rng, plt, allclose):
     assert allclose(loihi_out, nengo_out, atol=0.15 * out_max, rtol=0.15)
 
 
-def test_conv_preslice(Simulator, plt):
+@pytest.mark.parametrize("on_chip", [True, False])
+def test_conv_preslice(on_chip, Simulator, plt):
     conv2d = pytest.importorskip("nengo._vendor.npconv2d.conv2d")
 
     kernel = np.array([[-1, 2, -1], [-1, 2, -1], [-1, 2, -1]], dtype=float)
@@ -726,14 +727,18 @@ def test_conv_preslice(Simulator, plt):
     input_gain = 149.0
 
     neuron_type = nengo.SpikingRectifiedLinear()
+    loihi_neuron = LoihiSpikingRectifiedLinear()
+    layer0_neuron = loihi_neuron if on_chip else neuron_type
 
-    y_ref = LoihiSpikingRectifiedLinear().rates(image.ravel(), input_gain, 0)
+    y_ref = layer0_neuron.rates(image.ravel(), input_gain, 0)
     y_ref = conv2d.conv2d(
         y_ref.reshape((1, 5, 5, 1)), kernel.reshape((3, 3, 1, 1)), pad="VALID"
     )
-    y_ref = LoihiSpikingRectifiedLinear().rates(y_ref.ravel(), 1.0, 0.0).reshape((3, 3))
+    y_ref = loihi_neuron.rates(y_ref.ravel(), 1.0, 0.0).reshape((3, 3))
 
     with nengo.Network() as net:
+        nengo_loihi.add_params(net)
+
         u = nengo.Node(image2.ravel())
         a = nengo.Ensemble(
             50,
@@ -742,6 +747,7 @@ def test_conv_preslice(Simulator, plt):
             gain=nengo.dists.Choice([input_gain]),
             bias=nengo.dists.Choice([0]),
         )
+        net.config[a].on_chip = on_chip
 
         transform = nengo_transforms.Convolution(
             n_filters=1, input_shape=(5, 5, 1), init=kernel.reshape((3, 3, 1, 1))
@@ -928,6 +934,72 @@ def test_conv_overlap_input(Simulator, plt):
 
     assert np.allclose(y0, y_ref[:2], atol=0.02, rtol=0.1)
     assert np.allclose(y1, y_ref[1:], atol=0.02, rtol=0.1)
+
+
+@pytest.mark.target_loihi
+@pytest.mark.parametrize("precompute", [False])
+def test_population_dummy_axons(precompute, Simulator, rng):
+    """On the chip, dummy axons were still having an effect. Check this is fixed."""
+
+    # 6 x 6 input will have one extra pixel at edge with 3 x 3 kernel and stride 2
+    input_shape = nengo_transforms.ChannelShape((1, 6, 6), channels_last=False)
+
+    def conv_layer(x, *args, activation=True, label=None, **kwargs):
+        conv = nengo.Convolution(*args, **kwargs, channels_last=False)
+        layer = nengo.Ensemble(conv.output_shape.size, 1, label=label)
+        nengo.Connection(x, layer.neurons, transform=conv)
+        return layer, conv
+
+    max_rate = 100
+    amp = 1 / max_rate
+
+    n_filters = 4
+    X = rng.uniform(0.2, 1, size=input_shape.shape)
+    kernel = rng.uniform(0.2, 1, size=(3, 3, 1, n_filters))
+
+    with nengo.Network(seed=0) as net:
+        nengo_loihi.add_params(net)
+        net.config[nengo.Ensemble].neuron_type = nengo.SpikingRectifiedLinear(
+            amplitude=amp
+        )
+        net.config[nengo.Ensemble].max_rates = nengo.dists.Choice([max_rate])
+        net.config[nengo.Ensemble].intercepts = nengo.dists.Choice([0])
+        net.config[nengo.Connection].synapse = 0.005
+
+        inp = nengo.Node(X.ravel())
+
+        # first layer is off-chip to translate the inputs into spikes
+        layer0, conv0 = conv_layer(
+            inp,
+            n_filters=1,
+            input_shape=input_shape,
+            kernel_size=(1, 1),
+            init=np.ones((1, 1, 1, 1)),
+            label="layer0",
+        )
+        net.config[layer0.neurons.ensemble].on_chip = False
+
+        layer1, conv1 = conv_layer(
+            layer0.neurons,
+            n_filters=n_filters,
+            input_shape=conv0.output_shape,
+            kernel_size=(3, 3),
+            strides=(2, 2),
+            init=kernel,
+            label="layer1",
+        )
+
+        probe = nengo.Probe(layer1.neurons)
+
+    sim_time = 0.1
+    with Simulator(net, target="sim") as emulator:
+        emulator.run(sim_time)
+
+    with Simulator(net, target="loihi", precompute=precompute) as loihi:
+        loihi.run(sim_time)
+
+    assert np.all(emulator.data[probe].sum(axis=0) > 0)
+    assert np.array_equal(loihi.data[probe], emulator.data[probe])
 
 
 @pytest.mark.skipif(nengo_transforms is None, reason="Requires new nengo.transforms")

--- a/nengo_loihi/tests/test_conv.py
+++ b/nengo_loihi/tests/test_conv.py
@@ -2,7 +2,7 @@ import os
 import pickle
 
 import nengo
-from nengo.dists import Uniform
+from nengo.dists import Choice, Uniform
 from nengo.exceptions import ValidationError
 from nengo_extras.matplotlib import tile, imshow
 from nengo_extras.vision import Gabor
@@ -573,6 +573,157 @@ def test_conv_input(channels_last, Simulator, plt, allclose):
 
     # loihi spikes are not exactly the same, but should be close-ish
     assert allclose(p0, p1, rtol=0.15, atol=1)
+
+
+@pytest.mark.skipif(nengo_transforms is None, reason="Requires new nengo.transforms")
+@pytest.mark.parametrize("pop_type", [32, 16])
+def test_conv_deepnet(pop_type, Simulator, rng, seed, plt, allclose):
+    def conv_layer(
+        x, input_shape, array_init=None, label=None, conn_args=None, **conv_args
+    ):
+        conn_args = {} if conn_args is None else conn_args
+
+        if array_init is not None:
+            assert all(a not in conv_args for a in ("init", "kernel_size", "n_filters"))
+            assert array_init.ndim == 4
+            conv_args["init"] = array_init
+            conv_args["kernel_size"] = array_init.shape[:2]
+            assert array_init.shape[2] == input_shape.n_channels
+            conv_args["n_filters"] = array_init.shape[3]
+
+        conv = nengo.Convolution(input_shape=input_shape, **conv_args)
+
+        # add an ensemble to implement the activation function
+        layer = nengo.Ensemble(conv.output_shape.size, 1, label=label)
+
+        # connect up the input object to the new layer
+        conn = nengo.Connection(x, layer.neurons, transform=conv)
+
+        return layer, conv, conn
+
+    channels_last = True
+    channels = 1
+    n_filters0 = 1
+    n_filters1 = 4
+    n_filters2 = 4
+    # load data
+    with open(os.path.join(test_dir, "mnist10.pkl"), "rb") as f:
+        test10 = pickle.load(f)
+
+    test_x = test10[0][0].reshape(28, 28)  # range (0, 1)
+    input_shape = nengo_transforms.ChannelShape(
+        (test_x.shape + (channels,)) if channels_last else ((channels,) + test_x.shape),
+        channels_last=channels_last,
+    )
+
+    filters0 = np.ones((1, 1, channels, n_filters0))
+
+    # use Gabor filters for first layer
+    filters1 = Gabor(
+        freq=Uniform(0.5, 1), sigma_x=Choice([0.9]), sigma_y=Choice([0.9])
+    ).generate(n_filters1, (7, 7), rng=rng)
+    assert n_filters0 == 1
+    filters1 = filters1[None, :, :, :]  # single channel
+    filters1 = np.transpose(filters1, (2, 3, 0, 1))  # rows, cols, in_chan, out_chan
+
+    # use random combinations of first-layer channels in 1x1 convolution
+    filters2 = rng.uniform(-0.2, 1, size=(n_filters1, n_filters2)).clip(0, None)
+    filters2 *= 2 / filters2.sum(axis=0, keepdims=True)  # each filter sums to 2
+    filters2 = filters2[None, None, :, :]  # rows, cols, in_chan, out_chan
+
+    tau_s = 0.001
+    max_rate = 100
+    amp = 1 / max_rate
+
+    # use Loihi neuron type so Nengo sim mimics Loihi neuron effects
+    neuron_type = LoihiSpikingRectifiedLinear(amplitude=amp)
+
+    pres_time = 0.2
+
+    with nengo.Network(seed=seed) as net:
+        nengo_loihi.add_params(net)
+
+        net.config[nengo.Ensemble].neuron_type = neuron_type
+        net.config[nengo.Ensemble].max_rates = Choice([max_rate])
+        net.config[nengo.Ensemble].intercepts = Choice([0])
+        net.config[nengo.Connection].synapse = tau_s
+
+        u = nengo.Node(test_x.ravel(), label="u")
+
+        layer0, conv0, conn0 = conv_layer(
+            u,
+            input_shape=input_shape,
+            array_init=filters0,
+            strides=(1, 1),
+            label="layer0",
+            conn_args=dict(synapse=None),
+        )
+        net.config[layer0].on_chip = False
+
+        layer1, conv1, conn1 = conv_layer(
+            layer0.neurons,
+            input_shape=conv0.output_shape,
+            array_init=filters1,
+            strides=(2, 2),
+            label="layer1",
+        )
+        net.config[conn1].pop_type = pop_type
+
+        layer2, conv2, conn2 = conv_layer(
+            layer1.neurons,
+            input_shape=conv1.output_shape,
+            array_init=filters2,
+            strides=(1, 1),
+            label="layer2",
+        )
+        net.config[conn2].pop_type = pop_type
+
+        output_p = nengo.Probe(layer2.neurons)
+        output_shape = conv2.output_shape
+
+    with nengo.Simulator(net, optimize=False) as sim_nengo:
+        sim_nengo.run(pres_time)
+        ref_out = (sim_nengo.data[output_p] > 0).sum(axis=0).reshape(output_shape.shape)
+
+    hw_opts = dict(snip_max_spikes_per_step=800)
+    with Simulator(net, precompute=False, hardware_options=hw_opts) as sim_loihi:
+        block1 = sim_loihi.model.objs[layer1]["out"]
+        n_axons1 = sum(axon.axon_slots() for axon in block1.axons)
+        n_inputs1 = np.prod(conv1.output_shape.spatial_shape)
+        assert n_axons1 == (2 if pop_type == 32 else 1) * n_inputs1
+
+        sim_loihi.run(pres_time)
+        sim_out = (sim_loihi.data[output_p] > 0).sum(axis=0).reshape(output_shape.shape)
+
+    out_max = ref_out.max()
+    ref_out = ref_out / out_max
+    sim_out = sim_out / out_max
+
+    # --- plot results
+    rows = 2
+    cols = 3
+
+    ax = plt.subplot(rows, cols, 1)
+    imshow(test_x, vmin=0, vmax=1, ax=ax)
+
+    ax = plt.subplot(rows, cols, 2)
+    tile(np.transpose(filters1, (2, 3, 0, 1))[0], rows=2, cols=2, grid=True, ax=ax)
+
+    ax = plt.subplot(rows, cols, 3)
+    assert filters2.shape[:2] == (1, 1)
+    filters12 = filters1.dot(filters2[0, 0])
+    tile(np.transpose(filters12, (2, 3, 0, 1))[0], rows=2, cols=2, grid=True, ax=ax)
+
+    ax = plt.subplot(rows, cols, 4)
+    plt.hist((ref_out.ravel(), sim_out.ravel()), bins=21)
+
+    ax = plt.subplot(rows, cols, 5)
+    tile(np.transpose(ref_out, (2, 0, 1)), rows=2, cols=2, grid=True, ax=ax)
+
+    ax = plt.subplot(rows, cols, 6)
+    tile(np.transpose(sim_out, (2, 0, 1)), rows=2, cols=2, grid=True, ax=ax)
+
+    assert allclose(sim_out, ref_out, atol=0.15, rtol=1e-3)
 
 
 @pytest.mark.skipif(nengo_transforms is None, reason="Requires new nengo.transforms")

--- a/nengo_loihi/tests/test_conv.py
+++ b/nengo_loihi/tests/test_conv.py
@@ -577,7 +577,8 @@ def test_conv_input(channels_last, Simulator, plt, allclose):
 
 @pytest.mark.skipif(nengo_transforms is None, reason="Requires new nengo.transforms")
 @pytest.mark.parametrize("pop_type", [32, 16])
-def test_conv_deepnet(pop_type, Simulator, rng, seed, plt, allclose):
+@pytest.mark.parametrize("precompute", [False, True])
+def test_conv_deepnet(pop_type, precompute, Simulator, rng, seed, plt, allclose):
     def conv_layer(
         x, input_shape, array_init=None, label=None, conn_args=None, **conv_args
     ):
@@ -686,7 +687,7 @@ def test_conv_deepnet(pop_type, Simulator, rng, seed, plt, allclose):
         ref_out = (sim_nengo.data[output_p] > 0).sum(axis=0).reshape(output_shape.shape)
 
     hw_opts = dict(snip_max_spikes_per_step=800)
-    with Simulator(net, precompute=False, hardware_options=hw_opts) as sim_loihi:
+    with Simulator(net, precompute=precompute, hardware_options=hw_opts) as sim_loihi:
         block1 = sim_loihi.model.objs[layer1]["out"]
         n_axons1 = sum(axon.axon_slots() for axon in block1.axons)
         n_inputs1 = np.prod(conv1.output_shape.spatial_shape)
@@ -916,8 +917,8 @@ def test_conv_preslice(on_chip, Simulator, plt):
         nengo.Connection(a.neurons[::2], b.neurons, transform=transform)
         bp = nengo.Probe(b.neurons, synapse=nengo.Alpha(0.02))
 
-    hw_opts = dict(snip_max_spikes_per_step=100)
-    with Simulator(net, hardware_options=hw_opts) as sim:
+    with Simulator(net) as sim:
+        assert sim.precompute is True
         sim.run(0.3)
 
     y_ref = y_ref / input_gain
@@ -1088,25 +1089,44 @@ def test_conv_overlap_input(Simulator, plt):
 
 
 @pytest.mark.target_loihi
-@pytest.mark.parametrize("precompute", [False])
-def test_population_dummy_axons(precompute, Simulator, rng):
-    """On the chip, dummy axons were still having an effect. Check this is fixed."""
+@pytest.mark.parametrize("on_chip", [True, False])
+@pytest.mark.parametrize("precompute", [True, False])
+@pytest.mark.parametrize("pop_type", [16, 32])
+@pytest.mark.parametrize("channels_last", [True, False])
+def test_chip_population_axons(
+    on_chip, precompute, pop_type, channels_last, Simulator, rng
+):
+    """Check that all types of population axons work as inputs or between cores.
 
-    # 6 x 6 input will have one extra pixel at edge with 3 x 3 kernel and stride 2
-    input_shape = nengo_transforms.ChannelShape((1, 6, 6), channels_last=False)
+    Also, on the chip, dummy axons were still having an effect. Check this is fixed.
+    """
 
-    def conv_layer(x, *args, activation=True, label=None, **kwargs):
-        conv = nengo.Convolution(*args, **kwargs, channels_last=False)
+    def conv_layer(input=None, label=None, **kwargs):
+        conv = nengo.Convolution(**kwargs)
         layer = nengo.Ensemble(conv.output_shape.size, 1, label=label)
-        nengo.Connection(x, layer.neurons, transform=conv)
-        return layer, conv
+        conn = (
+            nengo.Connection(input, layer.neurons, transform=conv)
+            if input is not None
+            else None
+        )
+        return layer, conv, conn
+
+    if pop_type == 16 and not channels_last:
+        pytest.skip("pop16 axons not compatible with single-compartment shifts")
 
     max_rate = 100
     amp = 1 / max_rate
 
-    n_filters = 4
+    n_filters0 = 4
+    n_filters1 = 4
+    # 6 x 6 input will have one unused pixel at edge with 3 x 3 kernel and stride 2
+    input_shape = (6, 6, 1) if channels_last else (1, 6, 6)
+    input_shape = nengo_transforms.ChannelShape(
+        input_shape, channels_last=channels_last
+    )
     X = rng.uniform(0.2, 1, size=input_shape.shape)
-    kernel = rng.uniform(0.2, 1, size=(3, 3, 1, n_filters))
+    kernel0 = rng.uniform(0.2, 1, size=(1, 1, 1, n_filters0))
+    kernel1 = rng.uniform(0.1, 0.5, size=(3, 3, n_filters0, n_filters1))
 
     with nengo.Network(seed=0) as net:
         nengo_loihi.add_params(net)
@@ -1117,28 +1137,38 @@ def test_population_dummy_axons(precompute, Simulator, rng):
         net.config[nengo.Ensemble].intercepts = nengo.dists.Choice([0])
         net.config[nengo.Connection].synapse = 0.005
 
-        inp = nengo.Node(X.ravel())
+        inp = nengo.Node(X.ravel()) if not on_chip else None
 
         # first layer is off-chip to translate the inputs into spikes
-        layer0, conv0 = conv_layer(
-            inp,
-            n_filters=1,
+        layer0, conv0, _ = conv_layer(
+            input=inp,
+            n_filters=n_filters0,
             input_shape=input_shape,
+            channels_last=channels_last,
             kernel_size=(1, 1),
-            init=np.ones((1, 1, 1, 1)),
+            init=kernel0,
             label="layer0",
         )
-        net.config[layer0.neurons.ensemble].on_chip = False
 
-        layer1, conv1 = conv_layer(
-            layer0.neurons,
-            n_filters=n_filters,
+        net.config[layer0].on_chip = on_chip
+        if on_chip:
+            assert kernel0.shape[:2] == (1, 1)
+            w = kernel0[0, 0]
+            Y = X.dot(w) if channels_last else np.tensordot(w.T, X, axes=1)
+            layer0.gain = nengo.dists.Choice([0.0])
+            layer0.bias = Y.ravel() * max_rate
+
+        layer1, conv1, conn1 = conv_layer(
+            input=layer0.neurons,
+            n_filters=n_filters1,
             input_shape=conv0.output_shape,
+            channels_last=channels_last,
             kernel_size=(3, 3),
             strides=(2, 2),
-            init=kernel,
+            init=kernel1,
             label="layer1",
         )
+        net.config[conn1].pop_type = pop_type
 
         probe = nengo.Probe(layer1.neurons)
 

--- a/nengo_loihi/tests/test_splitter.py
+++ b/nengo_loihi/tests/test_splitter.py
@@ -3,7 +3,6 @@ import nengo
 from nengo.exceptions import BuildError
 import numpy as np
 
-from nengo_loihi.compat import nengo_transforms
 from nengo_loihi.config import add_params
 from nengo_loihi.splitter import Split
 
@@ -123,23 +122,6 @@ def test_precompute_host_to_learning_rule_unsupported():
         nengo.Connection(pre, post, learning_rule_type=nengo.PES())
 
     with pytest.raises(BuildError, match="learning rules"):
-        Split(net, precompute=True)
-
-
-@pytest.mark.skipif(nengo_transforms is None, reason="Requires new nengo.transforms")
-def test_precompute_with_convolution_unsupported():
-    with nengo.Network() as net:
-        stim = nengo.Node([0, 0])
-        ens = nengo.Ensemble(10, 2)
-        nengo.Connection(
-            stim,
-            ens,
-            transform=nengo_transforms.Convolution(
-                n_filters=2, input_shape=(1, 2, 1), kernel_size=(1, 2), strides=(1, 1)
-            ),
-        )
-
-    with pytest.raises(BuildError, match="convolutional connections"):
         Split(net, precompute=True)
 
 

--- a/nengo_loihi/validate.py
+++ b/nengo_loihi/validate.py
@@ -83,7 +83,11 @@ def validate_synapse(synapse):
         )
     if synapse.pop_type == 16:
         if synapse.axon_compartment_bases is not None:
-            assert all(b % d(b"NA==", int) == 0 for b in synapse.axon_compartment_bases)
+            assert all(
+                b % d(b"NA==", int) == 0
+                for b in synapse.axon_compartment_bases
+                if b >= 0
+            )
 
 
 def validate_synapse_cfg(synapse_cfg):


### PR DESCRIPTION
We were having problems with dummy axons still doing something on the chip, even though they shouldn't. This PR fixes that. I added the test in a separate commit first, so that it's easy to confirm the test fails before the fix and passes after it.

The latter two commits improve support for population axons. The first one allows users to make a connection use pop16 axons instead of the default pop32. This uses fewer axon slots, so that connections can have more axons, but adds some constraints to how these axons are used. (In convolutional networks, this functionally amounts to having to use numbers of filters that are a multiple of 4, with `channels_last=True`. This allows the axon compartment offset ("base") to be a multiple of 4, which is the requirement for pop16. We could make copies of the weights in the case that we need offsets that are not multiples of 4, such that we have up to 4 copies each for a different modulo of the offset. See #262.)

The last commit allows population axons to be used on input connections when `precompute=True` (since NxSDK's spike generators now support them).

Based on #260.