### PR TITLE
Fix split/sliced probe bugs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -125,6 +125,8 @@ Release history
   a NengoLoihi simulator.
   (`#248 <https://github.com/nengo/nengo-loihi/issues/248>`__,
   `#275 <https://github.com/nengo/nengo-loihi/pull/275>`__)
+- Fixed bug when probing sliced objects.
+  (`#284 <https://github.com/nengo/nengo-loihi/pull/284>`__)
 
 0.10.0 (November 25, 2019)
 ==========================

--- a/nengo_loihi/builder/probe.py
+++ b/nengo_loihi/builder/probe.py
@@ -1,6 +1,5 @@
 import nengo
 from nengo import Ensemble, Connection, Node
-from nengo.base import ObjView
 from nengo.connection import LearningRule
 from nengo.ensemble import Neurons
 from nengo.exceptions import BuildError
@@ -72,15 +71,10 @@ def conn_probe(model, nengo_probe):
     model.seeded[conn] = model.seeded[nengo_probe]
     model.seeds[conn] = model.seeds[nengo_probe]
 
-    if isinstance(nengo_probe.target, ObjView):
-        target_obj = nengo_probe.target.obj
-    else:
-        target_obj = nengo_probe.target
-
     d = conn.size_out
-    if isinstance(target_obj, Ensemble):
+    if isinstance(nengo_probe.obj, Ensemble):
         # probed values are scaled by the target ensemble's radius
-        scale = target_obj.radius
+        scale = nengo_probe.obj.radius
         w = np.diag(scale * np.ones(d))
         weights = np.vstack([w, -w])
     else:
@@ -109,14 +103,14 @@ def signal_probe(model, key, probe):
         assert kwargs["function"] is None
         weights = kwargs["transform"].T / model.dt
 
-    if isinstance(probe.target, nengo.ensemble.Neurons):
+    if isinstance(probe.obj, nengo.ensemble.Neurons):
         if probe.attr == "output":
             if weights is None:
                 # spike probes should give values of 1.0/dt on spike events
                 weights = 1.0 / model.dt
 
-            if hasattr(probe.target.ensemble.neuron_type, "amplitude"):
-                weights *= probe.target.ensemble.neuron_type.amplitude
+            if hasattr(probe.obj.ensemble.neuron_type, "amplitude"):
+                weights *= probe.obj.ensemble.neuron_type.amplitude
 
     # Signal probes directly probe a target signal
     target = model.objs[probe.obj]["out"]

--- a/nengo_loihi/builder/split_blocks.py
+++ b/nengo_loihi/builder/split_blocks.py
@@ -186,7 +186,7 @@ def split_probe(probe, block_map, synapse_map):
         else:
             diffs = np.unique(np.diff(comp_idxs))
             new_slice = (
-                slice(comp_idxs[0], comp_idxs[1] + 1, diffs[0])
+                slice(comp_idxs[0], comp_idxs[-1] + 1, diffs[0])
                 if len(diffs) == 1
                 else comp_idxs
             )

--- a/nengo_loihi/hardware/nxsdk_objects.py
+++ b/nengo_loihi/hardware/nxsdk_objects.py
@@ -157,7 +157,7 @@ class Core:
         for block in self.blocks:
             i1 = i0 + block.compartment.n_compartments
             a1 = a0 + sum(ax.n_axons for ax in block.axons)
-            compartment_idxs = list(range(i0, i1))
+            compartment_idxs = np.arange(i0, i1)
             ax_range = (a0, a1)
             yield block, compartment_idxs, ax_range
             i0 = i1


### PR DESCRIPTION
- Wrong index used for slice in `split_probe`.
- `compartment_idxs` must be an array to allow `probe.slice`
  to be an index array in `hardware.builder.build_probe`.
- Probe weights were not configured properly when the probe target
  was an `ObjView`.