### PR TITLE
Refactor block.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,10 @@ Release history
 - Added a ``timers`` attribute to ``Simulator`` that tracks the wall time
   taken by various parts of the model, including build time and run time.
   (`#260 <https://github.com/nengo/nengo-loihi/pull/260>`__)
+- Added the ``pop_type`` configuration option to the ``Connection`` config.
+  See `nengo_loihi.add_params
+  <https://www.nengo.ai/nengo-loihi/api.html#nengo_loihi.add_params>`__
+  for details. (`#261 <https://github.com/nengo/nengo-loihi/pull/261>`__)
 
 **Changed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,8 @@ Release history
 - Fixed an issue in which ignored axons were still having an effect in
   convolutional networks where not all input pixels are used in the output.
   (`#261 <https://github.com/nengo/nengo-loihi/pull/261>`__)
+- Fixed an issue that prevented population spikes to be sent to the chip when
+  ``precompute=True``. (`#261 <https://github.com/nengo/nengo-loihi/pull/261>`__)
 
 0.10.0 (November 25, 2019)
 ==========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,9 @@ Release history
 
 - We no longer create a spike generator if we are communicating through Snips.
   (`#260 <https://github.com/nengo/nengo-loihi/pull/260>`__)
+- Fixed an issue in which ignored axons were still having an effect in
+  convolutional networks where not all input pixels are used in the output.
+  (`#261 <https://github.com/nengo/nengo-loihi/pull/261>`__)
 
 0.10.0 (November 25, 2019)
 ==========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,9 @@ Release history
   (`#261 <https://github.com/nengo/nengo-loihi/pull/261>`__)
 - Fixed an issue that prevented population spikes to be sent to the chip when
   ``precompute=True``. (`#261 <https://github.com/nengo/nengo-loihi/pull/261>`__)
+- Fixed a bug preventing making sparse connections to an ensemble.
+  (`#245 <https://github.com/nengo/nengo-loihi/issues/245>`__,
+  `#246 <https://github.com/nengo/nengo-loihi/pull/246>`__)
 
 0.10.0 (November 25, 2019)
 ==========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,9 @@ Release history
 - Added the ``add_to_container`` argument to ``DecodeNeurons.get_ensemble``,
   which makes it easier to add a decode neurons ensemble to a network.
   (`#260 <https://github.com/nengo/nengo-loihi/pull/260>`__)
+- ``Convolution`` transforms with ``channels_last=True`` now work with outputs
+  up to 1024 neurons.
+  (`#261 <https://github.com/nengo/nengo-loihi/pull/261>`__)
 
 **Fixed**
 

--- a/nengo_loihi/block.py
+++ b/nengo_loihi/block.py
@@ -302,23 +302,23 @@ class Axon:
 
         Parameters
         ----------
-        axon_id : int
+        axon_idx : int
             The index of the axon within the targeted Synapse object.
         atom : int, optional (Default: 0)
             An index into the target Synapse weights. This allows spikes
             targeting a particular axon to use different weights.
         """
 
-        __slots__ = ["axon_id", "atom"]
+        __slots__ = ["axon_idx", "atom"]
 
-        def __init__(self, axon_id, atom=0):
-            self.axon_id = axon_id
+        def __init__(self, axon_idx, atom=0):
+            self.axon_idx = axon_idx
             self.atom = atom
 
         def __repr__(self):
-            return "%s(axon_id=%d, atom=%d)" % (
+            return "%s(axon_idx=%d, atom=%d)" % (
                 type(self).__name__,
-                self.axon_id,
+                self.axon_idx,
                 self.atom,
             )
 

--- a/nengo_loihi/block.py
+++ b/nengo_loihi/block.py
@@ -653,7 +653,7 @@ class Synapse:
 
         Does not include ``axon_compartment_base``.
         """
-        return max(i.max() if len(i) > 0 else -1 for i in self.indices)
+        return max(i.max() if i.size > 0 else -1 for i in self.indices)
 
     def _set_weights_indices(self, weights, indices=None):
         weights = [np.array(w, copy=False, dtype=np.float32, ndmin=2) for w in weights]

--- a/nengo_loihi/builder/connection.py
+++ b/nengo_loihi/builder/connection.py
@@ -768,11 +768,11 @@ def build_conv2d_connection(model, conn):
     assert isinstance(conn.pre_obj, (Neurons, ChipReceiveNeurons))
     assert isinstance(conn.transform, nengo_transforms.Convolution)
 
-    weights = conn.transform.sample(rng=rng)
+    kernel = conn.transform.sample(rng=rng)
     input_shape = conn.transform.input_shape
 
     # Account for nengo spike height of 1/dt
-    weights = weights / model.dt
+    kernel = kernel / model.dt
 
     if isinstance(conn.pre_obj, ChipReceiveNeurons):
         neuron_type = conn.pre_obj.neuron_type
@@ -780,7 +780,7 @@ def build_conv2d_connection(model, conn):
         neuron_type = conn.pre_obj.ensemble.neuron_type
 
     if neuron_type is not None and hasattr(neuron_type, "amplitude"):
-        weights = weights * neuron_type.amplitude
+        kernel = kernel * neuron_type.amplitude
 
     # --- post
     assert isinstance(conn.post_obj, Neurons)
@@ -788,7 +788,7 @@ def build_conv2d_connection(model, conn):
 
     gain = model.params[conn.post_obj.ensemble].gain
     if not np.all(gain == gain[0]):
-        # Cannot fold gains into weights, result would not be convolutional.
+        # Cannot fold gains into kernel, result would not be convolutional.
         # Therefore, Loihi does not support this if we want to share weights.
         raise ValidationError(
             "All neurons targeted by a Convolution connection must "
@@ -796,11 +796,11 @@ def build_conv2d_connection(model, conn):
             "gain",
             obj=conn.post_obj.ensemble,
         )
-    weights = weights * gain[0]
+    kernel = kernel * gain[0]
 
     pop_type = model.config[conn].pop_type
     new_transform = copy.copy(conn.transform)
-    type(new_transform).init.data[new_transform] = weights
+    type(new_transform).init.data[new_transform] = kernel
     weights, indices, axon_to_weight_map, offsets = conv2d_loihi_weights(new_transform)
 
     synapse = Synapse(np.prod(input_shape.spatial_shape), label="conv2d_weights")
@@ -823,5 +823,5 @@ def build_conv2d_connection(model, conn):
     post_obj.compartment.configure_filter(tau_s, dt=model.dt)
 
     model.params[conn] = BuiltConnection(
-        eval_points=None, solver_info=None, transform=None, weights=weights
+        eval_points=None, solver_info=None, transform=None, weights=kernel
     )

--- a/nengo_loihi/config.py
+++ b/nengo_loihi/config.py
@@ -11,6 +11,12 @@ def add_params(network):
       * ``on_chip``: Whether the ensemble should be simulated
         on a Loihi chip. Marking specific ensembles for simulation
         off of a Loihi chip can help with debugging.
+    `nengo.Connection`
+      * ``pop_type``: The axon format when using population spikes, which are only
+        used for convolutional connections. By default, we use ``pop_type`` 32.
+        Setting ``pop_type`` to 16 allows more axons to fit on one chip as long as
+        the ``Convolution`` transform has ``channels_last=True`` and ``n_filters``
+        is a multiple of 4.
 
     Examples
     --------
@@ -28,6 +34,10 @@ def add_params(network):
     ens_cfg = config[nengo.Ensemble]
     if "on_chip" not in ens_cfg._extra_params:
         ens_cfg.set_param("on_chip", Parameter("on_chip", default=None, optional=True))
+
+    conn_cfg = config[nengo.Connection]
+    if "pop_type" not in conn_cfg._extra_params:
+        conn_cfg.set_param("pop_type", Parameter("pop_type", default=32, optional=True))
 
 
 def set_defaults():

--- a/nengo_loihi/emulator/interface.py
+++ b/nengo_loihi/emulator/interface.py
@@ -491,9 +491,7 @@ class SynapseState(IterableState):
                 compartment_idxs = spike_input.spike_idxs(t - 1)
                 for axon in spike_input.axons:
                     spikes = axon.map_spikes(compartment_idxs)
-                    self.spikes_in[axon.target].extend(
-                        s for s in spikes if s is not None
-                    )
+                    self.spikes_in[axon.target].extend(spikes)
 
         # --- axons pass spikes to synapses
         for axon, a_idx in all_axons.items():

--- a/nengo_loihi/emulator/interface.py
+++ b/nengo_loihi/emulator/interface.py
@@ -506,12 +506,12 @@ class SynapseState(IterableState):
             qb = input[:, s_slice]
 
             for spike in self.spikes_in[synapse]:
-                base = synapse.axon_compartment_base(spike.axon_id)
+                base = synapse.axon_compartment_base(spike.axon_idx)
                 if base is None:
                     continue
 
                 weights, indices = synapse.axon_weights_indices(
-                    spike.axon_id, atom=spike.atom
+                    spike.axon_idx, atom=spike.atom
                 )
                 qb[0, base + indices] += weights
 
@@ -539,9 +539,9 @@ class SynapseState(IterableState):
             trace_spikes = self.trace_spikes.get(synapse, None)
             if trace_spikes is not None:
                 for spike in self.spikes_in[synapse]:
-                    if spike.axon_id in trace_spikes:
+                    if spike.axon_idx in trace_spikes:
                         self.error("Synaptic trace spikes lost")
-                    trace_spikes.add(spike.axon_id)
+                    trace_spikes.add(spike.axon_idx)
 
             trace = self.traces.get(synapse, None)
             if trace is not None and t % synapse.train_epoch == 0:

--- a/nengo_loihi/emulator/tests/test_interface.py
+++ b/nengo_loihi/emulator/tests/test_interface.py
@@ -60,8 +60,7 @@ def test_uv_overflow(n_axons, plt, allclose, monkeypatch):
     synapse.set_weights(np.ones((n_axons, 1)))
     block.add_synapse(synapse)
 
-    axon = Axon(n_axons)
-    axon.target = synapse
+    axon = Axon(n_axons, target=synapse, compartment_map=np.arange(1))
     input.add_axon(axon)
 
     probe_u = Probe(target=block, key="current")

--- a/nengo_loihi/hardware/builder.py
+++ b/nengo_loihi/hardware/builder.py
@@ -540,9 +540,6 @@ def build_axons(nxsdk_core, core, block, axon, compartment_ids, pop_id_map):
     spikes = axon.map_spikes(compartment_idxs)
 
     for compartment_id, spike in zip(compartment_ids, spikes):
-        if spike is None:
-            continue  # this compartment does not route through these axons
-
         taxon_idx = spike.axon_idx
         taxon_id = taxon_ids[taxon_idx]
         atom = int(spike.atom)

--- a/nengo_loihi/hardware/builder.py
+++ b/nengo_loihi/hardware/builder.py
@@ -415,9 +415,9 @@ def build_synapse(nxsdk_core, core, block, synapse, compartment_idxs):  # noqa C
     synapse_map = {}  # map weight_idx to (ptr, pop_size, len)
     total_synapse_ptr = int(core.synapse_entries[synapse][0])
     for axon_idx, axon_id in enumerate(axon_ids):
-        assert axon_id <= 2 ** axon_bits
+        assert axon_id is None or axon_id <= 2 ** axon_bits
 
-        weight_idx = int(synapse.axon_weight_idx(axon_idx))
+        weight_idx = synapse.axon_weight_idx(axon_idx)
         base = synapse.axon_compartment_base(axon_idx)
 
         if weight_idx not in synapse_map:
@@ -451,14 +451,12 @@ def build_synapse(nxsdk_core, core, block, synapse, compartment_idxs):  # noqa C
         synapse_ptr, n_atoms, n_compartments = synapse_map[weight_idx]
         assert n_atoms <= 2 ** atom_bits
 
-        if base is None:
-            # this is a dummy axon with no weights, so set n_compartments to 0
-            synapse_ptr = 0
-            n_compartments = 0
-            base = 0
-        else:
-            base = int(base)
+        if axon_id is None:
+            # This is a dummy axon with no base or no weights, so skip it
+            assert base is None or n_compartments == 0
+            continue
 
+        base = int(base)
         assert base <= d(b"MjU2", int), "Currently limited by hardware"
         d_set(
             d_get(nxsdk_core, b"c3luYXBzZU1hcA==")[axon_id],
@@ -539,7 +537,7 @@ def build_synapse(nxsdk_core, core, block, synapse, compartment_idxs):  # noqa C
 
 def build_axons(nxsdk_core, core, block, axon, compartment_ids, pop_id_map):
     synapse = axon.target
-    tchip_idx, tcore_idx, tsyn_idxs = core.board.find_synapse(synapse)
+    tchip_idx, tcore_idx, taxon_ids = core.board.find_synapse(synapse)
     nxsdk_board = d_get(nxsdk_core, b"cGFyZW50", b"cGFyZW50")
     tchip_id = d_get(d_get(nxsdk_board, b"bjJDaGlwcw==")[tchip_idx], b"aWQ=")
     tcore_id = d_get(
@@ -556,10 +554,13 @@ def build_axons(nxsdk_core, core, block, axon, compartment_ids, pop_id_map):
         if spike is None:
             continue  # this compartment does not route through these axons
 
-        taxon_idx = int(spike.axon_id)
-        taxon_id = int(tsyn_idxs[taxon_idx])
+        taxon_idx = spike.axon_idx
+        taxon_id = taxon_ids[taxon_idx]
         atom = int(spike.atom)
         n_atoms = synapse.axon_populations(taxon_idx)
+
+        if taxon_id is None:
+            continue  # this connects to a dummy axon, so do not build
 
         if synapse.pop_type == 0:  # discrete
             assert atom == 0

--- a/nengo_loihi/hardware/builder.py
+++ b/nengo_loihi/hardware/builder.py
@@ -379,26 +379,15 @@ def build_input(nxsdk_core, core, spike_input, compartment_idxs):
     nxsdk_board.spike_inputs[spike_input] = loihi_input
 
     # add any pre-existing spikes to spikegen
+    nxsdk_spike_generator = nxsdk_board.global_spike_generator
     for t in spike_input.spike_times():
         assert (
-            nxsdk_board.global_spike_generator is not None
+            nxsdk_spike_generator is not None
         ), "Cannot add pre-existing spikes when using Snips (no spike generator)"
 
         spikes = spike_input.spike_idxs(t)
-        for spike in loihi_input.spikes_to_loihi(spikes):
-            assert (
-                spike["atom"] == 0
-            ), "Cannot send population spikes through spike generator"
-            d_func(
-                nxsdk_board.global_spike_generator,
-                b"YWRkU3Bpa2U=",
-                kwargs={
-                    b"dGltZQ==": t,
-                    b"Y2hpcElk": spike["chip_id"],
-                    b"Y29yZUlk": spike["core_id"],
-                    b"YXhvbklk": spike["axon_id"],
-                },
-            )
+        loihi_spikes = loihi_input.spikes_to_loihi(spikes)
+        loihi_input.add_spikes_to_generator(t, loihi_spikes, nxsdk_spike_generator)
 
 
 def build_synapse(nxsdk_core, core, block, synapse, compartment_idxs):  # noqa C901

--- a/nengo_loihi/hardware/nxsdk_objects.py
+++ b/nengo_loihi/hardware/nxsdk_objects.py
@@ -245,6 +245,8 @@ class LoihiSpikeInput:
     atom : np.int32
         The population index (atom), used if this axon sends population spikes
         (i.e. axon_type != 0).
+    atom_bits_extra : np.int32
+        The number of extra bits used for the atom (pop16 axons only).
     """
 
     spike_dtype = np.dtype(
@@ -255,8 +257,40 @@ class LoihiSpikeInput:
             ("core_id", np.int32),
             ("axon_id", np.int32),
             ("atom", np.int32),
+            ("atom_bits_extra", np.int32),
         ]
     )
+
+    @classmethod
+    def add_spikes_to_generator(cls, t, spikes, basic_spike_generator):
+        methods = {
+            0: getattr(basic_spike_generator, d(b"YWRkU3Bpa2U=")),
+            16: getattr(basic_spike_generator, d(b"YWRkUG9wMTZTcGlrZQ==")),
+            32: getattr(basic_spike_generator, d(b"YWRkUG9wMzJTcGlrZQ==")),
+        }
+        time = d(b"dGltZQ==")
+        chip_id = d(b"Y2hpcElk")
+        core_id = d(b"Y29yZUlk")
+        axon_id = d(b"YXhvbklk")
+        atom = d(b"c3JjQXRvbQ==")
+        atom_bits_extra = d(b"YXRvbUJpdHM=")
+
+        for spike in spikes:
+            axon_type = int(spike["axon_type"])
+            kwargs = {
+                time: t,
+                chip_id: spike["chip_id"],
+                core_id: spike["core_id"],
+                axon_id: spike["axon_id"],
+            }
+            if axon_type == 0:
+                assert spike["atom"] == 0, "Atom must be zero for discrete spikes"
+            else:
+                kwargs[atom] = spike["atom"]
+                if axon_type == 16:
+                    kwargs[atom_bits_extra] = spike["atom_bits_extra"]
+
+            methods[axon_type](**kwargs)
 
     def __init__(self):
         self.axon_map = {}  # maps spike_input idx to axon in self.axons
@@ -277,9 +311,8 @@ class LoihiSpikeInput:
         assert len(self.axon_map) == 0
         input_idxs = np.arange(spike_input.n_neurons)
         for axon in spike_input.axons:
-            axon_type = axon.pop_type
-            assert axon_type in (0, 32), "Only discrete and pop32 supported"
             synapse = axon.target
+            atom_bits_extra = synapse.atom_bits_extra()
             tchip_idx, tcore_idx, taxon_ids = board.find_synapse(synapse)
             tchip = d_get(nxsdk_board, b"bjJDaGlwcw==")[tchip_idx]
             tcore = d_get(tchip, b"bjJDb3Jlcw==")[tcore_idx]
@@ -297,7 +330,15 @@ class LoihiSpikeInput:
 
                 self.axon_map[input_idx].append(
                     np.array(
-                        (-1, axon_type, tchip.id, tcore.id, taxon_id, spike.atom),
+                        (
+                            -1,
+                            axon.pop_type,
+                            tchip.id,
+                            tcore.id,
+                            taxon_id,
+                            spike.atom,
+                            atom_bits_extra,
+                        ),
                         dtype=self.spike_dtype,
                     )
                 )

--- a/nengo_loihi/hardware/nxsdk_objects.py
+++ b/nengo_loihi/hardware/nxsdk_objects.py
@@ -318,11 +318,6 @@ class LoihiSpikeInput:
             tcore = d_get(tchip, b"bjJDb3Jlcw==")[tcore_idx]
             spikes = axon.map_spikes(input_idxs)
             for input_idx, spike in zip(input_idxs, spikes):
-                if spike is None:
-                    # This should not happen, because input slices happen when
-                    # connecting into the spike input. If it does, we just skip it.
-                    continue  # pragma: no cover
-
                 self.axon_map.setdefault(input_idx, [])
                 taxon_id = taxon_ids[spike.axon_idx]
                 if taxon_id is None:

--- a/nengo_loihi/hardware/snips/nengo_io.c.template
+++ b/nengo_loihi/hardware/snips/nengo_io.c.template
@@ -33,16 +33,18 @@ void nengo_io(runState *s) {
 {% for core in cores %}
     {{ obfs.core_class }} *core{{ core }} = NEURON_PTR((CoreId){.id = {{ core }}});
 {% endfor %}
-    {{ obfs.id_class }} core_id;
+
     int in_channel = {{ obfs.get_channel }}("nengo_io_h2c");
     int out_channel = {{ obfs.get_channel }}("nengo_io_c2h");
 
-    {{ obfs.int_type }} axon_type;
-    {{ obfs.int_type }} axon_id;
-    {{ obfs.int_type }} atom;
     {{ obfs.int_type }} n_spikes; // input spike count
     {{ obfs.int_type }} i_spike;  // input spike position
     {{ obfs.int_type }} *spike;
+    {{ obfs.id_class }} core_id;
+    {{ obfs.int_type }} axon_type;
+    {{ obfs.int_type }} axon_id;
+    {{ obfs.int_type }} atom;
+    {{ obfs.int_type }} atom_bits;
 
     {{ obfs.int_type }} error_index;   // index into error stored in shared data
     {{ obfs.int_type }} i_error = 0;   // index of error block
@@ -115,10 +117,13 @@ void nengo_io(runState *s) {
         printf("send spike core=%d, axon=%d, type=%d atom=%d\n", core_id.id,
                axon_id, axon_type, atom);
 #endif
-        if (axon_type == {{ obfs.axon_type_0 }}) {
+        if (axon_type == 0) {
             {{ obfs.do_axon_type_0 }}(s->{{ obfs.step }}, core_id, axon_id);
-        } else if (axon_type == {{ obfs.axon_type_1 }}) {
-            {{ obfs.do_axon_type_1 }}(s->{{ obfs.step }}, core_id, axon_id, atom, 0, 0, 0);
+        } else if (axon_type == 32) {
+            {{ obfs.do_axon_type_32 }}(s->{{ obfs.step }}, core_id, axon_id, atom, 0, 0, 0);
+        } else if (axon_type >= 16) {
+            atom_bits = axon_type - 16;
+            {{ obfs.do_axon_type_16 }}(s->{{ obfs.step }}, core_id, axon_id, atom, atom_bits);
         } else {
             printf("Got invalid axon_type: %d\n", axon_type);
             return;

--- a/nengo_loihi/hardware/tests/test_allocators.py
+++ b/nengo_loihi/hardware/tests/test_allocators.py
@@ -71,23 +71,21 @@ def _basic_model():
     block1.compartment.configure_lif()
     model.add_block(block1)
 
-    axon1 = Axon(1)
-    block0.add_axon(axon1)
-
     synapse1 = Synapse(1)
     synapse1.set_weights([[1]])
-    axon1.target = synapse1
     block1.add_synapse(synapse1)
 
-    axon0 = Axon(1)
-    input = LoihiInput()
-    input.add_axon(axon0)
-    model.add_input(input)
+    axon1 = Axon(1, target=synapse1, compartment_map=np.arange(1))
+    block0.add_axon(axon1)
 
     synapse0 = Synapse(1)
     synapse0.set_weights([[1]])
-    axon0.target = synapse0
     block0.add_synapse(synapse0)
+
+    axon0 = Axon(1, target=synapse0, compartment_map=np.arange(1))
+    input = LoihiInput()
+    input.add_axon(axon0)
+    model.add_input(input)
 
     discretize_model(model)
 

--- a/nengo_loihi/hardware/tests/test_interface.py
+++ b/nengo_loihi/hardware/tests/test_interface.py
@@ -78,14 +78,13 @@ def test_builder_poptype_errors():
     block1.compartment.configure_lif()
     model.add_block(block1)
 
-    axon = Axon(1)
-    block0.add_axon(axon)
-
     synapse = Synapse(1)
     synapse.set_weights([[1]])
     synapse.pop_type = 8
-    axon.target = synapse
     block1.add_synapse(synapse)
+
+    axon = Axon(1, target=synapse, compartment_map=[0])
+    block0.add_axon(axon)
 
     discretize_model(model)
 

--- a/nengo_loihi/splitter.py
+++ b/nengo_loihi/splitter.py
@@ -4,7 +4,6 @@ from nengo import Direct, Ensemble, Node, Probe
 from nengo.exceptions import BuildError
 from nengo.connection import LearningRule
 
-from nengo_loihi.compat import nengo_transforms
 from nengo_loihi.config import add_params
 from nengo_loihi.passthrough import base_obj, PassthroughSplit
 
@@ -46,29 +45,13 @@ class PrecomputableSplit:
         # Also see issue #214.
         has_learning = any(conn.learning_rule is not None for conn in self._conns)
 
-        # host->chip convolutional connections are also not supported with
-        # precompute=True because the BasicSpikeGenerator cannot send population
-        # spikes correctly, meaning we have to use Snips.
-        has_convolution = False
-        if nengo_transforms is not None:
-            has_convolution = any(
-                isinstance(conn.transform, nengo_transforms.Convolution)
-                and not self.hostchip.on_chip(base_obj(conn.pre))
-                and self.hostchip.on_chip(base_obj(conn.post))
-                for conn in self._conns
-            )
-
-        if not has_learning and not has_convolution:
+        if not has_learning:
             self._find_precomputable_objs()
         else:
             self._precomputable = False
             if strict and has_learning:
                 raise BuildError(
                     "precompute=True not supported when using learning rules"
-                )
-            elif strict and has_convolution:
-                raise BuildError(
-                    "precompute=True not supported when using convolutional connections"
                 )
 
         if strict and not self._precomputable:

--- a/nengo_loihi/tests/test_block.py
+++ b/nengo_loihi/tests/test_block.py
@@ -40,7 +40,7 @@ def test_strings():
     synapse = Synapse(2, label="mySynapse")
     assert str(synapse) == "Synapse(mySynapse)"
 
-    axon = Axon(2, label="myAxon")
+    axon = Axon(2, target=None, compartment_map=[], label="myAxon")
     assert str(axon) == "Axon(myAxon)"
 
     spike = Axon.Spike(axon_idx=7, atom=2)
@@ -58,9 +58,6 @@ def test_negative_base(request, seed):
     input.add_spikes(1, list(range(n_axons)))
     model.add_input(input)
 
-    axon = Axon(n_axons)
-    input.add_axon(axon)
-
     block = LoihiBlock(3)
     block.compartment.configure_relu()
     model.add_block(block)
@@ -73,8 +70,10 @@ def test_negative_base(request, seed):
     synapse.set_population_weights(
         weights, indices, axon_to_weight_map, bases, pop_type=32
     )
-    axon.target = synapse
     block.add_synapse(synapse)
+
+    axon = Axon(n_axons, target=synapse, compartment_map=np.arange(3))
+    input.add_axon(axon)
 
     probe = Probe(target=block, key="voltage")
     block.add_probe(probe)

--- a/nengo_loihi/tests/test_block.py
+++ b/nengo_loihi/tests/test_block.py
@@ -43,8 +43,8 @@ def test_strings():
     axon = Axon(2, label="myAxon")
     assert str(axon) == "Axon(myAxon)"
 
-    spike = Axon.Spike(axon_id=7, atom=2)
-    assert str(spike) == "Spike(axon_id=7, atom=2)"
+    spike = Axon.Spike(axon_idx=7, atom=2)
+    assert str(spike) == "Spike(axon_idx=7, atom=2)"
 
 
 # TODO: Only targeting sim due to bug with negative cx_base on Loihi

--- a/nengo_loihi/tests/test_conv.py
+++ b/nengo_loihi/tests/test_conv.py
@@ -2,7 +2,7 @@ import os
 import pickle
 
 import nengo
-from nengo.dists import Uniform
+from nengo.dists import Choice, Uniform
 from nengo.exceptions import ValidationError
 from nengo_extras.matplotlib import tile, imshow
 from nengo_extras.vision import Gabor
@@ -573,6 +573,157 @@ def test_conv_input(channels_last, Simulator, plt, allclose):
 
     # loihi spikes are not exactly the same, but should be close-ish
     assert allclose(p0, p1, rtol=0.15, atol=1)
+
+
+@pytest.mark.skipif(nengo_transforms is None, reason="Requires new nengo.transforms")
+@pytest.mark.parametrize("pop_type", [32, 16])
+def test_conv_deepnet(pop_type, Simulator, rng, seed, plt, allclose):
+    def conv_layer(
+        x, input_shape, array_init=None, label=None, conn_args=None, **conv_args
+    ):
+        conn_args = {} if conn_args is None else conn_args
+
+        if array_init is not None:
+            assert all(a not in conv_args for a in ("init", "kernel_size", "n_filters"))
+            assert array_init.ndim == 4
+            conv_args["init"] = array_init
+            conv_args["kernel_size"] = array_init.shape[:2]
+            assert array_init.shape[2] == input_shape.n_channels
+            conv_args["n_filters"] = array_init.shape[3]
+
+        conv = nengo.Convolution(input_shape=input_shape, **conv_args)
+
+        # add an ensemble to implement the activation function
+        layer = nengo.Ensemble(conv.output_shape.size, 1, label=label)
+
+        # connect up the input object to the new layer
+        conn = nengo.Connection(x, layer.neurons, transform=conv)
+
+        return layer, conv, conn
+
+    channels_last = True
+    channels = 1
+    n_filters0 = 1
+    n_filters1 = 4
+    n_filters2 = 4
+    # load data
+    with open(os.path.join(test_dir, "mnist10.pkl"), "rb") as f:
+        test10 = pickle.load(f)
+
+    test_x = test10[0][0].reshape(28, 28)  # range (0, 1)
+    input_shape = nengo_transforms.ChannelShape(
+        (test_x.shape + (channels,)) if channels_last else ((channels,) + test_x.shape),
+        channels_last=channels_last,
+    )
+
+    filters0 = np.ones((1, 1, channels, n_filters0))
+
+    # use Gabor filters for first layer
+    filters1 = Gabor(
+        freq=Uniform(0.5, 1), sigma_x=Choice([0.9]), sigma_y=Choice([0.9])
+    ).generate(n_filters1, (7, 7), rng=rng)
+    assert n_filters0 == 1
+    filters1 = filters1[None, :, :, :]  # single channel
+    filters1 = np.transpose(filters1, (2, 3, 0, 1))  # rows, cols, in_chan, out_chan
+
+    # use random combinations of first-layer channels in 1x1 convolution
+    filters2 = rng.uniform(-0.2, 1, size=(n_filters1, n_filters2)).clip(0, None)
+    filters2 *= 2 / filters2.sum(axis=0, keepdims=True)  # each filter sums to 2
+    filters2 = filters2[None, None, :, :]  # rows, cols, in_chan, out_chan
+
+    tau_s = 0.001
+    max_rate = 100
+    amp = 1 / max_rate
+
+    # use Loihi neuron type so Nengo sim mimics Loihi neuron effects
+    neuron_type = LoihiSpikingRectifiedLinear(amplitude=amp)
+
+    pres_time = 0.2
+
+    with nengo.Network(seed=seed) as net:
+        nengo_loihi.add_params(net)
+
+        net.config[nengo.Ensemble].neuron_type = neuron_type
+        net.config[nengo.Ensemble].max_rates = Choice([max_rate])
+        net.config[nengo.Ensemble].intercepts = Choice([0])
+        net.config[nengo.Connection].synapse = tau_s
+
+        u = nengo.Node(test_x.ravel(), label="u")
+
+        layer0, conv0, conn0 = conv_layer(
+            u,
+            input_shape=input_shape,
+            array_init=filters0,
+            strides=(1, 1),
+            label="layer0",
+            conn_args=dict(synapse=None),
+        )
+        net.config[layer0].on_chip = False
+
+        layer1, conv1, conn1 = conv_layer(
+            layer0.neurons,
+            input_shape=conv0.output_shape,
+            array_init=filters1,
+            strides=(2, 2),
+            label="layer1",
+        )
+        net.config[conn1].pop_type = pop_type
+
+        layer2, conv2, conn2 = conv_layer(
+            layer1.neurons,
+            input_shape=conv1.output_shape,
+            array_init=filters2,
+            strides=(1, 1),
+            label="layer2",
+        )
+        net.config[conn2].pop_type = pop_type
+
+        output_p = nengo.Probe(layer2.neurons)
+        output_shape = conv2.output_shape
+
+    with nengo.Simulator(net, optimize=False) as sim_nengo:
+        sim_nengo.run(pres_time)
+        ref_out = (sim_nengo.data[output_p] > 0).sum(axis=0).reshape(output_shape.shape)
+
+    hw_opts = dict(snip_max_spikes_per_step=800)
+    with Simulator(net, precompute=False, hardware_options=hw_opts) as sim_loihi:
+        block1 = sim_loihi.model.objs[layer1]["out"]
+        n_axons1 = sum(axon.axon_slots() for axon in block1.axons)
+        n_inputs1 = np.prod(conv1.output_shape.spatial_shape)
+        assert n_axons1 == (2 if pop_type == 32 else 1) * n_inputs1
+
+        sim_loihi.run(pres_time)
+        sim_out = (sim_loihi.data[output_p] > 0).sum(axis=0).reshape(output_shape.shape)
+
+    out_max = ref_out.max()
+    ref_out = ref_out / out_max
+    sim_out = sim_out / out_max
+
+    # --- plot results
+    rows = 2
+    cols = 3
+
+    ax = plt.subplot(rows, cols, 1)
+    imshow(test_x, vmin=0, vmax=1, ax=ax)
+
+    ax = plt.subplot(rows, cols, 2)
+    tile(np.transpose(filters1, (2, 3, 0, 1))[0], rows=2, cols=2, grid=True, ax=ax)
+
+    ax = plt.subplot(rows, cols, 3)
+    assert filters2.shape[:2] == (1, 1)
+    filters12 = filters1.dot(filters2[0, 0])
+    tile(np.transpose(filters12, (2, 3, 0, 1))[0], rows=2, cols=2, grid=True, ax=ax)
+
+    ax = plt.subplot(rows, cols, 4)
+    plt.hist((ref_out.ravel(), sim_out.ravel()), bins=21)
+
+    ax = plt.subplot(rows, cols, 5)
+    tile(np.transpose(ref_out, (2, 0, 1)), rows=2, cols=2, grid=True, ax=ax)
+
+    ax = plt.subplot(rows, cols, 6)
+    tile(np.transpose(sim_out, (2, 0, 1)), rows=2, cols=2, grid=True, ax=ax)
+
+    assert allclose(sim_out, ref_out, atol=0.15, rtol=1e-3)
 
 
 @pytest.mark.skipif(nengo_transforms is None, reason="Requires new nengo.transforms")

--- a/nengo_loihi/tests/test_simulator.py
+++ b/nengo_loihi/tests/test_simulator.py
@@ -656,12 +656,6 @@ def test_population_input(request, allclose):
     model.add_input(input)
     spikes = [(input, ti, inds) for ti, inds in spike_times_inds]
 
-    input_axon = Axon(n_axons)
-    target_axons = np.zeros(n_inputs, dtype=int)
-    atoms = np.arange(n_inputs)
-    input_axon.set_compartment_axon_map(target_axons, atoms=atoms)
-    input.add_axon(input_axon)
-
     block = LoihiBlock(n_compartments)
     block.compartment.configure_lif(tau_rc=0.0, tau_ref=0.0, dt=dt)
     block.compartment.configure_filter(0, dt=dt)
@@ -676,7 +670,14 @@ def test_population_input(request, allclose):
         weights, indices, axon_to_weight_map, bases, pop_type=32
     )
     block.add_synapse(synapse)
-    input_axon.target = synapse
+
+    input_axon = Axon(
+        n_axons,
+        target=synapse,
+        compartment_map=np.zeros(n_inputs),
+        atoms=np.arange(n_inputs),
+    )
+    input.add_axon(input_axon)
 
     probe = Probe(target=block, key="voltage")
     block.add_probe(probe)

--- a/nengo_loihi/tests/test_splitter.py
+++ b/nengo_loihi/tests/test_splitter.py
@@ -3,7 +3,6 @@ import nengo
 from nengo.exceptions import BuildError
 import numpy as np
 
-from nengo_loihi.compat import nengo_transforms
 from nengo_loihi.config import add_params
 from nengo_loihi.splitter import Split
 
@@ -123,23 +122,6 @@ def test_precompute_host_to_learning_rule_unsupported():
         nengo.Connection(pre, post, learning_rule_type=nengo.PES())
 
     with pytest.raises(BuildError, match="learning rules"):
-        Split(net, precompute=True)
-
-
-@pytest.mark.skipif(nengo_transforms is None, reason="Requires new nengo.transforms")
-def test_precompute_with_convolution_unsupported():
-    with nengo.Network() as net:
-        stim = nengo.Node([0, 0])
-        ens = nengo.Ensemble(10, 2)
-        nengo.Connection(
-            stim,
-            ens,
-            transform=nengo_transforms.Convolution(
-                n_filters=2, input_shape=(1, 2, 1), kernel_size=(1, 2), strides=(1, 1)
-            ),
-        )
-
-    with pytest.raises(BuildError, match="convolutional connections"):
         Split(net, precompute=True)
 
 

--- a/nengo_loihi/tests/test_validate.py
+++ b/nengo_loihi/tests/test_validate.py
@@ -22,8 +22,7 @@ def test_validate_block():
     # too many output axons
     block = LoihiBlock(410)
     synapse = Synapse(2500)
-    axon = Axon(5000)
-    axon.target = synapse
+    axon = Axon(5000, target=synapse, compartment_map=np.arange(410))
     block.add_synapse(synapse)
     block.add_axon(axon)
     with pytest.raises(BuildError, match="Output axons"):
@@ -33,8 +32,7 @@ def test_validate_block():
     block = LoihiBlock(600)
     synapse = Synapse(500)
     synapse.set_weights(np.ones((500, 600)))
-    axon = Axon(500)
-    axon.target = synapse
+    axon = Axon(500, target=synapse, compartment_map=np.arange(500))
     block.add_synapse(synapse)
     block.add_axon(axon)
     with pytest.raises(BuildError, match="synapse bits"):

--- a/nengo_loihi/validate.py
+++ b/nengo_loihi/validate.py
@@ -66,7 +66,7 @@ def validate_axon(axon):
     if isinstance(axon.target, Synapse):
         if axon.compartment_atoms is not None:
             idxs = np.arange(len(axon.compartment_atoms))
-            axon_ids = axon.map_axon(idxs)
+            axon_ids = axon.compartment_map[idxs]
             for atom, axon_id in zip(axon.compartment_atoms, axon_ids):
                 n_populations = axon.target.axon_populations(axon_id)
                 assert 0 <= atom < n_populations

--- a/nengo_loihi/validate.py
+++ b/nengo_loihi/validate.py
@@ -83,7 +83,11 @@ def validate_synapse(synapse):
         )
     if synapse.pop_type == 16:
         if synapse.axon_compartment_bases is not None:
-            assert all(b % d(b"NA==", int) == 0 for b in synapse.axon_compartment_bases)
+            assert all(
+                b % d(b"NA==", int) == 0
+                for b in synapse.axon_compartment_bases
+                if b >= 0
+            )
 
 
 def validate_synapse_cfg(synapse_cfg):


### PR DESCRIPTION
In #261 I had some questions about [why a `spike is None` condition was necessary](https://github.com/nengo/nengo-loihi/pull/261#discussion_r368679570). In investigating that, I started refactoring `Axon` to reduce the number of ways you could misuse it, as currently it requires you to construct it, then set the `target` outside of the `Axon` constructor, and then call `set_compartment_axon_map`, and if you don't do one of those steps it will either fail or give you undocumented behavior.

While I was able to alleviate those concerns, when I tired to remove the possibility of returning `None` instead of a spike it became obvious that several classes inside `block.py` have similar assumptions, and so several unit tests were failing (despite many integration tests passing). This made me think that there are likely several more issues in how the classes in `block.py` are designed versus how they are actually used in Nengo Loihi, and that seemed outside of the scope of the original issue, so I stopped there. We can pick up this refactoring later if we want.