### PR TITLE
Allow 'same' padding for convolution

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -201,6 +201,8 @@ setup_cfg:
         no ensembles onchip
       test_simulator.py::test_steps:
         no ensembles onchip
+      test_simulator.py::test_sim_reopen:
+        no ensembles onchip
       test_simulator.py::test_time_absolute:
         no ensembles onchip
       test_simulator.py::test_trange*:
@@ -234,6 +236,8 @@ setup_cfg:
       utils/*test_neurons.py::test_rates_*:
         no ensembles onchip
       test_transforms.py::test_convolution*:
+        no ensembles onchip
+      test_transforms_conv.py::test_convolution[*:
         no ensembles onchip
       test_synapses.py::test_combined_delay:
         no ensembles onchip
@@ -443,10 +447,18 @@ setup_cfg:
       # unsupported neuron types
       test_neurons.py::test_sigmoid_invalid:
         Sigmoid neurons unsupported
+      test_neurons.py::test_spiking_types[base_type0]:
+        LIFRate neurons unsupported
+      test_neurons.py::test_spiking_types[base_type1]:
+        RectifiedLinear neurons unsupported
+      test_neurons.py::test_spiking_types[base_type2]:
+        Tanh neurons unsupported
 
-      # 1D conv not supported
+      # unsupported convolution features
       test_solvers.py::test_non_compositional_solver_transform_error:
         1D convolution not supported
+      test_transforms_conv.py::test_convolution_nef[*:
+        non-identical neuron gains not supported for convolution
 
       # sparse transforms not supported
       test_transforms.py::test_sparse[*:
@@ -497,12 +509,16 @@ travis_yml:
   jobs:
     - stage: basic
       script: emulator
+    - script: emulator
+      env:
+        NENGO_VERSION: "nengo[tests] @ git+https://github.com/nengo/nengo.git"
     - script: static
     - stage: advanced
       script: hardware
       python: 3.6.8
       env:
         NXSDK_VERSION: 1.0.0
+        NENGO_VERSION: "nengo[tests] @ git+https://github.com/nengo/nengo.git"
     - script: docs
       python: 3.7
       apt_install:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 
 repos:
 -   repo: https://github.com/psf/black
-    rev: 20.8b0
+    rev: 21.12b0
     hooks:
     - id: black
       files: \.py$

--- a/.templates/hardware.sh.template
+++ b/.templates/hardware.sh.template
@@ -8,7 +8,7 @@
         cp /nfs/ncl/releases/$NXSDK_VERSION/nxsdk-$NXSDK_VERSION.tar.gz .
         pip install nxsdk-$NXSDK_VERSION.tar.gz
 
-        pip install $NENGO_VERSION $NENGO_DL_VERSION jupyter
+        pip install "$NENGO_VERSION" "$NENGO_DL_VERSION" jupyter
         pip install -e .[tests]
 {% endblock %}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,15 @@ jobs:
     stage: basic
   -
     env:
+      NENGO_VERSION="nengo[tests] @ git+https://github.com/nengo/nengo.git"
+      SCRIPT="emulator"
+  -
+    env:
       SCRIPT="static"
   -
     env:
       NXSDK_VERSION="1.0.0"
+      NENGO_VERSION="nengo[tests] @ git+https://github.com/nengo/nengo.git"
       SCRIPT="hardware"
     stage: advanced
     python: 3.6.8

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,7 @@ Release history
 - Added ``Simulator.clear_probes`` to clear probe histories. This can help reduce memory
   usage during long runs, by running for a segment of the full run time, recording the
   relevant outputs, calling ``clear_probes``, and resuming the run. (`#303`_)
+- Added support for ``padding='same'`` on ``nengo.Convolution`` transforms. (`#297`_)
 
 **Changed**
 
@@ -47,6 +48,7 @@ Release history
 
 .. _#271: https://github.com/nengo/nengo-loihi/issues/271
 .. _#289: https://github.com/nengo/nengo-loihi/pull/289
+.. _#297: https://github.com/nengo/nengo-loihi/pull/297
 .. _#303: https://github.com/nengo/nengo-loihi/pull/303
 .. _#312: https://github.com/nengo/nengo-loihi/pull/312
 .. _#317: https://github.com/nengo/nengo-loihi/pull/317

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,7 @@ Release history
   is deleted. (`#312`_)
 - Fixed probe filters such that multiple ``Simulator.run`` calls now results in
   the same probe data as a single call of equivalent length. (`#271`_, `#303`_)
+- Convolution with 1 x 1 kernels now works as expected. (`#297`_)
 
 .. _#271: https://github.com/nengo/nengo-loihi/issues/271
 .. _#289: https://github.com/nengo/nengo-loihi/pull/289

--- a/nengo_loihi/builder/connection.py
+++ b/nengo_loihi/builder/connection.py
@@ -244,6 +244,12 @@ def build_host_to_chip(model, conn):
 
 
 def build_chip_to_host(model, conn):
+    if not is_transform_type(conn.transform, ("Dense", "NoTransform")):
+        raise BuildError(
+            f"{conn}: nengo-loihi does not yet support "
+            f"'{type(conn.transform).__name__}' transforms on chip to host connections"
+        )
+
     rng = np.random.RandomState(model.seeds[conn])
     dim = conn.size_out
     host = model.host_model(base_obj(conn.post))

--- a/nengo_loihi/builder/connection.py
+++ b/nengo_loihi/builder/connection.py
@@ -732,10 +732,6 @@ def build_conv2d_connection(model, transform, conn):
 
     if transform.dimensions != 2:
         raise NotImplementedError("nengo-loihi only supports 2D convolution")
-    if transform.padding != "valid":
-        raise NotImplementedError(
-            "nengo-loihi only supports convolution with 'valid' padding"
-        )
 
     # Create random number generator
     rng = np.random.RandomState(model.seeds[conn])

--- a/nengo_loihi/hardware/nxsdk_shim.py
+++ b/nengo_loihi/hardware/nxsdk_shim.py
@@ -34,7 +34,6 @@ try:
     def assert_nxsdk():
         pass
 
-
 except ImportError:
     HAS_NXSDK = False
     nxsdk = None

--- a/nengo_loihi/tests/__init__.py
+++ b/nengo_loihi/tests/__init__.py
@@ -1,7 +1,3 @@
-import os
-
-import pytest
-
 import nengo_loihi
 
 
@@ -23,39 +19,3 @@ def make_test_sim(request):
         return nengo_loihi.Simulator(net, *args, **kwargs)
 
     return TestSimulator
-
-
-def set_os_environ(key, value):
-    if value is not None:
-        os.environ[key] = value
-    elif key in os.environ:
-        del os.environ[key]
-
-
-def set_partition_env(
-    partition=os.environ.get("PARTITION", None),
-    lmt_options=os.environ.get("LMTOPTIONS", None),
-):
-    set_os_environ("PARTITION", partition)
-    set_os_environ("LMTOPTIONS", lmt_options)
-
-
-def has_partition(partition):
-    return os.popen("sinfo -h --partition=%s" % (partition,)).read().find("idle") > 0
-
-
-def require_partition(partition, request, action="return", **kwargs):
-    assert action in ("return", "skip", "fail")
-
-    if request.config.getoption("--target") == "loihi":
-        if has_partition(partition):
-            request.addfinalizer(set_partition_env)
-            set_partition_env(partition=partition, **kwargs)
-        elif action == "return":  # pragma: no cover
-            return False
-        else:  # pragma: no cover
-            (pytest.fail if action == "fail" else pytest.skip)(
-                "Partition %r is unavailable" % (partition,)
-            )
-
-    return True

--- a/nengo_loihi/tests/test_conv.py
+++ b/nengo_loihi/tests/test_conv.py
@@ -22,7 +22,6 @@ from nengo_loihi.hardware import HardwareInterface
 from nengo_loihi.hardware.allocators import RoundRobin
 from nengo_loihi.neurons import LoihiLIF, LoihiSpikingRectifiedLinear, loihi_rates
 from nengo_loihi.probe import LoihiProbe
-from nengo_loihi.tests import require_partition
 
 home_dir = os.path.dirname(nengo_loihi.__file__)
 test_dir = os.path.join(home_dir, "tests")
@@ -256,15 +255,8 @@ def test_pop_tiny(pop_type, channels_last, nc, request, plt, seed, allclose):
 
 @pytest.mark.parametrize("channels_last", (True, False))
 @pytest.mark.parametrize("padding", ("valid", "same"))
+@pytest.mark.requires_multichip_snips
 def test_conv2d_weights(padding, channels_last, request, plt, seed, rng, allclose):
-    # with NxSDK 0.9.8, only Nahuku32 is working with multi-chip SNIPs
-    require_partition(
-        "nahuku32",
-        request=request,
-        lmt_options="--skip-power=1",
-        action="fail" if nengo_loihi.version.dev is None else "skip",
-    )
-
     def loihi_rates_n(neuron_type, x, gain, bias, dt):
         """Compute Loihi rates on higher dimensional inputs"""
         y = x.reshape((-1, x.shape[-1]))
@@ -626,6 +618,7 @@ def test_conv_input(channels_last, Simulator, plt, allclose):
 @pytest.mark.parametrize("precompute", [False, True])  # noqa: C901
 @pytest.mark.parametrize("padding", ["valid", "same"])
 @pytest.mark.parametrize("channels_last, pop_type", [(True, 16), (False, 32)])
+@pytest.mark.requires_multichip_snips
 def test_conv_deepnet(
     channels_last,
     pop_type,
@@ -643,29 +636,6 @@ def test_conv_deepnet(
     Checks that network with block splitting on the target matches one without
     on the emulator.
     """
-
-    # if request.config.getoption("--target") == "loihi":
-    #     if (
-    #         pop_type == 32
-    #         and nxsdk_version is not None
-    #         and nxsdk_version < parse_version("0.9.5.dev0")
-    #     ):
-    #         pytest.skip("Pop32 multichip test requires NxSDK >= 0.9.5")
-    #     elif pop_type == 16:
-    #         # multichip pop_type = 16 works only on nahuku32 board currently
-    #         require_partition(
-    #             "nahuku32",
-    #             lmt_options="--skip-power=1",
-    #             action="fail" if nengo_loihi.version.dev is None else "skip",
-    #         )
-
-    # with NxSDK 0.9.8, only Nahuku32 is working with multi-chip SNIPs
-    require_partition(
-        "nahuku32",
-        request=request,
-        lmt_options="--skip-power=1",
-        action="fail" if nengo_loihi.version.dev is None else "skip",
-    )
 
     def conv_layer(
         x, input_shape, array_init=None, label=None, conn_args=None, **conv_args

--- a/nengo_loihi/tests/test_conv.py
+++ b/nengo_loihi/tests/test_conv.py
@@ -46,7 +46,7 @@ def make_channel_shape(spatial_shape, n_channels, channels_last):
 @pytest.mark.parametrize("channels_last", [False, True])
 @pytest.mark.parametrize("padding", ["valid", "same"])
 @pytest.mark.parametrize("strides", [(1, 1), (2, 2), (3, 2)])
-@pytest.mark.parametrize("kernel_size", [(3, 3), (4, 4)])
+@pytest.mark.parametrize("kernel_size", [(1, 1), (3, 3), (4, 4)])
 @pytest.mark.parametrize("spatial_shape", [(6, 6), (7, 9)])
 def test_conv2d_loihi_weights(
     spatial_shape, kernel_size, strides, padding, channels_last, rng, allclose

--- a/nengo_loihi/tests/test_conv.py
+++ b/nengo_loihi/tests/test_conv.py
@@ -5,10 +5,12 @@ import nengo
 import numpy as np
 import pytest
 import scipy.signal
+from nengo._vendor.npconv2d.conv2d import conv2d as np_conv2d
 from nengo.dists import Choice, Uniform
 from nengo.exceptions import ValidationError
 from nengo_extras.matplotlib import imshow, tile
 from nengo_extras.vision import Gabor
+from packaging import version
 
 import nengo_loihi
 from nengo_loihi import conv
@@ -35,6 +37,59 @@ def make_shape(spatial_shape, n_channels, channels_last):
 def make_channel_shape(spatial_shape, n_channels, channels_last):
     shape = make_shape(spatial_shape, n_channels, channels_last)
     return nengo.transforms.ChannelShape(shape, channels_last=channels_last)
+
+
+@pytest.mark.skipif(
+    version.parse(nengo.__version__) <= version.parse("3.1.0"),
+    reason="npconv2d had bugs that were fixed in nengo>3.1.0",
+)
+@pytest.mark.parametrize("channels_last", [False, True])
+@pytest.mark.parametrize("padding", ["valid", "same"])
+@pytest.mark.parametrize("strides", [(1, 1), (2, 2), (3, 2)])
+@pytest.mark.parametrize("kernel_size", [(3, 3), (4, 4)])
+@pytest.mark.parametrize("spatial_shape", [(6, 6), (7, 9)])
+def test_conv2d_loihi_weights(
+    spatial_shape, kernel_size, strides, padding, channels_last, rng, allclose
+):
+    spatial_shape = (4, 4)
+    n_channels = 3
+    n_filters = 4
+
+    inp = rng.normal(size=spatial_shape + (n_channels,))
+    kernel = rng.normal(size=kernel_size + (n_channels,) + (n_filters,))
+
+    transform = nengo.Convolution(
+        n_filters,
+        input_shape=make_channel_shape(spatial_shape, n_channels, channels_last),
+        kernel_size=kernel_size,
+        strides=strides,
+        padding=padding,
+        channels_last=channels_last,
+        init=kernel,
+    )
+    ref_out = np_conv2d(inp[None, ...], kernel, pad=padding.upper(), stride=strides)[0]
+    ref_out = ref_out if channels_last else np.transpose(ref_out, (2, 0, 1))
+    assert ref_out.shape == transform.output_shape.shape
+
+    # compute and manually apply Loihi weights
+    weights, indices, axon_to_weight_map, offsets = conv.conv2d_loihi_weights(transform)
+
+    input_pixels = np.prod(spatial_shape)
+    inp_flat = inp.reshape((input_pixels, n_channels))
+
+    out = np.zeros(transform.output_shape.size)
+    for ij in range(input_pixels):
+        w = weights[axon_to_weight_map[ij]]
+        inds = indices[axon_to_weight_map[ij]]
+        offset = offsets[ij]
+        if offset < 0:
+            continue
+
+        for k in range(n_channels):
+            out[offset + inds[k]] += w[k] * inp_flat[ij, k]
+
+    out = out.reshape(transform.output_shape.shape)
+    assert allclose(out, ref_out)
 
 
 @pytest.mark.parametrize(
@@ -92,8 +147,16 @@ def test_pop_tiny(pop_type, channels_last, nc, request, plt, seed, allclose):
     inp_biases = inp_biases / (inp_biases.max() + 0.001)
 
     # --- compute nengo_loihi outputs
-    ni, nj, nk = inp_biases.shape
-    si, sj, nc, nf = filters.shape
+    ni, nj, _ = inp_biases.shape
+    assert inp_biases.shape[-1] == nc
+    if not channels_last:
+        inp_biases = np.transpose(inp_biases, (2, 0, 1))  # put channels first
+
+    inp_shape = make_channel_shape((ni, nj), nc, channels_last=channels_last)
+
+    si, sj, _, nf = filters.shape
+    assert filters.shape[2] == nc
+
     nij = ni * nj
     nyi = 1 + (ni - si) // sti
     nyj = 1 + (nj - sj) // stj
@@ -103,7 +166,7 @@ def test_pop_tiny(pop_type, channels_last, nc, request, plt, seed, allclose):
     model = Model()
 
     # input block
-    inp = LoihiBlock(ni * nj * nk, label="inp")
+    inp = LoihiBlock(inp_shape.size, label="inp")
     model.add_block(inp)
 
     assert inp.n_neurons <= 1024
@@ -111,15 +174,9 @@ def test_pop_tiny(pop_type, channels_last, nc, request, plt, seed, allclose):
     inp.compartment.bias[:] = inp_biases.ravel()
 
     inp_ax = Axon(nij, label="inp_ax")
-
-    # we always compute the pixel/channel idxs with channels_last=True
-    # (not sure why?), and then set it to the correct value afterwards
-    inp_shape = make_channel_shape((ni, nj), nk, channels_last=True)
     inp_ax.set_compartment_axon_map(
         target_axons=conv.pixel_idxs(inp_shape), atoms=conv.channel_idxs(inp_shape)
     )
-    inp_shape.shape = make_shape((ni, nj), nk, channels_last)
-    inp_shape.channels_last = channels_last
 
     inp.add_axon(inp_ax)
 
@@ -198,7 +255,8 @@ def test_pop_tiny(pop_type, channels_last, nc, request, plt, seed, allclose):
 
 
 @pytest.mark.parametrize("channels_last", (True, False))
-def test_conv2d_weights(channels_last, request, plt, seed, rng, allclose):
+@pytest.mark.parametrize("padding", ("valid", "same"))
+def test_conv2d_weights(padding, channels_last, request, plt, seed, rng, allclose):
     # with NxSDK 0.9.8, only Nahuku32 is working with multi-chip SNIPs
     require_partition(
         "nahuku32",
@@ -249,8 +307,8 @@ def test_conv2d_weights(channels_last, request, plt, seed, rng, allclose):
 
     # --- compute ideal outputs
     def conv_pm(x, kernel):
-        y0 = scipy.signal.correlate2d(x[0], kernel, mode="valid")[::sti, ::stj]
-        y1 = scipy.signal.correlate2d(x[1], kernel, mode="valid")[::sti, ::stj]
+        y0 = scipy.signal.correlate2d(x[0], kernel, mode=padding)[::sti, ::stj]
+        y1 = scipy.signal.correlate2d(x[1], kernel, mode=padding)[::sti, ::stj]
         return [y0, -y1]
 
     ref_out = np.array([test_x, -test_x])
@@ -271,9 +329,10 @@ def test_conv2d_weights(channels_last, request, plt, seed, rng, allclose):
     conv2d_transform = nengo.Convolution(
         8,
         inp_shape,
-        strides=(sti, stj),
-        channels_last=channels_last,
         kernel_size=(7, 7),
+        strides=(sti, stj),
+        padding=padding,
+        channels_last=channels_last,
         init=kernel,
     )
 
@@ -565,9 +624,19 @@ def test_conv_input(channels_last, Simulator, plt, allclose):
 
 
 @pytest.mark.parametrize("precompute", [False, True])  # noqa: C901
+@pytest.mark.parametrize("padding", ["valid", "same"])
 @pytest.mark.parametrize("channels_last, pop_type", [(True, 16), (False, 32)])
 def test_conv_deepnet(
-    channels_last, pop_type, precompute, Simulator, request, rng, seed, plt, allclose
+    channels_last,
+    pop_type,
+    padding,
+    precompute,
+    Simulator,
+    request,
+    rng,
+    seed,
+    plt,
+    allclose,
 ):
     """Run a convolutional network with two layers on the chip.
 
@@ -674,6 +743,7 @@ def test_conv_deepnet(
             array_init=filters0,
             strides=(1, 1),
             channels_last=channels_last,
+            padding=padding,
             label="layer0",
             conn_args=dict(synapse=None),
         )
@@ -685,6 +755,7 @@ def test_conv_deepnet(
             array_init=filters1,
             strides=(2, 2),
             channels_last=channels_last,
+            padding=padding,
             label="layer1",
         )
         net.config[layer1].block_shape = nengo_loihi.BlockShape(
@@ -698,6 +769,7 @@ def test_conv_deepnet(
             array_init=filters2,
             strides=(1, 1),
             channels_last=channels_last,
+            padding=padding,
             label="layer2",
         )
         net.config[layer2].block_shape = nengo_loihi.BlockShape(

--- a/nengo_loihi/tests/test_conv.py
+++ b/nengo_loihi/tests/test_conv.py
@@ -7,7 +7,7 @@ import pytest
 import scipy.signal
 from nengo._vendor.npconv2d.conv2d import conv2d as np_conv2d
 from nengo.dists import Choice, Uniform
-from nengo.exceptions import ValidationError
+from nengo.exceptions import BuildError, ValidationError
 from nengo_extras.matplotlib import imshow, tile
 from nengo_extras.vision import Gabor
 from packaging import version
@@ -1420,3 +1420,19 @@ def test_split_transform(rng):
         conv.split_transform(transform, in_slice=slice8)
     with pytest.raises(AssertionError):
         conv.split_transform(transform, out_slice=slice8)
+
+
+def test_conv_chip2host(Simulator):
+    input_shape = nengo.transforms.ChannelShape((5, 6, 2))
+
+    with nengo.Network() as model:
+        a = nengo.Ensemble(n_neurons=input_shape.size, dimensions=1)
+        conv = nengo.Convolution(
+            n_filters=4, input_shape=input_shape, strides=(1, 1), kernel_size=(3, 3)
+        )
+        b = nengo.Node(lambda t, x: x + 1, size_in=conv.output_shape.size)
+        nengo.Connection(a.neurons, b, transform=conv)
+
+    with pytest.raises(BuildError, match="'Convolution'.*on chip to host"):
+        with Simulator(model):
+            pass

--- a/nengo_loihi/tests/test_dvs.py
+++ b/nengo_loihi/tests/test_dvs.py
@@ -76,6 +76,7 @@ def generate_sinusoidal_spikes(
     return dvs_events
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "dvs_shape, pool, channels_last",
     [

--- a/setup.cfg
+++ b/setup.cfg
@@ -142,6 +142,8 @@ nengo_test_unsupported =
         "no ensembles onchip"
     test_simulator.py::test_steps
         "no ensembles onchip"
+    test_simulator.py::test_sim_reopen
+        "no ensembles onchip"
     test_simulator.py::test_time_absolute
         "no ensembles onchip"
     test_simulator.py::test_trange*
@@ -175,6 +177,8 @@ nengo_test_unsupported =
     utils/*test_neurons.py::test_rates_*
         "no ensembles onchip"
     test_transforms.py::test_convolution*
+        "no ensembles onchip"
+    test_transforms_conv.py::test_convolution[*
         "no ensembles onchip"
     test_synapses.py::test_combined_delay
         "no ensembles onchip"
@@ -352,8 +356,16 @@ nengo_test_unsupported =
         "decoded connection optimized away"
     test_neurons.py::test_sigmoid_invalid
         "Sigmoid neurons unsupported"
+    test_neurons.py::test_spiking_types[base_type0]
+        "LIFRate neurons unsupported"
+    test_neurons.py::test_spiking_types[base_type1]
+        "RectifiedLinear neurons unsupported"
+    test_neurons.py::test_spiking_types[base_type2]
+        "Tanh neurons unsupported"
     test_solvers.py::test_non_compositional_solver_transform_error
         "1D convolution not supported"
+    test_transforms_conv.py::test_convolution_nef[*
+        "non-identical neuron gains not supported for convolution"
     test_transforms.py::test_sparse[*
         "sparse transforms not supported on host-chip connections"
     test_connection.py::test_neuron_advanced_indexing


### PR DESCRIPTION
This allows `"same"` padding to be used with `nengo.Convolution`. 

TODO:
- [x] More testing (e.g. in `test_conv_deepnet`)