### PR TITLE
WIP: Neuron voltage subtraction reset for accuracy

### DIFF
--- a/nengo_loihi/neurons.py
+++ b/nengo_loihi/neurons.py
@@ -43,7 +43,8 @@ def loihi_lif_rates(neuron_type, x, gain, bias, dt):
     j = neuron_type.current(x, gain, bias) - 1
     out = np.zeros_like(j)
     period = tau_ref + tau_rc * np.log1p(1. / j[j > 0])
-    out[j > 0] = (neuron_type.amplitude / dt) / np.ceil(period / dt)
+    # out[j > 0] = (neuron_type.amplitude / dt) / np.ceil(period / dt)
+    out[j > 0] = neuron_type.amplitude / period
     return out
 
 
@@ -52,7 +53,8 @@ def loihi_spikingrectifiedlinear_rates(neuron_type, x, gain, bias, dt):
 
     out = np.zeros_like(j)
     period = 1. / j[j > 0]
-    out[j > 0] = (neuron_type.amplitude / dt) / np.ceil(period / dt)
+    # out[j > 0] = (neuron_type.amplitude / dt) / np.ceil(period / dt)
+    out[j > 0] = neuron_type.amplitude / period
     return out
 
 

--- a/nengo_loihi/tests/test_neurons.py
+++ b/nengo_loihi/tests/test_neurons.py
@@ -29,7 +29,7 @@ def test_loihi_rates(dt, neuron_type, Simulator, plt, allclose):
     x = np.linspace(-0.1, 1, n)
 
     encoders = np.ones((n, 1))
-    max_rates = 400 * np.ones(n)
+    max_rates = 300 * np.ones(n)
     intercepts = 0 * np.ones(n)
     gain, bias = neuron_type.gain_bias(max_rates, intercepts)
     j = x * gain + bias


### PR DESCRIPTION
Subtracting the voltage threshold from the membrane voltage
instead of setting it to zero after a spike provides more
accurate tuning curves (solves the aliasing problem).
However, this is not yet available on Loihi hardware.