### PR TITLE
Block size error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -129,6 +129,9 @@ Release history
   (`#284 <https://github.com/nengo/nengo-loihi/pull/284>`__)
 - Fixed bug when connecting to a single neuron ensemble with a single scalar
   weight. (`#287 <https://github.com/nengo/nengo-loihi/pull/287>`__)
+- Added an error if more than 32 "populations" (e.g. convolutional filters) are used
+  with ``pop_type=16`` axons, since this is not yet supported by NxSDK.
+  (`#286 <https://github.com/nengo/nengo-loihi/pull/286>`__)
 
 0.10.0 (November 25, 2019)
 ==========================

--- a/nengo_loihi/builder/split_blocks.py
+++ b/nengo_loihi/builder/split_blocks.py
@@ -344,6 +344,7 @@ def split_block(old_block, block_shapes):
             (ceil_div(n_compartments, n_split),), (n_compartments,)
         )
     old_block_shape = block_shapes[old_block]
+    assert old_block_shape.ensemble_size == old_block.n_neurons
 
     # find compartment indices for each new block
     new_block_inds = []

--- a/nengo_loihi/config.py
+++ b/nengo_loihi/config.py
@@ -1,4 +1,6 @@
 import nengo
+from nengo import Ensemble
+from nengo.config import InstanceParams
 from nengo.exceptions import ValidationError
 from nengo.params import Parameter
 import numpy as np
@@ -8,7 +10,25 @@ from nengo_loihi.compat import is_integer, nengo_transforms
 
 class BlockShapeParam(Parameter):
     def coerce(self, instance, block_shape):
+        if isinstance(instance, InstanceParams):
+            instance = instance._configures
+
+        assert isinstance(instance, Ensemble), "Not implemented for non-Ensembles"
         self.check_type(instance, block_shape, BlockShape)
+
+        if instance.n_neurons != block_shape.ensemble_size:
+            raise ValidationError(
+                "Block shape ensemble size (`prod(%s) = %d`) must match "
+                "number of ensemble neurons (%d)"
+                % (
+                    list(block_shape.ensemble_shape),
+                    block_shape.ensemble_size,
+                    instance.n_neurons,
+                ),
+                attr=self.name,
+                obj=instance,
+            )
+
         return super().coerce(instance, block_shape)
 
 

--- a/nengo_loihi/hardware/builder.py
+++ b/nengo_loihi/hardware/builder.py
@@ -436,6 +436,11 @@ def build_synapse(nxsdk_core, core, block, synapse, compartment_idxs):  # noqa C
     atom_bits = synapse.atom_bits()
     axon_bits = synapse.axon_bits()
     atom_bits_extra = synapse.atom_bits_extra()
+    if atom_bits_extra > 0:
+        raise NotImplementedError(
+            "Using more than 32 'populations' (e.g. convolutional filters) with "
+            "`pop_type=16` axons has not yet been implemented in NxSDK"
+        )
 
     target_compartments = set()
     synapse_map = {}  # map weight_idx to (ptr, pop_size, len)

--- a/nengo_loihi/tests/test_config.py
+++ b/nengo_loihi/tests/test_config.py
@@ -1,7 +1,8 @@
+import nengo
 from nengo.exceptions import ValidationError
 import pytest
 
-from nengo_loihi.config import BlockShape
+from nengo_loihi.config import add_params, BlockShape
 
 
 def test_block_shape_errors():
@@ -13,6 +14,13 @@ def test_block_shape_errors():
 
     with pytest.raises(ValidationError, match="[Mm]ust be the same length"):
         BlockShape((2, 2), (8,))
+
+    with nengo.Network() as net:
+        add_params(net)
+        a = nengo.Ensemble(10, 1)
+
+        with pytest.raises(ValidationError, match="Block shape ensemble size"):
+            net.config[a].block_shape = BlockShape((3, 2), (6, 2))
 
 
 def test_block_shape_1d():


### PR DESCRIPTION
Add an error if the block shape does not match the ensemble number of neurons. Fixes #285.

Also adds an error if extra atom bits are used with pop16 axons on hardware, since this is not yet implemented in NxSDK.