### PR TITLE
Install NengoDL neuron builders on neuron init

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,14 +62,15 @@ jobs:
         distributions: "sdist bdist_wheel "
         on:
           all_branches: true
+          tags: false
           condition: $TRAVIS_BRANCH =~ ^release-candidate-*
-          condition: $TRAVIS_TAG = ""
       - provider: pypi
         user: tbekolay
         password: $PYPI_TOKEN
         distributions: "sdist bdist_wheel "
         on:
           all_branches: true
+          tags: true
           condition: $TRAVIS_TAG =~ ^v[0-9]*
 
 before_install:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -104,6 +104,10 @@ Release history
 - We now shut down the connection to the board more reliably, which should
   reduce the number of cases in which a model hangs indefinitely.
   (`#266 <https://github.com/nengo/nengo-loihi/pull/266>`__)
+- ``LoihiLIF`` neurons now round ``tau_rc`` to mimic the discretization that occurs on
+  Loihi, for more accurate simulation in Nengo (this was already done in the rate
+  equation and NengoDL implementation of this neuron).
+  (`#275 <https://github.com/nengo/nengo-loihi/pull/275>`__)
 
 0.10.0 (November 25, 2019)
 ==========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -108,6 +108,11 @@ Release history
   Loihi, for more accurate simulation in Nengo (this was already done in the rate
   equation and NengoDL implementation of this neuron).
   (`#275 <https://github.com/nengo/nengo-loihi/pull/275>`__)
+- ``LoihiLIF`` and ``LoihiSpikingRectifiedLinear`` now add the appropriate NengoDL
+  builders when instantiated, so they work properly if used in NengoDL without making
+  a NengoLoihi simulator.
+  (`#248 <https://github.com/nengo/nengo-loihi/issues/248>`__,
+  `#275 <https://github.com/nengo/nengo-loihi/pull/275>`__)
 
 0.10.0 (November 25, 2019)
 ==========================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "nbsphinx",
     "nengo_sphinx_theme",
+    "nengo_sphinx_theme.ext.backoff",
     "numpydoc",
 ]
 
@@ -62,6 +63,7 @@ linkcheck_ignore = [r"http://localhost:\d+"]
 linkcheck_anchors = True
 default_role = "py:obj"
 pygments_style = "sphinx"
+user_agent = "nengo_loihi"
 
 project = "Nengo Loihi"
 authors = "Applied Brain Research"

--- a/nengo_loihi/builder/nengo_dl.py
+++ b/nengo_loihi/builder/nengo_dl.py
@@ -363,10 +363,12 @@ class Installer:
         self.installed = False
 
     def __call__(self):
-        if not HAS_DL:
-            warnings.warn("nengo_dl cannot be imported")
-        elif not self.installed:
-            logger.debug("Installing NengoDL neuron builders")
+        if self.installed:
+            pass
+        elif not HAS_DL:
+            logger.info("nengo_dl cannot be imported, so not installing builders")
+        else:
+            logger.info("Installing NengoDL neuron builders")
             nengo_dl.neuron_builders.SimNeuronsBuilder.TF_NEURON_IMPL[
                 LoihiLIF
             ] = LoihiLIFBuilder
@@ -374,8 +376,6 @@ class Installer:
                 LoihiSpikingRectifiedLinear
             ] = LoihiSpikingRectifiedLinearBuilder
             self.installed = True
-        else:
-            logger.debug("NengoDL neuron builders already installed")
 
 
 install_dl_builders = Installer()

--- a/nengo_loihi/neurons.py
+++ b/nengo_loihi/neurons.py
@@ -126,10 +126,11 @@ class LoihiLIF(LIF):
 
     def step_math(self, dt, J, spiked, voltage, refractory_time):
         tau_ref = discretize_tau_ref(self.tau_ref, dt)
+        tau_rc = discretize_tau_rc(self.tau_rc, dt)
 
         refractory_time -= dt
         delta_t = (dt - refractory_time).clip(0, dt)
-        voltage -= (J - voltage) * np.expm1(-delta_t / self.tau_rc)
+        voltage -= (J - voltage) * np.expm1(-delta_t / tau_rc)
 
         spiked_mask = voltage > 1
         spiked[:] = spiked_mask * (self.amplitude / dt)

--- a/nengo_loihi/neurons.py
+++ b/nengo_loihi/neurons.py
@@ -4,6 +4,15 @@ import numpy as np
 from nengo_loihi.compat import HAS_TF, tf
 
 
+def _install_dl_builders():
+    # avoid circular import by doing import in here
+    from nengo_loihi.builder.nengo_dl import (  # pylint: disable=import-outside-toplevel
+        install_dl_builders,
+    )
+
+    install_dl_builders()
+
+
 def discretize_tau_rc(tau_rc, dt):
     """Discretize tau_rc as per discretize_compartment.
 
@@ -109,10 +118,11 @@ class LoihiLIF(LIF):
         amplitude=1,
         nengo_dl_noise=None,
     ):
-        super(LoihiLIF, self).__init__(
+        super().__init__(
             tau_rc=tau_rc, tau_ref=tau_ref, min_voltage=min_voltage, amplitude=amplitude
         )
         self.nengo_dl_noise = nengo_dl_noise
+        _install_dl_builders()
 
     @property
     def _argreprs(self):
@@ -148,6 +158,10 @@ class LoihiSpikingRectifiedLinear(SpikingRectifiedLinear):
     same output firing rate. This class reproduces this effect. It can be used
     in e.g. ``nengo`` or ``nengo_dl`` to reproduce these unique Loihi effects.
     """
+
+    def __init__(self, amplitude=1):
+        super().__init__(amplitude=amplitude)
+        _install_dl_builders()
 
     def rates(self, x, gain, bias, dt=0.001):
         return loihi_spikingrectifiedlinear_rates(self, x, gain, bias, dt)

--- a/nengo_loihi/passthrough.py
+++ b/nengo_loihi/passthrough.py
@@ -8,7 +8,7 @@ from nengo.ensemble import Neurons
 from nengo.exceptions import BuildError, NengoException
 import numpy as np
 
-from nengo_loihi.compat import nengo_transforms, transform_array
+from nengo_loihi.compat import is_transform_type, nengo_transforms, transform_array
 
 
 def is_passthrough(obj):
@@ -73,14 +73,15 @@ class Cluster:
         """
 
         def format_transform(size, transform):
-            if nengo_transforms is not None:
-                if isinstance(transform, nengo_transforms.Dense):
-                    transform = transform.init
-                else:
-                    raise NotImplementedError(
-                        "Mergeable transforms must be Dense; "
-                        "set remove_passthrough=False"
-                    )
+            if is_transform_type(transform, "NoTransform"):
+                transform = np.array(1.0)
+            elif is_transform_type(transform, "Dense"):
+                transform = transform_array(transform)
+            else:
+                raise NotImplementedError(
+                    "Mergeable transforms must be Dense; "
+                    "set remove_passthrough=False"
+                )
 
             if not isinstance(transform, np.ndarray):
                 raise NotImplementedError(

--- a/nengo_loihi/simulator.py
+++ b/nengo_loihi/simulator.py
@@ -10,7 +10,6 @@ import nengo.utils.numpy as npext
 import numpy as np
 
 from nengo_loihi.builder import Model
-from nengo_loihi.builder.nengo_dl import HAS_DL, install_dl_builders
 from nengo_loihi.compat import NengoSimulationData
 from nengo_loihi.emulator import EmulatorInterface
 from nengo_loihi.hardware import HardwareInterface, HAS_NXSDK
@@ -114,9 +113,6 @@ class Simulator:
 
         if progress_bar:
             warnings.warn("nengo-loihi does not support progress bars")
-
-        if HAS_DL:
-            install_dl_builders()
 
         if model is None:
             self.model = Model(dt=float(dt), label="%s, dt=%f" % (network, dt))

--- a/nengo_loihi/tests/test_conv.py
+++ b/nengo_loihi/tests/test_conv.py
@@ -488,7 +488,7 @@ def test_conv_connection(channels, channels_last, Simulator, seed, rng, plt, all
     ax = plt.subplot(rows, cols, 6)
     tile(np.transpose(sim_out, (2, 0, 1)), vmin=0, vmax=out_max, cols=8, ax=ax)
 
-    assert allclose(emu_out, ref_out, atol=1, rtol=1e-3)
+    assert allclose(emu_out, ref_out, atol=10, rtol=1e-3)
     assert allclose(sim_out, ref_out, atol=10, rtol=1e-3)
 
 

--- a/nengo_loihi/tests/test_splitter.py
+++ b/nengo_loihi/tests/test_splitter.py
@@ -99,7 +99,7 @@ def test_split_host_to_learning_rule():
         net.config[err_offchip].on_chip = False
         ens_conn = nengo.Connection(pre, post, learning_rule_type=nengo.PES())
         neurons_conn = nengo.Connection(
-            pre.neurons, post.neurons, learning_rule_type=nengo.PES()
+            pre.neurons, post.neurons, transform=1.0, learning_rule_type=nengo.PES()
         )
         nengo.Connection(err_onchip, ens_conn.learning_rule)
         nengo.Connection(err_onchip, neurons_conn.learning_rule)

--- a/nengo_loihi/version.py
+++ b/nengo_loihi/version.py
@@ -43,5 +43,5 @@ minimum_nengo_version = info2string(minimum_nengo_version_info)
 
 # newest nengo version we are compatible with (set to latest released nengo
 # version when releasing this repository)
-latest_nengo_version_info = (3, 0, 1)
+latest_nengo_version_info = (3, 1, 0)
 latest_nengo_version = info2string(latest_nengo_version_info)


### PR DESCRIPTION
This insures that the NengoDL neuron builders are added even if
a `nengo_loihi.Simulator` has not yet been created (e.g. if they're
being used for training in NengoDL first).

Fixes #248.