### PR TITLE
fixup! Add Keras-to-Loihi example

### DIFF
--- a/docs/examples/keras-to-loihi.ipynb
+++ b/docs/examples/keras-to-loihi.ipynb
@@ -22,6 +22,7 @@
    "outputs": [],
    "source": [
     "import collections\n",
+    "import warnings\n",
     "\n",
     "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
@@ -32,10 +33,14 @@
     "\n",
     "import nengo_loihi\n",
     "\n",
+    "# ignore NengoDL warning about no GPU\n",
+    "warnings.filterwarnings(\"ignore\", message=\"No GPU\", module=\"nengo_dl\")\n",
+    "\n",
     "# The results in this notebook should be reproducible across many random seeds.\n",
     "# However, some seed values may cause problems, particularly in the `to-spikes` layer\n",
     "# where poor initialization can result in no information being sent to the chip. We set\n",
     "# the seed to ensure that good results are reproducible without having to re-train.\n",
+    "np.random.seed(0)\n",
     "tf.random.set_seed(0)"
    ]
   },
@@ -230,13 +235,14 @@
     "    nengo_input = nengo_converter.inputs[inp]\n",
     "    nengo_output = nengo_converter.outputs[dense1]\n",
     "\n",
-    "    # add a probe to the first convolutional layer to record activity\n",
+    "    # add probes to layers to record activity\n",
     "    with nengo_converter.net:\n",
     "        probes = collections.OrderedDict(\n",
     "            [\n",
     "                [to_spikes_layer, nengo.Probe(nengo_converter.layers[to_spikes])],\n",
     "                [conv0_layer, nengo.Probe(nengo_converter.layers[conv0])],\n",
     "                [conv1_layer, nengo.Probe(nengo_converter.layers[conv1])],\n",
+    "                [dense0_layer, nengo.Probe(nengo_converter.layers[dense0])],\n",
     "            ]\n",
     "        )\n",
     "\n",
@@ -265,7 +271,7 @@
     "    # plot the results\n",
     "    mean_rates = []\n",
     "    for i in range(n_plots):\n",
-    "        plt.figure(figsize=(12, 4))\n",
+    "        plt.figure(figsize=(12, 6))\n",
     "\n",
     "        plt.subplot(1, 3, 1)\n",
     "        plt.title(\"Input image\")\n",
@@ -276,14 +282,14 @@
     "        mean_rates_i = []\n",
     "        for j, layer in enumerate(probes.keys()):\n",
     "            probe = probes[layer]\n",
-    "            plt.subplot(n_layers, 3, (j * n_layers) + 2)\n",
+    "            plt.subplot(n_layers, 3, (j * 3) + 2)\n",
     "            plt.suptitle(\"Neural activities\")\n",
     "\n",
     "            outputs = data[probe][i]\n",
     "\n",
     "            # look at only at non-zero outputs\n",
     "            nonzero = (outputs > 0).any(axis=0)\n",
-    "            outputs = outputs[:, nonzero]\n",
+    "            outputs = outputs[:, nonzero] if sum(nonzero) > 0 else outputs\n",
     "\n",
     "            # undo neuron amplitude to get real firing rates\n",
     "            outputs /= nengo_converter.layers[layer].ensemble.neuron_type.amplitude\n",
@@ -372,6 +378,8 @@
    "source": [
     "An important feature of SNNs is the time required to generate output. The larger your scaling factor, the quicker the network response to input will be. This is because more spikes will be generated at each layer, triggering a quicker response at the succeeding layer.\n",
     "\n",
+    "For still images, where each successive image has no correlation with the previous image, this leads to a lag in generating output. SNNs are however much more efficient in a problem like processing a video stream, where there is high correlation between frames. In general, SNNs perform better in situations with temporal dynamics. For simplicity, though, we only examine the case of processing still images here.\n",
+    "\n",
     "Let's see what happens when we convert to an SNN using Loihi neurons.\n",
     "\n",
     "## Converting to SNN using Loihi neurons\n",
@@ -444,7 +452,7 @@
    "source": [
     "We can see that for lower firing rates the behaviour of the Loihi neurons approximates the normal `relu` and `lif` neurons relatively well, but for higher firing rates the discrepancy becomes larger. The discretization results in large plateus of input signal values where the output firing rate from the neuron stays the same, making different input values in this range indistinguishable. Also, as mentioned above, for input values above 1000 (not shown) the `LoihiSpikingRectifiedLinear` neuron will have a constant output of 1000 Hz (since this corresponds to one spike per timestep, the maximum firing rate on Loihi); the `SpikingRectifiedLinear` neuron, on the other hand, is able to fire faster than 1000 Hz by using multiple spikes per timestep.\n",
     "\n",
-    "We can now return to our original question: How do we pick good firing rates for each layer? For outputs above 200 Hz, both Loihi activation functions show significant deviations from the non-Loihi activation profiles; they also become more discontinuous above this point. We therefore want to keep our maximum firing rates below 200 Hz. We also need the firing rate to be high enough to generate sufficient spikes, so that information can be transmitted from layer to layer in a reasonable time. . For these reasons, we'll choose a target mean firing rate for each layer to be 100. We'll generate a scaling term for each layer individually to hit this target."
+    "We can now return to our original question: How do we pick good firing rates for each layer? For outputs above 250 Hz, both Loihi activation functions show significant deviations from the non-Loihi activation profiles; they also become more discontinuous above this point. We therefore want to keep our maximum firing rates below 250 Hz. We also need the firing rate to be high enough to generate sufficient spikes, so that information can be transmitted from layer to layer in a reasonable time. For these reasons, we'll choose a target mean firing rate for each layer to be 200. We'll generate a scaling term for each layer individually to hit this target."
    ]
   },
   {
@@ -453,11 +461,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "target_mean = 100\n",
+    "target_mean = 200\n",
     "scale_firing_rates = {\n",
     "    to_spikes_layer: target_mean / mean_rates[0],\n",
     "    conv0_layer: target_mean / mean_rates[1],\n",
     "    conv1_layer: target_mean / mean_rates[2],\n",
+    "    dense0_layer: target_mean / mean_rates[3],\n",
     "}\n",
     "\n",
     "# test the trained networks using spiking neurons\n",
@@ -472,7 +481,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As we can see, when we individually scale the activity of each layer, we almost fully recover non-spiking performance. Note that the firing rates of some layers (the later layers in particular) do not quite meet the target mean firing rate of 100 Hz, though. This is because our mean firing rates were measured using the `RectifiedLinear` neuron type, and do not account for the difference between it and the `LoihiSpikingRectifiedLinear` activation function.\n",
+    "As we can see, when we individually scale the activity of each layer, we almost fully recover non-spiking performance. Note that the firing rates of some layers (the later layers in particular) do not quite meet the target mean firing rate of 200 Hz, though. This is because our mean firing rates were measured using the `RectifiedLinear` neuron type, and do not account for the difference between it and the `LoihiSpikingRectifiedLinear` activation function. For better results, we could go back and measure the mean firing rates using the Loihi neuron type, or hand-tune the scaling factors on each layer to achieve the desired firing rates.\n",
     "\n",
     "Alternatively, we can train our network using the `LoihiSpikingRectifiedLinear`. This will account both for the discretization in the activation profile, and the hard limit of 1 spike per time step. For larger or more complex networks this can save time tuning.\n",
     "\n",
@@ -528,11 +537,11 @@
    "source": [
     "This is another way that we can recover normal ReLU performance using Loihi neurons.\n",
     "\n",
-    "As discussed in the [Keras to SNN example](https://www.nengo.ai/nengo-dl/examples/keras-to-snn.html), we can also train up this network using an extra term added to the cost function as a way of getting neurons into the desired range of firing rates. This method has the benefit of being more precise in the resultant firing rates of neurons in the network. When we set `scale_firing_rates` to a large number during training we're simply instantiating the network with high firing rates and hoping it settles without changing the firing rates too much.\n",
+    "As discussed in the [Keras to SNN example](https://www.nengo.ai/nengo-dl/examples/keras-to-snn.html), we can also train up this network using an extra term added to the loss function as a way of getting neurons into the desired range of firing rates. This method has the benefit of being more precise in the resultant firing rates of neurons in the network. When we set `scale_firing_rates` to a large number during training, we're simply instantiating the network with high firing rates and hoping it converges while maintaining these higher firing rates, but there is no guarantee. Adding the rate regularization term to the loss function ensures that the firing rates stay near their targets throughout the training process.\n",
     "\n",
     "## Running your SNN on Loihi\n",
     "\n",
-    "At this point we're SNN ready to test out our network on the Loihi. To actually run it on Loihi we have to set up a few more configuration parameters.\n",
+    "At this point we're ready to test out our network on the Loihi. To actually run it on Loihi we have to set up a few more configuration parameters.\n",
     "\n",
     "We'll start by converting our network same as before, using the same parameters on the Converter call:"
    ]


### PR DESCRIPTION
The conversion using `scale_firing_rates` for each layer was giving 2% accuracy, it was caused by not scaling the additional `dense0` layer that was added due to Loihi constraints on spike probes. In fixing this, it made sense to add another subplot with the output from this layer, which then prompted the height of the plots to increase.

Fixed a couple of typos and an error that arose in plotting when there was no activity in any neurons in an ensemble.

Also added a line mentioning SNNs are better suited to temporal problems like video processing over still frames.