### PR TITLE
Release candidate 1.0.0

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -60,7 +60,7 @@ setup_py:
     - pytest-xdist<1.28.0
     - matplotlib>=2.0
   classifiers:
-    - "Development Status :: 3 - Alpha"
+    - "Development Status :: 4 - Beta"
     - "Framework :: Nengo"
     - "Intended Audience :: Science/Research"
     - "License :: Free for non-commercial use"
@@ -502,7 +502,7 @@ travis_yml:
       apt_install:
       - pandoc
       - ffmpeg  # ffmpeg required for matplotlib's `to_html5_video`
-  pypi_user: tbekolay
+  pypi_user: __token__
   deploy_dists:
     - sdist
     - bdist_wheel

--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -24,7 +24,7 @@ manifest_in:
     - .ci/travis_rsa.enc
 
 setup_py:
-  python_requires: ">=3.4"
+  python_requires: ">=3.5"
   entry_points:
     nengo.backends:
       - loihi = nengo_loihi:Simulator
@@ -65,7 +65,6 @@ setup_py:
     - "Intended Audience :: Science/Research"
     - "License :: Free for non-commercial use"
     - "Operating System :: OS Independent"
-    - "Programming Language :: Python :: 3.4"
     - "Programming Language :: Python :: 3.5"
     - "Programming Language :: Python :: 3.6"
     - "Topic :: Scientific/Engineering :: Artificial Intelligence"

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
     deploy:
       - provider: pypi
         server: https://test.pypi.org/legacy/
-        user: tbekolay
+        user: __token__
         password: $PYPI_TEST_TOKEN
         distributions: "sdist bdist_wheel "
         on:
@@ -64,7 +64,7 @@ jobs:
           tags: false
           condition: $TRAVIS_BRANCH =~ ^release-candidate-*
       - provider: pypi
-        user: tbekolay
+        user: __token__
         password: $PYPI_TOKEN
         distributions: "sdist bdist_wheel "
         on:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ Release history
 
 *Compatible with Nengo 3.1.0*
 
-*Compatible with NxSDK 0.8.7 - 0.9.9*
+*Compatible with NxSDK 0.9.0 - 0.9.9*
 
 **Added**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,8 +19,8 @@ Release history
    - Removed
    - Fixed
 
-0.11.0 (unreleased)
-===================
+1.0.0 (January 20, 2021)
+========================
 
 *Compatible with Nengo 3.1.0*
 

--- a/nengo_loihi/hardware/interface.py
+++ b/nengo_loihi/hardware/interface.py
@@ -61,7 +61,7 @@ class HardwareInterface:
     """
 
     connection_retries = 3
-    min_nxsdk_version = parse_nxsdk_version("0.8.7")
+    min_nxsdk_version = parse_nxsdk_version("0.9.0")
     max_nxsdk_version = parse_nxsdk_version("0.9.9")
 
     def __init__(

--- a/nengo_loihi/hardware/nxsdk_objects.py
+++ b/nengo_loihi/hardware/nxsdk_objects.py
@@ -292,9 +292,9 @@ class LoihiSpikeInput:
             axon_type = int(spike["axon_type"])
             kwargs = {
                 time: t,
-                chip_id: spike["chip_id"],
-                core_id: spike["core_id"],
-                axon_id: spike["axon_id"],
+                chip_id: spike["chip_id"].item(),
+                core_id: spike["core_id"].item(),
+                axon_id: spike["axon_id"].item(),
             }
             if axon_type == 0:
                 assert spike["atom"] == 0, "Atom must be zero for discrete spikes"

--- a/nengo_loihi/tests/test_dvs.py
+++ b/nengo_loihi/tests/test_dvs.py
@@ -246,12 +246,12 @@ def test_dvs_errors(tmpdir):
         with open(path, "w") as fh:
             fh.write(" ")
 
-    no_ext_path = tmpdir.join("dvs")
+    no_ext_path = str(tmpdir.join("dvs"))
     empty_file(no_ext_path)
     with pytest.raises(ValueError, match="Events file .* has no extension"):
         DVSEvents.from_file(no_ext_path)
 
-    bad_ext_path = tmpdir.join("dvs.what")
+    bad_ext_path = str(tmpdir.join("dvs.what"))
     empty_file(bad_ext_path)
     with pytest.raises(ValueError, match="Unrecognized file format 'what'"):
         DVSEvents.from_file(bad_ext_path)
@@ -271,7 +271,7 @@ def test_dvs_errors(tmpdir):
         dvs_events.write_file(bad_ext_path)
 
     # mangled last event
-    mangled_path = tmpdir.join("dvs.aedat")
+    mangled_path = str(tmpdir.join("dvs.aedat"))
     write_aedat_file(mangled_path, dvs_events, mangle_last=True)
     with pytest.warns(UserWarning, match="Mangled event at end"):
         DVSEvents.from_file(mangled_path)

--- a/nengo_loihi/version.py
+++ b/nengo_loihi/version.py
@@ -29,8 +29,8 @@ def info2string(info):
 
 
 name = "nengo_loihi"
-version_info = (0, 11, 0)  # (major, minor, patch)
-dev = 0
+version_info = (1, 0, 0)  # (major, minor, patch)
+dev = None
 
 version = "{v}{dev}".format(
     v=info2string(version_info), dev=(".dev%d" % dev) if dev is not None else ""

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         "optional": optional_req,
         "tests": tests_req,
     },
-    python_requires=">=3.4",
+    python_requires=">=3.5",
     entry_points={
         "nengo.backends": [
             "loihi = nengo_loihi:Simulator",
@@ -97,7 +97,6 @@ setup(
         "Intended Audience :: Science/Research",
         "License :: Free for non-commercial use",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
         ],
     },
     classifiers=[
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 4 - Beta",
         "Framework :: Nengo",
         "Intended Audience :: Science/Research",
         "License :: Free for non-commercial use",


### PR DESCRIPTION
I tested some older NxSDK versions. We were failing on 0.8.7 because some of the SNIP communication stuff doesn't work with that, so I've just dropped support for 0.8.7. Everything works on 0.9.0. (Except `test_conv_deepnet`, but that's an expected failure, since there's some population axon stuff that's been fixed in a more recent NxSDK. We actually used to skip that test on older NxSDK, but that got removed at some point. We could re-add an xfail or something, but it didn't seem worth it since we only ever run these tests on older NxSDK manually on a release.)

I also found some of the DVS stuff didn't work with older python/NxSDK, so I've fixed that. Also fixed some inconsistent naming of the `format` argument for DVS file format (I know `format` is a built-in, but I've never seen us use it as a stand-alone function, so I figured it's fine to overwrite it).