### PR TITLE
BuildErrors specify an object

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,10 @@ Release history
   usage during long runs, by running for a segment of the full run time, recording the
   relevant outputs, calling ``clear_probes``, and resuming the run. (`#303`_)
 
+**Changed**
+
+- Build errors specify the associated objects, making them easier to debug. (`#289`_)
+
 **Fixed**
 
 - Fixed several issues to ensure that memory is freed when a ``Simulator``
@@ -41,6 +45,7 @@ Release history
   the same probe data as a single call of equivalent length. (`#271`_, `#303`_)
 
 .. _#271: https://github.com/nengo/nengo-loihi/issues/271
+.. _#289: https://github.com/nengo/nengo-loihi/pull/289
 .. _#303: https://github.com/nengo/nengo-loihi/pull/303
 .. _#312: https://github.com/nengo/nengo-loihi/pull/312
 .. _#317: https://github.com/nengo/nengo-loihi/pull/317

--- a/nengo_loihi/block.py
+++ b/nengo_loihi/block.py
@@ -224,7 +224,7 @@ class Compartment:
         self.scale_u = decay_u > self.DECAY_SCALE_TH
         if not self.scale_u:
             raise BuildError(
-                "Current (U) scaling is required. Perhaps a synapse time "
+                f"{self}: Current (U) scaling is required. Perhaps a synapse time "
                 "constant is too large in your model."
             )
 
@@ -253,7 +253,7 @@ class Compartment:
         self.scale_v = np.all(self.decay_v > self.DECAY_SCALE_TH)
         if not self.scale_v:
             raise BuildError(
-                "Voltage (V) scaling is required with LIF neurons. Perhaps "
+                f"{self}: Voltage (V) scaling is required with LIF neurons. Perhaps "
                 "the neuron tau_rc time constant is too large."
             )
 

--- a/nengo_loihi/builder/connection.py
+++ b/nengo_loihi/builder/connection.py
@@ -147,13 +147,13 @@ def build_host_to_chip(model, conn):
 
     if is_transform_type(conn.transform, "Convolution"):
         raise BuildError(
-            "Conv2D transforms not supported for off-chip to "
+            f"{conn}: Conv2D transforms not supported for off-chip to "
             "on-chip connections where `pre` is not a Neurons object."
         )
     elif not is_transform_type(conn.transform, ("Dense", "NoTransform")):
         raise BuildError(
-            "nengo-loihi does not yet support %r transforms "
-            "on host to chip connections" % (type(conn.transform).__name__,)
+            f"{conn}: nengo-loihi does not yet support "
+            f"'{type(conn.transform).__name__}' transforms on host to chip connections"
         )
 
     # Scale the input spikes based on the radius of the target ensemble
@@ -297,9 +297,9 @@ def build_host_to_learning_rule(model, conn):
     if not is_transform_type(conn.transform, ("Dense", "NoTransform")):
         # TODO: What needs to be done to support this? It looks like it should just work
         raise BuildError(
-            "nengo-loihi does not yet support %r transforms "
-            "on host to chip learning rule connections"
-            % (type(conn.transform).__name__,)
+            f"{conn}: nengo-loihi does not yet support "
+            f"'{type(conn.transform).__name__}' transforms on host to chip "
+            "learning rule connections"
         )
 
     dim = conn.size_out
@@ -352,7 +352,7 @@ def build_decoders(model, conn, rng, sampled_transform):
         # targets = np.dot(targets, transform.T)
         if not is_transform_type(conn.transform, "Dense"):  # pragma: no cover
             raise BuildError(
-                "Non-compositional solvers only work with Dense transforms"
+                f"{conn}: Non-compositional solvers only work with Dense transforms"
             )
         targets = np.dot(targets, sampled_transform.T)
 
@@ -385,9 +385,9 @@ def solve_for_decoders(conn, gain, bias, x, targets, rng, dt):
 
     if np.count_nonzero(activities) == 0:
         raise BuildError(
-            "Building %s: 'activities' matrix is all zero for %s. "
+            f"{conn}: 'activities' matrix is all zero for {conn.pre_obj}. "
             "This is because no evaluation points fall in the firing "
-            "ranges of any neurons." % (conn, conn.pre_obj)
+            "ranges of any neurons."
         )
 
     decoders, solver_info = conn.solver(activities, targets, rng=rng)

--- a/nengo_loihi/builder/discretize.py
+++ b/nengo_loihi/builder/discretize.py
@@ -311,7 +311,7 @@ def discretize_compartment(comp, w_max):
             if (vth <= vth_max).all() and (np.abs(bias) <= BIAS_MAX).all():
                 break
         else:
-            raise BuildError("Could not find appropriate weight exponent")
+            raise BuildError(f"{comp}: Could not find appropriate weight exponent")
     elif b_max > 1e-8:
         b_scale = BIAS_MAX / b_max
         while b_scale * b_max > 1:
@@ -324,7 +324,7 @@ def discretize_compartment(comp, w_max):
 
             b_scale /= 2.0
         else:
-            raise BuildError("Could not find appropriate bias scaling")
+            raise BuildError(f"{comp}: Could not find appropriate bias scaling")
     else:
         # reduce vth_max in this case to avoid overflow since we're setting
         # all vth to vth_max (esp. in learning with zeroed initial weights)

--- a/nengo_loihi/builder/ensemble.py
+++ b/nengo_loihi/builder/ensemble.py
@@ -54,11 +54,10 @@ def get_gain_bias(ens, rng=np.random, intercept_limit=1.0):
         gain, bias = ens.neuron_type.gain_bias(max_rates, intercepts)
         if gain is not None and (not np.all(np.isfinite(gain)) or np.any(gain <= 0.0)):
             raise BuildError(
-                "The specified intercepts for %s lead to neurons with "
-                "negative or non-finite gain. Please adjust the intercepts so "
-                "that all gains are positive. For most neuron types (e.g., "
-                "LIF neurons) this is achieved by reducing the maximum "
-                "intercept value to below 1." % ens
+                f"{ens}: The specified intercepts lead to neurons with negative or "
+                "non-finite gain. Please adjust the intercepts so that all gains are "
+                "positive. For most neuron types (e.g., LIF neurons) this is achieved "
+                "by reducing the maximum intercept value to below 1."
             )
 
     return gain, bias, max_rates, intercepts
@@ -85,9 +84,9 @@ def build_ensemble(model, ens):
 
     if np.any(np.isnan(encoders)):
         raise BuildError(
-            "NaNs detected in %r encoders. This usually means that you had zero-length "
-            "encoders that were normalized, resulting in NaNs. Ensure all encoders "
-            "have non-zero length, or set `normalize_encoders=False`." % ens
+            f"{ens}: NaNs detected in encoders. This usually means that you have "
+            "zero-length encoders; when normalized, these result in NaNs. Ensure all "
+            "encoders have non-zero length, or set `normalize_encoders=False`."
         )
 
     # Build the neurons
@@ -134,11 +133,11 @@ def build_neurons(model, neurontype, neurons, block):
     # If we haven't registered a builder for a specific type, then it cannot
     # be simulated on Loihi.
     raise BuildError(
-        "The neuron type %r cannot be simulated on Loihi. Please either "
-        "switch to a supported neuron type like LIF or "
-        "SpikingRectifiedLinear, or explicitly mark ensembles using this "
-        "neuron type as off-chip with\n"
-        "  net.config[ensembles].on_chip = False" % type(neurontype).__name__
+        f"{neurons}: The neuron type '{type(neurontype).__name__}' cannot be "
+        "simulated on Loihi. Please either switch to a supported neuron type like "
+        "LIF or SpikingRectifiedLinear, or explicitly mark ensembles using "
+        "this neuron type as off-chip with\n"
+        "  net.config[ensembles].on_chip = False"
     )
 
 

--- a/nengo_loihi/builder/probe.py
+++ b/nengo_loihi/builder/probe.py
@@ -151,7 +151,7 @@ def build_probe(model, probe):
         if isinstance(probe.obj, nengotype):
             break
     else:
-        raise BuildError("Type %r is not probeable" % type(probe.obj).__name__)
+        raise BuildError(f"{probe}: Type '{type(probe.obj).__name__}' is not probeable")
 
     key = probeables[probe.attr] if probe.attr in probeables else probe.attr
     if key is None:

--- a/nengo_loihi/builder/tests/test_discretize.py
+++ b/nengo_loihi/builder/tests/test_discretize.py
@@ -123,23 +123,23 @@ def test_lossy_shift(lossy_shift, rng):
 
 def test_bad_weight_exponent_error(Simulator):
     with nengo.Network() as net:
-        a = nengo.Ensemble(5, 1)
-        b = nengo.Ensemble(5, 1, neuron_type=nengo.LIF(tau_rc=5.0))
+        a = nengo.Ensemble(5, 1, label="a")
+        b = nengo.Ensemble(5, 1, neuron_type=nengo.LIF(tau_rc=5.0), label="b")
         nengo.Connection(
             a.neurons, b.neurons, transform=1e-8 * np.ones((5, 5)), synapse=5.0
         )
 
-    with pytest.raises(BuildError, match="[Cc]ould not find.*weight exp"):
+    with pytest.raises(BuildError, match="Ensemble .b.*Could not find.*weight exp"):
         with Simulator(net):
             pass
 
 
 def test_bad_bias_scaling_error(Simulator):
-    block = LoihiBlock(10)
+    block = LoihiBlock(10, label="mylab")
     block.compartment.configure_lif(tau_rc=5.0, vth=1e8)
     block.compartment.bias[:] = 1000.0
 
-    with pytest.raises(BuildError, match="[Cc]ould not find.*bias scaling"):
+    with pytest.raises(BuildError, match="mylab.*Could not find.*bias scaling"):
         discretize_block(block)
 
 

--- a/nengo_loihi/builder/validate.py
+++ b/nengo_loihi/builder/validate.py
@@ -33,8 +33,7 @@ def validate_block(block):
     n_axons = sum(a.axon_slots() for a in block.axons)
     if n_axons > MAX_OUT_AXONS:
         raise BuildError(
-            "Output axons (%d) exceeded max (%d) in %s"
-            % (n_axons, MAX_OUT_AXONS, block)
+            f"{block}: Output axons ({n_axons}) exceeded max ({MAX_OUT_AXONS})"
         )
 
     for axon in block.axons:
@@ -44,14 +43,14 @@ def validate_block(block):
     n_axons = sum(s.n_axons for s in block.synapses)
     if n_axons > MAX_IN_AXONS:
         raise BuildError(
-            "Input axons (%d) exceeded max (%d) in %s" % (n_axons, MAX_IN_AXONS, block)
+            f"{block}: Input axons ({n_axons}) exceeded max ({MAX_IN_AXONS})"
         )
 
     synapse_bits = sum(s.bits() for s in block.synapses)
     if synapse_bits > MAX_SYNAPSE_BITS:
         raise BuildError(
-            "Total synapse bits (%d) exceeded max (%d) in %s"
-            % (synapse_bits, MAX_SYNAPSE_BITS, block)
+            f"{block}: Total synapse bits ({synapse_bits}) exceeded max "
+            f"({MAX_SYNAPSE_BITS})"
         )
 
     for synapse in block.synapses:
@@ -61,8 +60,8 @@ def validate_block(block):
 def validate_compartment(comp):
     if comp.n_compartments > MAX_COMPARTMENTS:
         raise BuildError(
-            "Number of compartments (%d) exceeded max (%d) in %s"
-            % (comp.n_compartments, MAX_COMPARTMENTS, comp)
+            f"{comp}: Number of compartments ({comp.n_compartments}) exceeded max "
+            f"({MAX_COMPARTMENTS})"
         )
 
 
@@ -81,17 +80,15 @@ def validate_synapse(synapse):
     if synapse.axon_compartment_bases is not None:
         min_base = d(b"LTE=", int)
         max_base = d(b"MjU2", int)
-        assert all(
-            min_base <= b < max_base for b in synapse.axon_compartment_bases
-        ), "compartment base must be >= %d and < %d (-1 indicating unused)" % (
-            min_base,
-            max_base,
+        assert all(min_base <= b < max_base for b in synapse.axon_compartment_bases), (
+            f"{synapse}: compartment base must be >= {min_base} and < {max_base} "
+            "(-1 indicating unused)"
         )
     if synapse.pop_type == 16:
         if synapse.axon_compartment_bases is not None:
             assert all(b % 4 == 0 for b in synapse.axon_compartment_bases if b >= 0), (
-                "Pop16 axons must have all compartment bases modulo 4: %s"
-                % synapse.axon_compartment_bases
+                f"{synapse}: Pop16 axons must have all compartment bases modulo 4: "
+                f"{synapse.axon_compartments_bases}"
             )
 
 

--- a/nengo_loihi/hardware/builder.py
+++ b/nengo_loihi/hardware/builder.py
@@ -403,7 +403,7 @@ def build_block(nxsdk_core, core, block, compartment_idxs, ax_range):
     logger.debug("- Building %d axons", len(block.axons))
     pop_id_map = {}
     for axon in block.axons:
-        build_axons(nxsdk_core, core, block, axon, compartment_idxs, pop_id_map)
+        build_axon(nxsdk_core, core, block, axon, compartment_idxs, pop_id_map)
 
 
 def build_synapse(nxsdk_core, core, block, synapse, compartment_idxs):  # noqa C901
@@ -506,7 +506,7 @@ def build_synapse(nxsdk_core, core, block, synapse, compartment_idxs):  # noqa C
                 **{d_compartment_offset: base}
             )
         else:
-            raise BuildError("Synapse: unrecognized pop_type: %s" % (synapse.pop_type,))
+            raise BuildError(f"{synapse}: unrecognized pop_type: {synapse.pop_type}")
 
         if synapse.learning:
             assert core.stdp_pre_cfg_idx is not None
@@ -539,7 +539,7 @@ def build_synapse(nxsdk_core, core, block, synapse, compartment_idxs):  # noqa C
             )
 
 
-def build_axons(nxsdk_core, core, block, axon, compartment_ids, pop_id_map):
+def build_axon(nxsdk_core, core, block, axon, compartment_ids, pop_id_map):
     synapse = axon.target
     tchip_idx, tcore_idx, taxon_ids = core.board.find_synapse(synapse)
     nxsdk_board = d_get(nxsdk_core, b"cGFyZW50", b"cGFyZW50")
@@ -611,7 +611,7 @@ def build_axons(nxsdk_core, core, block, axon, compartment_ids, pop_id_map):
             else:
                 d_func(nxsdk_core, b"Y3JlYXRlUG9wMzJBeG9u", kwargs=kwargs)
         else:
-            raise BuildError("Axon: unrecognized pop_type: %s" % (synapse.pop_type,))
+            raise BuildError(f"{synapse}: unrecognized pop_type: {synapse.pop_type}")
 
 
 def build_probe(nxsdk_board, board, probe, use_snips):

--- a/nengo_loihi/hardware/tests/test_interface.py
+++ b/nengo_loihi/hardware/tests/test_interface.py
@@ -69,10 +69,10 @@ def test_builder_poptype_errors():
     allocator = Greedy()  # one core per ensemble
     board = allocator(model, n_chips=1)
 
-    with pytest.raises(ValueError, match="[Ss]ynapse.*[Uu]nrec.*pop.*type"):
+    with pytest.raises(ValueError, match="unrecognized pop_type"):
         build_board(board)
 
-    # Test error in collect_axons
+    # Test error in build_axon
     model = Model()
     block0 = LoihiBlock(1)
     block0.compartment.configure_lif()
@@ -94,7 +94,7 @@ def test_builder_poptype_errors():
 
     board = allocator(model, n_chips=1)
 
-    with pytest.raises(ValueError, match="[Aa]xon.*[Uu]nrec.*pop.*type"):
+    with pytest.raises(ValueError, match="unrecognized pop_type"):
         build_board(board)
 
 

--- a/nengo_loihi/passthrough.py
+++ b/nengo_loihi/passthrough.py
@@ -92,7 +92,9 @@ class Cluster:
             if transform.ndim == 0:  # scalar
                 transform = np.eye(size) * transform
             elif transform.ndim != 2:
-                raise BuildError("Unhandled transform shape: %s" % (transform.shape,))
+                raise BuildError(
+                    f"{node}: Unhandled transform shape: {transform.shape}"
+                )
 
             return transform
 

--- a/nengo_loihi/simulator.py
+++ b/nengo_loihi/simulator.py
@@ -66,6 +66,15 @@ class Simulator:
         Whether the simulator should target the emulator (``'sim'``) or
         Loihi hardware (``'loihi'``). If None, *target* will default to
         ``'loihi'`` if NxSDK is installed, and the emulator if it is not.
+    progress_bar : bool or `nengo.utils.progress.ProgressBar`, optional
+        Progress bar for displaying build and simulation progress. If ``True``, the
+        default progress bar will be used. If ``False``, the progress bar will be
+        disabled. For more control, pass in a ``ProgressBar`` instance.
+    remove_passthrough : bool, optional
+        Whether to remove passthrough `nengo.Node` objects from the model (i.e. Nodes
+        with ``output=None`` that only act as intermediaries between other objects).
+        This will often allow more of the network to be run on-chip, but can sometimes
+        require significantly larger connections (e.g. more input and output axons).
     hardware_options : dict, optional (Default: {})
         Dictionary of additional configuration for the hardware.
         See `.hardware.HardwareInterface` for possible parameters.


### PR DESCRIPTION
It is almost always the case that a BuildError is associated with
building a particular object, and specifying the object makes it
easier to track down.