### PR TITLE
Clear spikes

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -4,7 +4,7 @@
 NengoLoihi license
 ******************
 
-Copyright (c) 2018-2021 Applied Brain Research
+Copyright (c) 2018-2022 Applied Brain Research
 
 NengoLoihi is made available under a proprietary license
 that permits using, copying, sharing, and making derivative works from

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,7 @@ user_agent = "nengo_loihi"
 
 project = "NengoLoihi"
 authors = "Applied Brain Research"
-copyright = "2018-2021 Applied Brain Research"
+copyright = "2018-2022 Applied Brain Research"
 version = ".".join(nengo_loihi.__version__.split(".")[:2])  # Short X.Y version
 release = nengo_loihi.__version__  # Full version, with tags
 

--- a/nengo_loihi/builder/inputs.py
+++ b/nengo_loihi/builder/inputs.py
@@ -34,17 +34,14 @@ class HostReceiveProcess(Process):
         def __init__(self, size_out):
             self.size_out = size_out
             self.queue = [(0, np.zeros(self.size_out))]
-            self.queue_index = 0
 
         def __call__(self, t):
-            while (
-                len(self.queue) > self.queue_index + 1
-                and self.queue[self.queue_index][0] < t
-            ):
-                self.queue_index += 1
-            return self.queue[self.queue_index][1]
+            while len(self.queue) > 1 and self.queue[0][0] < t:
+                self.queue.pop(0)
+            return self.queue[0][1]
 
         def receive(self, t, x):
+            assert not self.queue or t >= self.queue[0][0]
             self.queue.append((t, x))
 
     def make_step(self, shape_in, shape_out, dt, rng, state):

--- a/nengo_loihi/builder/node.py
+++ b/nengo_loihi/builder/node.py
@@ -39,7 +39,9 @@ def build_dvs_file_chip_process(model, process, node=None):
         t += dt_us
         image_idx += 1
         new_event_idx = event_idx + np.searchsorted(e_t[event_idx:], t)
-        spike_input.add_spikes(image_idx, e_idx[event_idx:new_event_idx])
+        spike_input.add_spikes(
+            image_idx, e_idx[event_idx:new_event_idx], permanent=True
+        )
         event_idx = new_event_idx
 
     model.add_input(spike_input)

--- a/nengo_loihi/emulator/tests/test_interface.py
+++ b/nengo_loihi/emulator/tests/test_interface.py
@@ -50,7 +50,8 @@ def test_uv_overflow(n_axons, plt, allclose, monkeypatch):
     # n_axons controls number of input spikes and thus amount of overflow
     input = SpikeInput(n_axons)
     for t in np.arange(1, nt + 1):
-        input.add_spikes(t, np.arange(n_axons))  # send spikes to all axons
+        # send spikes to all axons
+        input.add_spikes(t, np.arange(n_axons), permanent=True)
     model.add_input(input)
 
     block = LoihiBlock(1)

--- a/nengo_loihi/inputs.py
+++ b/nengo_loihi/inputs.py
@@ -18,19 +18,25 @@ class SpikeInput(LoihiInput):
         super().__init__(label=label)
         self.n_neurons = n_neurons
         self.spikes = {}  # map sim timestep index to list of spike inds
+        self.permanent = set()  # spike times that are added during build, do not clear
 
-    def add_spikes(self, ti, spike_idxs):
+    def add_spikes(self, ti, spike_idxs, permanent=False):
         assert is_integer(ti)
         ti = int(ti)
         assert ti > 0, "Spike times must be >= 1 (got %d)" % ti
         assert ti not in self.spikes
         self.spikes[ti] = spike_idxs
+        if permanent:
+            self.permanent.add(ti)
 
     def spike_times(self):
         return sorted(self.spikes)
 
     def spike_idxs(self, ti):
-        return self.spikes.get(ti, [])
+        if ti in self.permanent:
+            return self.spikes.get(ti, [])
+        else:
+            return self.spikes.pop(ti, [])
 
 
 class ChipProcess(Process, metaclass=ABCMeta):

--- a/nengo_loihi/tests/test_block.py
+++ b/nengo_loihi/tests/test_block.py
@@ -54,7 +54,7 @@ def test_negative_base(request, seed):
     model = Model()
 
     input = SpikeInput(n_axons)
-    input.add_spikes(1, list(range(n_axons)))
+    input.add_spikes(1, list(range(n_axons)), permanent=True)
     model.add_input(input)
 
     axon = Axon(n_axons)

--- a/nengo_loihi/tests/test_simulator.py
+++ b/nengo_loihi/tests/test_simulator.py
@@ -689,7 +689,7 @@ def test_population_input(request, allclose):
             y = sim.collect_probe_output(probe)
     else:
         for inp, ti, inds in spikes:
-            inp.add_spikes(ti, inds)
+            inp.add_spikes(ti, inds, permanent=True)
 
         with EmulatorInterface(model) as sim:
             sim.run_steps(steps)


### PR DESCRIPTION
Clears intermediary values as we consume them, freeing up memory (particularly when `run_steps` is called more than once). Addresses #323.