### PR TITLE
Limit tensorflow-probability to <0.12

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -541,6 +541,7 @@ ci_scripts:
       - $NENGO_DL_VERSION
       - cython
       - tensorflow<2.4
+      - tensorflow-probability<0.12
   - template: deploy
 
 codecov_yml: {}


### PR DESCRIPTION
For compatibility with the tensorflow<2.4 requirement added in https://github.com/nengo/nengo-loihi/pull/304. 