### PR TITLE
Fix memory leaks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,12 @@ Release history
 
 - Added support for NxSDK 1.0.0. (`#317`_)
 
+**Fixed**
+
+- Fixed several issues to ensure that memory is freed when a ``Simulator``
+  is deleted. (`#312`_)
+
+.. _#312: https://github.com/nengo/nengo-loihi/pull/312
 .. _#317: https://github.com/nengo/nengo-loihi/pull/317
 
 1.0.0 (January 20, 2021)

--- a/nengo_loihi/builder/builder.py
+++ b/nengo_loihi/builder/builder.py
@@ -171,6 +171,7 @@ class Model:
         self.host2chip_senders = OrderedDict()
         self.host2chip_pes_senders = OrderedDict()
         self.needs_sender = {}
+        self.spike_targets = {}
 
     def __getstate__(self):
         raise NotImplementedError("Can't pickle nengo_loihi.builder.Model")

--- a/nengo_loihi/builder/node.py
+++ b/nengo_loihi/builder/node.py
@@ -12,7 +12,7 @@ def build_chip_receive_node(model, node):
     spike_input = SpikeInput(node.raw_dimensions, label=node.label)
     model.add_input(spike_input)
     model.objs[node]["out"] = spike_input
-    node.spike_target = spike_input
+    model.spike_targets[node] = spike_input
 
 
 @Builder.register(nengo.Node)

--- a/nengo_loihi/tests/__init__.py
+++ b/nengo_loihi/tests/__init__.py
@@ -51,7 +51,7 @@ def require_partition(partition, request, action="return", **kwargs):
         if has_partition(partition):
             request.addfinalizer(set_partition_env)
             set_partition_env(partition=partition, **kwargs)
-        elif action == "return":
+        elif action == "return":  # pragma: no cover
             return False
         else:  # pragma: no cover
             (pytest.fail if action == "fail" else pytest.skip)(

--- a/nengo_loihi/tests/test_simulator.py
+++ b/nengo_loihi/tests/test_simulator.py
@@ -916,7 +916,7 @@ def test_network_unchanged(Simulator):
         nengo.Ensemble(100, 1)
         with Simulator(model):
             pass
-        assert model.all_networks == []
+        assert not model.all_networks
 
 
 def test_timers():


### PR DESCRIPTION
To address #311. 

TODO:
- [x] Look at `Probe.target` to see if there's a similar memory leak there.
- [x] Find the memory leak when running (it's the biggest).
- [x] Look for more memory leaks when `run` isn't called (there's still one, but it's much smaller).

Test script:

This can also be run with `run_steps` commented out to test for builder memory leaks.
```
import gc

import nengo
import nengo_loihi
import numpy as np

from guppy import hpy

h = hpy()


class NewClass:
    def __init__(self):
        self.input_size = 10
        self.n_neurons = 500
        self.initialize_nengo()

    def initialize_nengo(self):
        network = nengo.Network()
        with network:
            def input_func(t):
                return np.ones(10)

            def output_func(t, x):
                self.output = x

            input_layer  = nengo.Node(output=input_func, size_in=0, size_out = self.input_size)
            ensemble     = nengo.Ensemble(n_neurons=self.n_neurons, dimensions=1 )
            output_layer = nengo.Node(output=output_func, size_in=self.n_neurons, size_out=0)

            conn_in  = nengo.Connection(input_layer, ensemble.neurons, transform=np.ones((self.n_neurons,self.input_size)))
            conn_out = nengo.Connection(ensemble.neurons, output_layer)

        self.network = network

    def run(self, steps, num_resets):
        print(h.heap())

        for i in range(num_resets):
            with nengo_loihi.Simulator(self.network, precompute=True) as sim:
            # with nengo.Simulator(self.network, progress_bar=False) as sim:
                sim.run_steps(steps)
                # pass

            del sim

            print('finished iteration:', i)
            if i % 25 == 0:
                gc.collect()
                print(h.heap())

steps = 1000
num_resets = 101

nengo_class = NewClass()
nengo_class.run(steps,num_resets)
```