### PR TITLE
team-robot vision project improvements

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -48,6 +48,8 @@ setup_py:
     - numpydoc>=0.6
     - sphinx>=1.8
     - tensorflow-probability>=0.8.0
+  optional_req:
+    - networkx-metis>=1.0
   tests_req:
     - coverage>=4.3
     - nengo-extras

--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -201,6 +201,8 @@ setup_cfg:
         no ensembles onchip
       test_processes.py::TestPiecewise*:
         no ensembles onchip
+      test_processes.py::test_x_copy:
+        no ensembles onchip
       test_simulator.py::test_steps:
         no ensembles onchip
       test_simulator.py::test_sim_reopen:

--- a/.templates/hardware.sh.template
+++ b/.templates/hardware.sh.template
@@ -31,3 +31,11 @@
       && ./codecov -f coverage.xml
 {{ super() }}
 {% endblock %}
+
+{% block remote_cleanup %}
+    mkdir -p emptydir
+    ls -tp | grep '{{ pkg }}-' | tail -n +3 \
+      | xargs -I {} sh -c \
+      'rsync -av --delete emptydir/ {} | tqdm --unit files --unit_scale | wc -l && rmdir {}'
+    rmdir emptydir || true
+{% endblock %}

--- a/.templates/hardware.sh.template
+++ b/.templates/hardware.sh.template
@@ -8,6 +8,7 @@
         cp /nfs/ncl/releases/$NXSDK_VERSION/nxsdk-$NXSDK_VERSION.tar.gz .
         pip install nxsdk-$NXSDK_VERSION.tar.gz
 
+        pip install git+https://github.com/networkx/networkx-metis.git
         pip install "$NENGO_VERSION" "$NENGO_DL_VERSION" jupyter
         pip install -e .[tests]
 {% endblock %}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,7 @@ Release history
 - Deobfuscated NxSDK API calls. (`#320`_)
 - The builder now respects the `precision.bits`_ attribute in ``nengorc`` files,
   allowing for reduced-precision builds to save memory. (`#309`_)
+- The new ``GreedyInterchip`` allocator is now the default allocator. (`#309`_)
 
 **Fixed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,9 @@ Release history
 - Added support for ``nengo.transforms.ConvolutionTranspose``. (`#300`_)
 - ``Block`` and ``Compartment`` now have ``.discretize_info`` attributes that store
   parameters used for discretizing that block and compartment. (`#309`_)
+- ``Model`` now has a ``connection_decode_neurons`` attribute that maps ``Connection``
+  objects that require decode neurons to the corresponding ``Ensemble`` objects
+  implementing them. (`#309`_)
 
 **Changed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,12 +48,14 @@ Release history
   the same probe data as a single call of equivalent length. (`#271`_, `#303`_)
 - Convolution with 1 x 1 kernels now works as expected. (`#297`_)
 - Fixed a bug preventing targeting Loihi even if NxSDK is installed. (`#300`_)
+- Fixed how ``DecodeNeurons`` handles ``dt != 0.001``. (`#309`_)
 
 .. _#271: https://github.com/nengo/nengo-loihi/issues/271
 .. _#289: https://github.com/nengo/nengo-loihi/pull/289
 .. _#297: https://github.com/nengo/nengo-loihi/pull/297
 .. _#300: https://github.com/nengo/nengo-loihi/pull/300
 .. _#303: https://github.com/nengo/nengo-loihi/pull/303
+.. _#309: https://github.com/nengo/nengo-loihi/pull/309
 .. _#312: https://github.com/nengo/nengo-loihi/pull/312
 .. _#317: https://github.com/nengo/nengo-loihi/pull/317
 .. _#320: https://github.com/nengo/nengo-loihi/pull/320

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,8 @@ Release history
 
 - Build errors specify the associated objects, making them easier to debug. (`#289`_)
 - Deobfuscated NxSDK API calls. (`#320`_)
+- The builder now respects the `precision.bits`_ attribute in ``nengorc`` files,
+  allowing for reduced-precision builds to save memory. (`#309`_)
 
 **Fixed**
 
@@ -59,6 +61,7 @@ Release history
 .. _#312: https://github.com/nengo/nengo-loihi/pull/312
 .. _#317: https://github.com/nengo/nengo-loihi/pull/317
 .. _#320: https://github.com/nengo/nengo-loihi/pull/320
+.. _precision.bits: https://www.nengo.ai/nengo/nengorc.html#configuration-options
 
 1.0.0 (January 20, 2021)
 ========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,8 @@ Release history
   relevant outputs, calling ``clear_probes``, and resuming the run. (`#303`_)
 - Added support for ``padding='same'`` on ``nengo.Convolution`` transforms. (`#297`_)
 - Added support for ``nengo.transforms.ConvolutionTranspose``. (`#300`_)
+- ``Block`` and ``Compartment`` now have ``.discretize_info`` attributes that store
+  parameters used for discretizing that block and compartment. (`#309`_)
 
 **Changed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,8 @@ Release history
 - ``Model`` now has a ``connection_decode_neurons`` attribute that maps ``Connection``
   objects that require decode neurons to the corresponding ``Ensemble`` objects
   implementing them. (`#309`_)
+- Added the ``GreedyInterchip`` allocator, which reduces inter-chip communication,
+  speeding up networks with high traffic between chips. (`#309`_)
 
 **Changed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,9 @@ Release history
   implementing them. (`#309`_)
 - Added the ``GreedyInterchip`` allocator, which reduces inter-chip communication,
   speeding up networks with high traffic between chips. (`#309`_)
+- Added the ``PartitionInterchip`` allocator, which reduces inter-chip communication
+  with better partitioning than ``GreedyInterchip``. Requires the ``nxmetis``
+  package. (`#309`_)
 
 **Changed**
 

--- a/conftest.py
+++ b/conftest.py
@@ -9,6 +9,7 @@ import pytest
 from pytest_allclose import report_rmses
 
 import nengo_loihi
+from nengo_loihi.builder.builder import Model, ValidationLevel
 from nengo_loihi.emulator import EmulatorInterface
 from nengo_loihi.tests import make_test_sim
 
@@ -18,6 +19,7 @@ def pytest_configure(config):
     EmulatorInterface.strict = True
 
     nengo_loihi.set_defaults()
+    Model.default_validation_level = ValidationLevel.FULL
 
     config.addinivalue_line(
         "markers", "target_sim: mark test as only running on emulator"

--- a/conftest.py
+++ b/conftest.py
@@ -156,10 +156,12 @@ def pytest_runtest_call(item):
             )
         if partition is None:
             os.environ["PARTITION"] = "pohoiki"  # TODO: nahuku32,pohoiki when it works
+            set_partition = True
 
         lmtoptions = os.getenv("LMTOPTIONS")
         if lmtoptions is None:
             os.environ["LMTOPTIONS"] = "--skip-power=1"
+            set_lmtoptions = True
         elif "--skip-power=1" not in lmtoptions:
             warnings.warn(
                 f"Tests may hang if LMTOPTIONS does not contain --skip-power=1. "

--- a/nengo_loihi/block.py
+++ b/nengo_loihi/block.py
@@ -154,19 +154,21 @@ class Compartment:
     def __init__(self, n_compartments, label=None):
         self.n_compartments = n_compartments
         self.label = label
+        # dtype must be float32, because of how we discretize in place to int32
+        self.dtype = np.float32
 
         # parameters specific to compartments/block
-        self.decay_u = np.ones(n_compartments, dtype=np.float32)
+        self.decay_u = np.ones(n_compartments, dtype=self.dtype)
         # ^ default to no filter
-        self.decay_v = np.zeros(n_compartments, dtype=np.float32)
+        self.decay_v = np.zeros(n_compartments, dtype=self.dtype)
         # ^ default to integration
         self.tau_s = None
         self.scale_u = True
         self.scale_v = False
 
         self.refract_delay = np.zeros(n_compartments, dtype=np.int32)
-        self.vth = np.zeros(n_compartments, dtype=np.float32)
-        self.bias = np.zeros(n_compartments, dtype=np.float32)
+        self.vth = np.zeros(n_compartments, dtype=self.dtype)
+        self.bias = np.zeros(n_compartments, dtype=self.dtype)
         self.enable_noise = np.zeros(n_compartments, dtype=bool)
 
         # parameters common to core
@@ -683,9 +685,11 @@ class Synapse:
         self,
         weights,
         indices=None,
-        weight_dtype=np.float32,
+        weight_dtype=None,
         compression=0,
     ):
+        weight_dtype = np.dtype(np.float32 if weight_dtype is None else weight_dtype)
+        assert weight_dtype.name in ("float32", "int32")
         weights = [
             np.array(w, copy=False, dtype=weight_dtype, ndmin=2) for w in weights
         ]

--- a/nengo_loihi/block.py
+++ b/nengo_loihi/block.py
@@ -49,6 +49,10 @@ class LoihiBlock:
         self.synapses = []
         self.named_synapses = {}
 
+    @property
+    def discretize_info(self):
+        return self.compartment.discretize_info
+
     def __str__(self):
         return "%s(%s)" % (type(self).__name__, self.label if self.label else "")
 
@@ -177,6 +181,8 @@ class Compartment:
         self.noise_offset = 0
         self.noise_exp = 0
         self.noise_at_membrane = 0
+
+        self.discretize_info = None
 
     def __str__(self):
         return "%s(%s)" % (type(self).__name__, self.label if self.label else "")

--- a/nengo_loihi/block.py
+++ b/nengo_loihi/block.py
@@ -517,13 +517,14 @@ class SynapseConfig(Config):
 
         synapse_idx_bits = 4
         n_synapses_bits = 6
+        bits_per_memunit = 64
         bits = 0
         synapses_per_block = self.n_synapses + 1
         for i in range(0, n_weights, synapses_per_block):
             n = min(n_weights - i, synapses_per_block)
             bits_i = n * bits_per_weight + synapse_idx_bits + n_synapses_bits
             # round up to nearest memory unit
-            bits_i = -64 * (-bits_i // 64)
+            bits_i = -bits_per_memunit * (-bits_i // bits_per_memunit)
             bits += bits_i
 
         return bits

--- a/nengo_loihi/builder/builder.py
+++ b/nengo_loihi/builder/builder.py
@@ -1,5 +1,6 @@
 import logging
 from collections import OrderedDict, defaultdict
+from enum import IntEnum
 
 import numpy as np
 from nengo import Ensemble, Network, Node, Probe
@@ -13,6 +14,12 @@ from nengo_loihi.decode_neurons import OnOffDecodeNeurons, Preset10DecodeNeurons
 from nengo_loihi.inputs import LoihiInput
 
 logger = logging.getLogger(__name__)
+
+
+class ValidationLevel(IntEnum):
+    NONE = 1
+    MINIMAL = 2
+    FULL = 3
 
 
 class Model:
@@ -62,6 +69,9 @@ class Model:
         Learning weight exponent (base 2) for PES learning connections. This
         controls the maximum weight magnitude (where a larger exponent means
         larger potential weights, but lower weight resolution).
+    validation_level : ValidationLevel
+        Level of validation to do during the build process.
+        Defaults to ValidationLevel.MINIMAL.
     vth_nonspiking : float
         Voltage threshold for non-spiking neurons (i.e. voltage decoders).
 
@@ -99,6 +109,9 @@ class Model:
     seeds : dict
         Mapping from objects to the integer seed assigned to that object.
     """
+
+    # TODO: move this to an RC file or something like an RC file
+    default_validation_level = ValidationLevel.MINIMAL
 
     def __init__(self, dt=0.001, label=None, builder=None):
         self.dt = dt
@@ -143,6 +156,8 @@ class Model:
         self.seeded = {}
 
         # --- other (typically standard) parameters
+        self.validation_level = self.default_validation_level
+
         # Filter on decode neurons
         self.decode_tau = 0.005
         # ^TODO: how to choose this filter? Even though the input is spikes,

--- a/nengo_loihi/builder/builder.py
+++ b/nengo_loihi/builder/builder.py
@@ -51,9 +51,6 @@ class Model:
 
     Attributes
     ----------
-    connection_decode_neurons : dict of {Connection: Ensemble}
-        Map of each `nengo.Connection` that requires DecodeNeurons, to the
-        `nengo.Ensemble` that implements said DecodeNeurons.
 
     Build parameters
 
@@ -86,11 +83,14 @@ class Model:
         Mapping from Loihi blocks to `.BlockShape` instances.
     builder : Builder
         The build functions used by this model.
-    dt : float
-        The length of a simulator timestep, in seconds.
+    connection_decode_neurons : dict of {Connection: Ensemble}
+        Map of each `nengo.Connection` that requires DecodeNeurons, to the
+        `nengo.Ensemble` that implements said DecodeNeurons.
     chip2host_params : dict
         Mapping from Nengo objects to any additional parameters associated
         with those objects for use during the build process.
+    dt : float
+        The length of a simulator timestep, in seconds.
     inputs : list of LoihiInput
         List of inputs to this model.
     label : str or None
@@ -142,6 +142,7 @@ class Model:
         self.blocks = OrderedDict()
         self.block_shapes = {}
         self.probes = []
+        self.block_comp_map = {}
 
         self.connection_decode_neurons = {}
 

--- a/nengo_loihi/builder/builder.py
+++ b/nengo_loihi/builder/builder.py
@@ -51,6 +51,9 @@ class Model:
 
     Attributes
     ----------
+    connection_decode_neurons : dict of {Connection: Ensemble}
+        Map of each `nengo.Connection` that requires DecodeNeurons, to the
+        `nengo.Ensemble` that implements said DecodeNeurons.
 
     Build parameters
 
@@ -140,12 +143,12 @@ class Model:
         self.block_shapes = {}
         self.probes = []
 
-        # Will be filled in by the simulator __init__
-        self.split = None
+        self.connection_decode_neurons = {}
 
         # Will be filled in by the network builder
         self.toplevel = None
         self.config = None
+        self.split = None
 
         # Resources used by the build process
         self.objs = defaultdict(dict)  # maps Nengo objects to Loihi objects

--- a/nengo_loihi/builder/connection.py
+++ b/nengo_loihi/builder/connection.py
@@ -207,6 +207,7 @@ def build_host_to_chip(model, conn):
     ens.label = None if conn.label is None else "%s_ens" % conn.label
     _inherit_seed(host, ens, model, conn)
     host.build(ens)
+    model.connection_decode_neurons[conn] = ens
 
     pre2ens = Connection(
         conn.pre,
@@ -557,8 +558,6 @@ def build_full_chip_connection(model, conn):  # noqa: C901
                 dt=model.dt, vth=model.vth_nonspiking
             )
             decoder_block.compartment.bias[:] = 0
-            model.add_block(decoder_block)
-            model.objs[conn]["decoded"] = decoder_block
 
             dec_syn = Synapse(n, label="probe_decoders")
             weights2 = stack_matrices(
@@ -568,7 +567,6 @@ def build_full_chip_connection(model, conn):  # noqa: C901
 
             dec_syn.set_weights(weights2)
             decoder_block.add_synapse(dec_syn)
-            model.objs[conn]["decoders"] = dec_syn
         else:
             # use spiking decode neurons for on-chip connection
             if isinstance(conn.post_obj, Ensemble):
@@ -586,9 +584,10 @@ def build_full_chip_connection(model, conn):  # noqa: C901
                 loihi_weights, block_label="%s" % conn, syn_label="decoders"
             )
 
-            model.add_block(decoder_block)
-            model.objs[conn]["decoded"] = decoder_block
-            model.objs[conn]["decoders"] = dec_syn
+        model.add_block(decoder_block)
+        model.objs[conn]["decoded"] = decoder_block
+        model.objs[conn]["decoders"] = dec_syn
+        model.connection_decode_neurons[conn] = decoder_block
 
         # use tau_s for filter into decode neurons, decode_tau for filter out
         decoder_block.compartment.configure_filter(tau_s, dt=model.dt)

--- a/nengo_loihi/builder/discretize.py
+++ b/nengo_loihi/builder/discretize.py
@@ -146,7 +146,7 @@ def decay_magnitude(decay, x0=2 ** 21, bits=12, offset=0):
 
         x_i = floor(r x_{i-1})
 
-    where ``r = (2**bits - offset - decay)``.
+    where ``r = (2**bits - offset - decay) / 2**bits``.
 
     To simulate the effects of rounding in decay, we subtract an expected loss
     due to rounding (``q``) each iteration. Our estimated series is therefore::

--- a/nengo_loihi/builder/discretize.py
+++ b/nengo_loihi/builder/discretize.py
@@ -242,10 +242,11 @@ def discretize_block(block):
     w_maxs = [s.max_abs_weight() for s in block.synapses]
     w_max = max(w_maxs) if len(w_maxs) > 0 else 0
 
-    p = discretize_compartment(block.compartment, w_max)
+    info = discretize_compartment(block.compartment, w_max)
     for synapse in block.synapses:
-        discretize_synapse(synapse, w_max, p["w_scale"], p["w_exp"])
-    return p["v_scale"]
+        discretize_synapse(synapse, w_max, info["w_scale"], info["w_exp"])
+
+    return info["v_scale"]
 
 
 def discretize_compartment(comp, w_max):
@@ -363,7 +364,10 @@ def discretize_compartment(comp, w_max):
     vmaxe = np.clip(np.round((np.log2(vmax + 1) - 9) * 0.5), 0, 2 ** 3 - 1)
     comp.vmax = 2 ** (9 + 2 * vmaxe) - 1
 
-    return dict(w_max=w_max, w_scale=w_scale, w_exp=w_exp, v_scale=v_scale)
+    comp.discretize_info = dict(
+        w_max=w_max, w_exp=w_exp, v_scale=v_scale, b_scale=b_scale, w_scale=w_scale
+    )
+    return comp.discretize_info
 
 
 def discretize_synapse(synapse, w_max, w_scale, w_exp):

--- a/nengo_loihi/builder/ensemble.py
+++ b/nengo_loihi/builder/ensemble.py
@@ -12,9 +12,10 @@ from nengo_loihi.block import LoihiBlock
 from nengo_loihi.builder.builder import Builder
 
 
-def get_gain_bias(ens, rng=np.random, intercept_limit=1.0):
+def get_gain_bias(ens, rng=np.random, intercept_limit=1.0, dtype=None):
     # Modified from the Nengo version to handle `intercept_limit`
 
+    dtype = nengo.rc.float_dtype if dtype is None else dtype
     if ens.gain is not None and ens.bias is not None:
         gain = get_samples(ens.gain, ens.n_neurons, rng=rng)
         bias = get_samples(ens.bias, ens.n_neurons, rng=rng)
@@ -60,6 +61,11 @@ def get_gain_bias(ens, rng=np.random, intercept_limit=1.0):
                 "by reducing the maximum intercept value to below 1."
             )
 
+    dtype = nengo.rc.float_dtype
+    gain = gain.astype(dtype) if gain is not None else gain
+    bias = bias.astype(dtype) if bias is not None else bias
+    max_rates = max_rates.astype(dtype) if max_rates is not None else max_rates
+    intercepts = intercepts.astype(dtype) if intercepts is not None else intercepts
     return gain, bias, max_rates, intercepts
 
 
@@ -71,13 +77,16 @@ def build_ensemble(model, ens):
     # Create random number generator
     rng = np.random.RandomState(model.seeds[ens])
 
-    eval_points = gen_eval_points(ens, ens.eval_points, rng=rng)
+    eval_points = gen_eval_points(
+        ens, ens.eval_points, rng=rng, dtype=nengo.rc.float_dtype
+    )
 
     # Set up encoders
     if isinstance(ens.encoders, Distribution):
         encoders = get_samples(ens.encoders, ens.n_neurons, ens.dimensions, rng=rng)
+        encoders = np.asarray(encoders, dtype=nengo.rc.float_dtype)
     else:
-        encoders = npext.array(ens.encoders, min_dims=2, dtype=np.float64)
+        encoders = npext.array(ens.encoders, min_dims=2, dtype=nengo.rc.float_dtype)
 
     if ens.normalize_encoders:
         encoders /= npext.norm(encoders, axis=1, keepdims=True)
@@ -90,7 +99,9 @@ def build_ensemble(model, ens):
         )
 
     # Build the neurons
-    gain, bias, max_rates, intercepts = get_gain_bias(ens, rng, model.intercept_limit)
+    gain, bias, max_rates, intercepts = get_gain_bias(
+        ens, rng, intercept_limit=model.intercept_limit, dtype=nengo.rc.float_dtype
+    )
 
     block = LoihiBlock(ens.n_neurons, label="%s" % ens)
     block.compartment.bias[:] = bias

--- a/nengo_loihi/builder/network.py
+++ b/nengo_loihi/builder/network.py
@@ -40,7 +40,12 @@ def build_network(
             model.build(conn)
 
         # Split blocks into blocks that will fit on cores
-        split_model(model)
+        block_map = split_model(model)
+        model.block_comp_map = {
+            new_block: comp_idxs
+            for old_block, new_blocks in block_map.items()
+            for new_block, comp_idxs in new_blocks.items()
+        }
 
         if discretize:
             discretize_model(model)

--- a/nengo_loihi/builder/validate.py
+++ b/nengo_loihi/builder/validate.py
@@ -8,9 +8,13 @@ from nengo_loihi.block import (
     MAX_SYNAPSE_BITS,
     Synapse,
 )
+from nengo_loihi.builder.builder import ValidationLevel
 
 
 def validate_model(model):
+    if model.validation_level is ValidationLevel.NONE:
+        return
+
     if len(model.blocks) == 0:
         raise BuildError(
             "No neurons marked for execution on-chip. "

--- a/nengo_loihi/conv.py
+++ b/nengo_loihi/conv.py
@@ -114,7 +114,7 @@ def channel_idxs(shape):
     shape : `nengo.transforms.ChannelShape` (default: True)
         Output shape of convolution
     """
-    idxs = np.arange(shape.size, dtype=int)
+    idxs = np.arange(shape.size, dtype=np.int32)
     return (
         (idxs % shape.n_channels)
         if shape.channels_last
@@ -130,7 +130,7 @@ def pixel_idxs(shape):
     shape : `nengo.transforms.ChannelShape` (default: True)
         Output shape of convolution
     """
-    idxs = np.arange(shape.size, dtype=int)
+    idxs = np.arange(shape.size, dtype=np.int32)
     return (
         (idxs // shape.n_channels)
         if shape.channels_last
@@ -203,8 +203,8 @@ def conv2d_loihi_weights(transform):  # noqa: C901
     weights = []
     indices = []
     # compartment offset (aka. compartment base) for each axon
-    offsets = np.zeros(input_rows * input_cols, dtype=int)
-    axon_to_weight_map = np.zeros(input_rows * input_cols, dtype=int)
+    offsets = np.zeros(input_rows * input_cols, dtype=np.int32)
+    axon_to_weight_map = np.zeros(input_rows * input_cols, dtype=np.int32)
     weights_map = {}
     for i, j in itertools.product(range(input_rows), range(input_cols)):
         ij = i * input_cols + j
@@ -257,10 +257,10 @@ def conv2d_loihi_weights(transform):  # noqa: C901
 
             # --- determine indices
             # channel inds are zero, since we use same indices for each channel
-            channel_inds = np.zeros(n_channels, dtype=int)
-            row_inds = np.arange(wmask_i.sum(), dtype=int)
-            col_inds = np.arange(wmask_j.sum(), dtype=int)
-            filter_inds = np.arange(n_filters, dtype=int)
+            channel_inds = np.zeros(n_channels, dtype=np.int32)
+            row_inds = np.arange(wmask_i.sum(), dtype=np.int32)
+            col_inds = np.arange(wmask_j.sum(), dtype=np.int32)
+            filter_inds = np.arange(n_filters, dtype=np.int32)
 
             order = [channel_inds, row_inds, col_inds, filter_inds]
             shape = [n_channels, output_rows, output_cols, n_filters]
@@ -271,7 +271,7 @@ def conv2d_loihi_weights(transform):  # noqa: C901
                 shape = [shape[i] for i in (0, 3, 1, 2)]
 
             n = len(shape)
-            strides = [np.prod(shape[i + 1 :], dtype=int) for i in range(n)]
+            strides = [np.prod(shape[i + 1 :], dtype=np.int32) for i in range(n)]
 
             # inds[i_0,...,i_{n-1}] = sum_{k=0}^{n-1} strides[k] * order[k][i_k]
             strided_inds = [

--- a/nengo_loihi/decode_neurons.py
+++ b/nengo_loihi/decode_neurons.py
@@ -261,6 +261,10 @@ class Preset5DecodeNeurons(OnOffDecodeNeurons):
         nengo-loihi-sandbox/utils/interneuron_unidecoder_design.py
     """
 
+    # TODO: why does this scale factor help? Found it empirically in
+    # test_decode_neurons.test_add_inputs (see there for a description)
+    scale_factor = 1.05
+
     def __init__(self, dt=0.001, rate=None):
         super().__init__(pairs_per_dim=5, dt=dt, rate=rate)
 
@@ -270,14 +274,12 @@ class Preset5DecodeNeurons(OnOffDecodeNeurons):
         gain, bias = self.neuron_type.gain_bias(max_rates, intercepts)
 
         target_point = 0.85
-        target_rate = np.sum(self.neuron_type.rates(target_point, gain, bias))
-        self.scale = 1.08 * target_point / (self.dt * target_rate)
-        # ^ TODO: why does this 1.08 factor help? found it empirically in
-        # test_decode_neurons.test_add_inputs
+        target_rate = np.sum(self.neuron_type.rates(target_point, gain, bias, dt=dt))
+        self.scale = self.scale_factor * target_point / (self.dt * target_rate)
 
+        # repeat gains/biases for on/off neurons
         self.gain = gain.repeat(2)
         self.bias = bias.repeat(2)
-        # ^ repeat for on/off neurons
 
     def __str__(self):
         return "%s(dt=%0.3g, rate=%0.3g)" % (type(self).__name__, self.dt, self.rate)
@@ -290,6 +292,10 @@ class Preset10DecodeNeurons(OnOffDecodeNeurons):
         nengo-loihi-sandbox/utils/interneuron_unidecoder_design.py
     """
 
+    # TODO: why does this scale factor help? Found it empirically in
+    # test_decode_neurons.test_add_inputs (see there for a description)
+    scale_factor = 1.05
+
     def __init__(self, dt=0.001, rate=None):
         super().__init__(pairs_per_dim=10, dt=dt, rate=rate)
 
@@ -300,14 +306,12 @@ class Preset10DecodeNeurons(OnOffDecodeNeurons):
         gain, bias = self.neuron_type.gain_bias(max_rates, intercepts)
 
         target_point = 1.0
-        target_rate = np.sum(self.neuron_type.rates(target_point, gain, bias))
-        self.scale = 1.05 * target_point / (self.dt * target_rate)
-        # ^ TODO: why does this 1.05 factor help? found it empirically in
-        # test_decode_neurons.test_add_inputs
+        target_rate = np.sum(self.neuron_type.rates(target_point, gain, bias, dt=dt))
+        self.scale = self.scale_factor * target_point / (self.dt * target_rate)
 
+        # repeat gains/biases for on/off neurons
         self.gain = gain.repeat(2)
         self.bias = bias.repeat(2)
-        # ^ repeat for on/off neurons
 
     def __str__(self):
         return "%s(dt=%0.3g, rate=%0.3g)" % (type(self).__name__, self.dt, self.rate)

--- a/nengo_loihi/emulator/tests/test_interface.py
+++ b/nengo_loihi/emulator/tests/test_interface.py
@@ -81,8 +81,9 @@ def test_uv_overflow(n_axons, plt, allclose, monkeypatch):
 
     assert EmulatorInterface.strict  # Tests should be run in strict mode
     monkeypatch.setattr(EmulatorInterface, "strict", False)
+    overflow_var = "q0" if n_axons == 1000 else "current"
     with EmulatorInterface(model) as emu:
-        with pytest.warns(UserWarning):
+        with pytest.warns(UserWarning, match=f"Overflow in {overflow_var}"):
             emu.run_steps(nt)
         emu_u = emu.collect_probe_output(probe_u)
         emu_v = emu.collect_probe_output(probe_v)

--- a/nengo_loihi/hardware/allocators.py
+++ b/nengo_loihi/hardware/allocators.py
@@ -11,6 +11,16 @@ from nengo_loihi.hardware.nxsdk_objects import (
     VthConfig,
 )
 
+try:
+    import networkx
+    import nxmetis
+
+    HAS_NXMETIS = True
+except ImportError:
+    networkx = nxmetis = None
+    HAS_NXMETIS = False
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -455,5 +465,85 @@ class GreedyInterchip(Greedy):
         board.probes.extend(model.probes)
 
         logger.info("GreedyInterchip allocation across %d chips", board.n_chips)
+
+        return board
+
+
+class PartitionInterchip(Allocator):
+    """Spreads blocks equally across cores and minimizes inter-chip communication.
+
+    This allocator uses the METIS partitioner, which requires
+    `nxmetis <https://networkx-metis.readthedocs.io/en/latest/install.html>`_.
+    """
+
+    # TODO:
+    # - Potentially allow more blocks on one chip (i.e. unbalanced partitioning),
+    #   if it will improve communication. Unclear if nxmetis supports this.
+    # - Check that partitioning is always balanced, and that no chips
+    #   will have too many cores. Initial tests show that it is always balanced.
+
+    def __init__(self, ensemble_rates=None, rate_scale=1):
+        if not HAS_NXMETIS:
+            raise ImportError("networkx-metis is required for PartitionInterchip")
+
+        super().__init__()
+        self.ensemble_rates = ensemble_rates
+        self.rate_scale = rate_scale
+
+    def __call__(self, model, n_chips):
+        block_map = dict(enumerate(model.blocks))
+
+        block_rates = None
+        if self.ensemble_rates is not None:
+            block_rates = ensemble_to_block_rates(model, self.ensemble_rates)
+            block_rates = {
+                block: np.round(rate * self.rate_scale)
+                for block, rate in block_rates.items()
+            }
+
+        block_conns = estimate_interblock_activity(block_map, block_rates=block_rates)
+
+        # partition graph
+        G = networkx.Graph()
+        G.add_nodes_from(block_map.keys())
+
+        edge_map = set()
+        for i in block_map:
+            for j, val in block_conns[i].items():
+                if (i, j) in edge_map or (j, i) in edge_map:
+                    continue
+
+                val = val + block_conns[j].get(i, 0)
+                G.add_edge(i, j, weight=int(round(val)))  # weights must be integers
+                edge_map.add((i, j))
+                edge_map.add((j, i))
+
+        _, parts = nxmetis.partition(G, nparts=int(n_chips))
+
+        for i, part in enumerate(parts):
+            if len(part) > 128:
+                raise ValueError(
+                    f"Partition {i} has {len(part)} cores, "
+                    "which exceeds the available 128 cores"
+                )
+
+        # --- create board
+        board = Board()
+
+        # add inputs to board
+        for input in model.inputs:
+            self.input_to_board(input, board)
+
+        # blocks to chips
+        for part in parts:
+            chip = board.new_chip()
+            for block_idx in part:
+                block = block_map[block_idx]
+                self.block_to_new_core(block, chip)
+
+        # add probes
+        board.probes.extend(model.probes)
+
+        logger.info("METIS allocation across %d chips", board.n_chips)
 
         return board

--- a/nengo_loihi/hardware/allocators.py
+++ b/nengo_loihi/hardware/allocators.py
@@ -22,7 +22,7 @@ def compute_cfgs(core, list_cfgs):
     cfgs = list(set(p for plist in cfg_lists for p in plist))
     cfg_idxs = {}
     for block, plist in zip(core.blocks, cfg_lists):
-        cfg_idxs[block] = np.zeros(len(plist), dtype=int)
+        cfg_idxs[block] = np.zeros(len(plist), dtype=np.int32)
         for k, cfg in enumerate(cfgs):
             cfg_idxs[block][[p == cfg for p in plist]] = k
 

--- a/nengo_loihi/hardware/builder.py
+++ b/nengo_loihi/hardware/builder.py
@@ -296,8 +296,8 @@ def build_block(nxsdk_core, core, block, compartment_idxs, ax_range):
 
     logger.debug("Building %s on core.id=%d", block, nxsdk_core.id)
 
-    for i, bias in enumerate(block.compartment.bias):
-        bman, bexp = bias_to_manexp(bias)
+    bmans, bexps = bias_to_manexp(block.compartment.bias)
+    for i, (bman, bexp) in enumerate(zip(bmans, bexps)):
         icomp = core.compartment_cfg_idxs[block][i]
         ivth = core.vth_cfg_idxs[block][i]
 

--- a/nengo_loihi/hardware/interface.py
+++ b/nengo_loihi/hardware/interface.py
@@ -13,7 +13,7 @@ import numpy as np
 from nengo.exceptions import SimulationError
 
 from nengo_loihi.builder.discretize import scale_pes_errors
-from nengo_loihi.hardware.allocators import Greedy
+from nengo_loihi.hardware.allocators import GreedyInterchip
 from nengo_loihi.hardware.builder import build_board
 from nengo_loihi.hardware.nxsdk_objects import LoihiSpikeInput
 from nengo_loihi.hardware.nxsdk_shim import (
@@ -53,7 +53,7 @@ class HardwareInterface:
         timestep if ``.use_snips`` is True.
     n_chips : int, optional (Default: 2)
         The number of chips on the board.
-    allocator : Allocator, optional (Default: ``Greedy()``)
+    allocator : Allocator, optional (Default: ``GreedyInterchip()``)
         Callable object that allocates the board's devices to given models.
         Defaults to one block and one input per core on a single chip.
     """
@@ -84,7 +84,7 @@ class HardwareInterface:
         SpikeProbe.probeDict.clear()
 
         # --- allocate
-        allocator = Greedy() if allocator is None else allocator
+        allocator = GreedyInterchip() if allocator is None else allocator
         self.board = allocator(self.model, n_chips=n_chips)
 
         # --- validate

--- a/nengo_loihi/hardware/interface.py
+++ b/nengo_loihi/hardware/interface.py
@@ -774,13 +774,15 @@ class HostSnip:
             else:  # pragma: no cover
                 n_retries += 1
 
-        if np.frombuffer(data[-4:], np.int32) == -1:
-            raise RuntimeError("Received shutdown signal from chip")
-
         if len(data) < bytes_expected:
             raise RuntimeError(
                 "Received (%d) less than expected (%d)" % (len(data), bytes_expected)
             )
+
+        last_val = np.frombuffer(data[-4:], np.int32).item()
+        logger.debug("Received %d bytes, last_val=%d", len(data), last_val)
+        if last_val == -1:
+            raise RuntimeError("Received shutdown signal from chip")
 
         return np.frombuffer(data, dtype=np.int32)
 

--- a/nengo_loihi/hardware/snips/nengo_host.cpp.template
+++ b/nengo_loihi/hardware/snips/nengo_host.cpp.template
@@ -105,6 +105,12 @@ class NengoHostProcess : public ConcurrentHostSnip {
             ssize_t n_read = recv(client_socket, buffer, 4 * READ_SIZE, 0);
             int buffer_len = n_read / 4;
             int buffer_pos = 0;
+#if DEBUG > 0
+            msg("Read %zu bytes", n_read);
+#endif
+#if DEBUG > 2
+            msg("buffer[0]: 0x%X = %d", buffer[0], buffer[0]);
+#endif
             if (buffer[0] < 0) {
                 msg("Received shutdown signal: %d", buffer[0]);
                 shutdown();
@@ -115,9 +121,6 @@ class NengoHostProcess : public ConcurrentHostSnip {
                 shutdown();
                 return;
             }
-#if DEBUG > 0
-            msg("Read %zu bytes", n_read);
-#endif
 
             // process header
             if (n_read < 4 * N_CHIPS) {
@@ -152,8 +155,8 @@ class NengoHostProcess : public ConcurrentHostSnip {
 
                     // subsequent reads are non-blocking, so we just read what's there
                     while (buffer_len < required_size) {
-                        if (i_wait > 100) {
-                            msg("Waited too long for socket read");
+                        if (i_wait > 1000) {
+                            msg("ERROR: Timed out waiting for chips to write back output. Increasing i_wait might help?");
                             shutdown();
                             return;
                         }
@@ -167,6 +170,7 @@ class NengoHostProcess : public ConcurrentHostSnip {
 #if DEBUG > 0
                             msg("Read %zu bytes", n_read);
 #endif
+                            i_wait = 0;
                             buffer_len += n_read / 4;
                         } else {
                             i_wait++;

--- a/nengo_loihi/hardware/snips/nengo_io.c.template
+++ b/nengo_loihi/hardware/snips/nengo_io.c.template
@@ -233,6 +233,11 @@ void nengo_io(runState *s) {
 #if DEBUG > 0
     printf("Sending %d packet(s)\n", N_OUTPUT_PACKETS);
 #endif
+#if DEBUG > 2
+    for (int i = 0; i < N_OUTPUT_PACKETS; i++) {
+        printf("Packet %d: 0x%X = %d\n", i, buffer[i], buffer[i]);
+    }
+#endif
     writeChannel(out_channel, buffer, N_OUTPUT_PACKETS);
 
     if (s->total_steps > 0 && s->time_step >= s->total_steps) {

--- a/nengo_loihi/hardware/tests/test_allocators.py
+++ b/nengo_loihi/hardware/tests/test_allocators.py
@@ -2,12 +2,19 @@ import nengo
 import numpy as np
 import pytest
 from nengo.exceptions import ValidationError
-from nengo.utils.numpy import rms
 
+import nengo_loihi
 from nengo_loihi.block import Axon, LoihiBlock, Synapse
 from nengo_loihi.builder import Model
 from nengo_loihi.builder.discretize import discretize_model
-from nengo_loihi.hardware.allocators import Greedy, RoundRobin, core_stdp_pre_cfgs
+from nengo_loihi.hardware.allocators import (
+    Greedy,
+    GreedyInterchip,
+    RoundRobin,
+    core_stdp_pre_cfgs,
+    ensemble_to_block_rates,
+    estimate_interchip_activity,
+)
 from nengo_loihi.hardware.nxsdk_objects import Board
 from nengo_loihi.inputs import LoihiInput
 
@@ -163,40 +170,145 @@ def test_greedy_chip_allocator_cfg_check():
         Greedy(cores_per_chip=130)(model, n_chips=4)
 
 
-@pytest.mark.slow
+@pytest.mark.parametrize("Allocator", [GreedyInterchip])
+def test_interchip_allocators(Allocator, Simulator):
+    rng = np.random.RandomState(1)  # same seed for all allocators, to compare
+    with nengo.Network(seed=0) as net:
+        n_ensembles = 256
+        n_neurons = rng.randint(64, 256, size=n_ensembles)
+        ensembles = [nengo.Ensemble(n, dimensions=1) for n in n_neurons]
+
+        conn_pairs = rng.randint(0, n_ensembles, size=(2 * n_ensembles, 2))
+        for i, j in conn_pairs:
+            ei, ej = ensembles[i].neurons, ensembles[j].neurons
+            nengo.Connection(
+                ei,
+                ej,
+                transform=rng.uniform(-0.1, 0.1, size=(ej.size_in, ei.size_out)),
+            )
+
+    ens_rates = {
+        ensemble: rng.uniform(1, 100, size=1)
+        * rng.uniform(0.9, 1, size=ensemble.n_neurons)
+        for ensemble in ensembles
+    }
+
+    with Simulator(net, target="sim") as sim:
+        model = sim.model
+        n_chips = 3
+        block_rates = ensemble_to_block_rates(model, ens_rates)
+        sim.timers.start("norates")
+        board_norates = Allocator()(model, n_chips=n_chips)
+        sim.timers.stop("norates")
+        sim.timers.start("rates")
+        board_rates = Allocator(ensemble_rates=ens_rates)(model, n_chips=n_chips)
+        sim.timers.stop("rates")
+
+    norates_axons = estimate_interchip_activity(board_norates)
+    norates_spikes = estimate_interchip_activity(board_norates, block_rates=block_rates)
+    rates_axons = estimate_interchip_activity(board_rates)
+    rates_spikes = estimate_interchip_activity(board_rates, block_rates=block_rates)
+
+    print(f"Using allocator {Allocator.__name__}")
+    print(
+        f"No rates: {norates_axons['interchip']} axons, "
+        f"{norates_spikes['interchip']:.2f} spikes, "
+        f"took {sim.timers['norates']:.3f} seconds"
+    )
+    print(
+        f"Rates: {rates_axons['interchip']} axons, "
+        f"{rates_spikes['interchip']:.2f} spikes, "
+        f"took {sim.timers['rates']:.3f} seconds"
+    )
+    assert norates_axons["interchip"] < rates_axons["interchip"]
+    assert rates_spikes["interchip"] < norates_spikes["interchip"]
+
+
+def test_interchip_helpers(Simulator, rng):
+    """Test other cases for helper functions used by Interchip allocators."""
+
+    with nengo.Network() as net:
+        nengo_loihi.add_params(net)
+        a = nengo.Ensemble(2000, 1)  # this ensemble will be split (2 blocks)
+        b = nengo.Ensemble(1000, 1)  # this ensemble will be one block
+        c = nengo.Ensemble(1000, 1)  # this ensemble will be off-chip
+        net.config[c].on_chip = False
+        nengo.Connection(a, b)
+
+    with nengo.Network():
+        d = nengo.Ensemble(10, 1)  # this ensemble is in a different network (errors)
+
+    ens_rates = {
+        a: rng.uniform(size=a.n_neurons),
+        b: rng.uniform(size=b.n_neurons),
+        c: rng.uniform(size=c.n_neurons),
+    }
+
+    with Simulator(net) as sim:
+        # --- test ensemble_to_block_rates
+        block_rates = ensemble_to_block_rates(sim.model, ens_rates)
+
+        a_blocks = sim.model.objs[a]["out"]
+        b_blocks = sim.model.objs[b]["out"]
+        assert set(block_rates) == (set(a_blocks) | set(b_blocks))
+
+        i = 0
+        for block in a_blocks:
+            assert np.array_equal(
+                ens_rates[a][i : i + block.n_neurons], block_rates[block]
+            )
+            i += block.n_neurons
+
+        assert len(b_blocks) == 1 and np.array_equal(
+            ens_rates[b], block_rates[b_blocks[0]]
+        )
+
+        # test ValueError if ensemble not in model
+        ens_rates[d] = rng.uniform(size=d.n_neurons)
+        with pytest.raises(ValueError, match="Ensemble.*does not appear in the model"):
+            ensemble_to_block_rates(sim.model, ens_rates)
+
+        # --- test compute_block_conns error
+        partial_ens_rates = {a: ens_rates[a]}
+        with pytest.raises(KeyError, match="block.*not in block_rates"):
+            GreedyInterchip(ensemble_rates=partial_ens_rates)(sim.model, n_chips=2)
+
+
 @pytest.mark.target_loihi
-def test_deterministic_network_allocation(Simulator, seed):
+# Unclear why this requires nahuku32 or poihiki, as the basic multichip functionality
+# in this test should run on nahuku08, but currently it's hanging there.
+@pytest.mark.requires_multichip_snips
+def test_allocator_integration_consistency(Simulator, seed, allclose):
     # test that we get the same simulations results across allocators.
     # the determinism of the allocation itself is covered by other unit tests.
     n_neurons = 64
     n_ensembles = 8
-    tau = 0.1
-    sim_t = 1.0
+    probe_tau = 0.01
+    sim_t = 0.1
 
     with nengo.Network(seed=seed) as model:
         prev = nengo.Node(output=1)
 
         p = []
-        for i in range(n_ensembles):
+        for _ in range(n_ensembles):
             ens = nengo.Ensemble(n_neurons, 1)
-            nengo.Connection(prev, ens, synapse=tau)
-            p.append(nengo.Probe(ens, synapse=tau))
+            nengo.Connection(prev, ens)
+            p.append(nengo.Probe(ens, synapse=probe_tau))
             prev = ens
 
-    with nengo.Simulator(model) as sim_ref:
+    with Simulator(model, target="sim") as sim_ref:
         sim_ref.run(sim_t)
 
     # one block each for ensemble, connection, probe, minus no final connection
     n_blocks = n_ensembles * 3 - 1
     allocation = [
         (1, 1, RoundRobin()),
-        (3, 3, RoundRobin()),
-        (8, 8, RoundRobin()),
+        (7, 7, RoundRobin()),
         (6, ceil_div(n_blocks, 4), Greedy(cores_per_chip=4)),
         (8, ceil_div(n_blocks, 5), Greedy(cores_per_chip=5)),
+        (6, ceil_div(n_blocks, 4), GreedyInterchip(cores_per_chip=4)),
     ]
 
-    sim_prev = None
     for n_chips, n_chips_used, allocator in allocation:
         with Simulator(
             model,
@@ -208,7 +320,4 @@ def test_deterministic_network_allocation(Simulator, seed):
         assert len(sim_loihi.model.blocks) == n_blocks
         assert n_chips_used == sim_loihi.sims["loihi"].board.n_chips
         for p_i in p:
-            assert rms(sim_loihi.data[p_i] - sim_ref.data[p_i]) < 0.05
-            if sim_prev is not None:
-                assert np.allclose(sim_prev.data[p_i], sim_loihi.data[p_i])
-        sim_prev = sim_loihi
+            assert allclose(sim_loihi.data[p_i], sim_ref.data[p_i]), allocator

--- a/nengo_loihi/hardware/tests/test_interface.py
+++ b/nengo_loihi/hardware/tests/test_interface.py
@@ -129,11 +129,11 @@ def test_host_snip_recv_bytes():
     data[-1] = -1
     host_snip.send_all(data)
     with pytest.raises(RuntimeError, match="shutdown signal from chip"):
-        # With proper amount received
         host_snip.recv_bytes(1100 * 4)
+
+    # Too little data with shutdown signal still raises too little data
     host_snip.send_all(data)
-    with pytest.raises(RuntimeError, match="shutdown signal from chip"):
-        # With early stop
+    with pytest.raises(RuntimeError, match="less than expected"):
         host_snip.recv_bytes(2048 * 4)
 
 

--- a/nengo_loihi/tests/test_decode_neurons.py
+++ b/nengo_loihi/tests/test_decode_neurons.py
@@ -23,6 +23,15 @@ from nengo_loihi.decode_neurons import (
     ],
 )
 def test_add_inputs(decode_neurons, tolerance, Simulator, seed, plt):
+    """Test the addition of two inputs with DecodeNeurons.
+
+    This test forms the basis for the scale factors for Preset5DecodeNeurons
+    and Preset10DecodeNeurons. It is unclear exactly why these scale factors help.
+    The best values depend on the exact inputs below, as well as the seed used for
+    this test. More testing is needed to find optimal scale factors, or (ideally)
+    get rid of them completely if we can better understand the underlying mechanics.
+    """
+
     sim_time = 2.0
     pres_time = sim_time / 4
     eval_time = sim_time / 8
@@ -35,6 +44,8 @@ def test_add_inputs(decode_neurons, tolerance, Simulator, seed, plt):
     stim_fn_b = nengo.processes.Piecewise(
         {t: stim_values[i][1] for i, t in enumerate(stim_times)}
     )
+
+    probe_solver = nengo.solvers.LstsqL2nz(reg=0.01)
 
     with nengo.Network(seed=seed) as model:
         stim_a = nengo.Node(stim_fn_a)
@@ -54,9 +65,9 @@ def test_add_inputs(decode_neurons, tolerance, Simulator, seed, plt):
         stim_synapse = out_synapse.combine(nengo.Alpha(0.005)).combine(
             nengo.Alpha(0.005)
         )
-        p_stim_a = nengo.Probe(stim_a, synapse=stim_synapse)
-        p_stim_b = nengo.Probe(stim_b, synapse=stim_synapse)
-        p_c = nengo.Probe(c, synapse=out_synapse)
+        p_stim_a = nengo.Probe(stim_a, synapse=stim_synapse, solver=probe_solver)
+        p_stim_b = nengo.Probe(stim_b, synapse=stim_synapse, solver=probe_solver)
+        p_c = nengo.Probe(c, synapse=out_synapse, solver=probe_solver)
 
     build_model = Model()
     build_model.decode_neurons = decode_neurons

--- a/nengo_loihi/tests/test_learning.py
+++ b/nengo_loihi/tests/test_learning.py
@@ -51,7 +51,7 @@ def pes_network(
     return model, probes
 
 
-@pytest.mark.parametrize("dims", (1, 3))
+@pytest.mark.parametrize("dims", (1, pytest.param(3, marks=pytest.mark.slow)))
 @pytest.mark.requires_multichip_snips
 def test_pes_comm_channel(dims, allclose, plt, seed, Simulator):
     n_per_dim = 300
@@ -206,7 +206,9 @@ def test_pes_error_clip(request, plt, seed, Simulator):
     # ^ error on emulator vs chip is quite different, hence large tolerances
 
 
-@pytest.mark.parametrize("init_function", [None, lambda x: 0])
+@pytest.mark.parametrize(
+    "init_function", [None, pytest.param(lambda x: 0, marks=pytest.mark.slow)]
+)
 @pytest.mark.requires_multichip_snips
 def test_multiple_pes(init_function, request, allclose, plt, seed, Simulator):
     n_errors = 5
@@ -246,6 +248,7 @@ def test_multiple_pes(init_function, request, allclose, plt, seed, Simulator):
         )
 
 
+@pytest.mark.slow
 @pytest.mark.requires_multichip_snips
 def test_pes_deterministic(Simulator, seed, allclose):
     """Ensure that learning output is the same between runs"""
@@ -285,6 +288,7 @@ def test_pes_deterministic(Simulator, seed, allclose):
         assert allclose(sim.data[probe], sim0.data[probe])
 
 
+@pytest.mark.slow
 @pytest.mark.requires_multichip_snips
 def test_learning_seed(Simulator, seed):
     n_per_dim = 120

--- a/nengo_loihi/tests/test_passthrough.py
+++ b/nengo_loihi/tests/test_passthrough.py
@@ -197,6 +197,7 @@ def test_transform_errors(Simulator):
             pass
 
 
+@pytest.mark.slow
 def test_cluster_errors(Simulator, seed, plt):
     """Test that situations with ClusterErrors keep passthrough nodes"""
     simtime = 0.2

--- a/nengo_loihi/tests/test_simulator.py
+++ b/nengo_loihi/tests/test_simulator.py
@@ -652,7 +652,7 @@ def test_population_input(request, allclose):
     spikes = [(input, ti, inds) for ti, inds in spike_times_inds]
 
     input_axon = Axon(n_axons)
-    target_axons = np.zeros(n_inputs, dtype=int)
+    target_axons = np.zeros(n_inputs, dtype=np.int32)
     atoms = np.arange(n_inputs)
     input_axon.set_compartment_axon_map(target_axons, atoms=atoms)
     input.add_axon(input_axon)
@@ -664,9 +664,9 @@ def test_population_input(request, allclose):
 
     synapse = Synapse(n_axons)
     weights = 0.1 * np.array([[[1, 2], [2, 3], [4, 5]]], dtype=float)
-    indices = np.array([[[0, 1], [0, 1], [0, 1]]], dtype=int)
-    axon_to_weight_map = np.zeros(n_axons, dtype=int)
-    bases = np.zeros(n_axons, dtype=int)
+    indices = np.array([[[0, 1], [0, 1], [0, 1]]], dtype=np.int32)
+    axon_to_weight_map = np.zeros(n_axons, dtype=np.int32)
+    bases = np.zeros(n_axons, dtype=np.int32)
     synapse.set_population_weights(
         weights, indices, axon_to_weight_map, bases, pop_type=32
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -140,6 +140,8 @@ nengo_test_unsupported =
         "no ensembles onchip"
     test_processes.py::TestPiecewise*
         "no ensembles onchip"
+    test_processes.py::test_x_copy
+        "no ensembles onchip"
     test_simulator.py::test_steps
         "no ensembles onchip"
     test_simulator.py::test_sim_reopen

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,9 @@ docs_req = [
     "sphinx>=1.8",
     "tensorflow-probability>=0.8.0",
 ]
-optional_req = []
+optional_req = [
+    "networkx-metis>=1.0",
+]
 tests_req = [
     "coverage>=4.3",
     "nengo-extras",


### PR DESCRIPTION
This is a culmination of a number of improvements made for a team-robot vision project:

- Speed ups for block splitting code
- Properly pass `dt` for preset DecodeNeurons, which allows `dt` to be changed for them.
- Save info from `discretize_block` so that users can make use of this if need be.
- Speed up build process.
- Reduce memory required for build, and use the nengo `float_dtype` to allow users to further reduce memory by setting this to e.g. float32 instead of the default float64.
- Add `GreedyComms` and `PartitionComms` allocators, which both aim to reduce inter-chip communication.

Based off #300. 